### PR TITLE
Storage call Fedora

### DIFF
--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -1,10 +1,20 @@
-﻿namespace Preservation.Client;
+﻿using Microsoft.Extensions.Logging;
 
-internal class PreservationApiClient(HttpClient httpClient) : IPreservationApiClient
+namespace Preservation.Client;
+
+internal class PreservationApiClient(HttpClient httpClient, ILogger<PreservationApiClient> logger) : IPreservationApiClient
 {
     public async Task<bool> IsAlive(CancellationToken cancellationToken = default)
     {
-        var res = await httpClient.GetAsync("/storage", cancellationToken);
-        return res.IsSuccessStatusCode;
+        try
+        {
+            var res = await httpClient.GetAsync("/storage", cancellationToken);
+            return res.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occured while checking if Fedora is alive");
+            return false;
+        }
     }
 }

--- a/src/DigitalPreservation/Storage.API/Features/Fedora/FedoraController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Fedora/FedoraController.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Storage.API.Features.Fedora.Requests;
+
+namespace Storage.API.Features.Fedora;
+
+/// <summary>
+/// Temporary for connectivity check only
+/// </summary>
+[ApiController]
+[Route("[controller]")]
+public class FedoraController(IMediator mediator) : Controller
+{
+    public async Task<IActionResult> FedoraCheck()
+    {
+        var res = await mediator.Send(new VerifyFedoraRunning());
+        return new OkObjectResult(new { FedoraAccessible = res });
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Features/Fedora/Requests/VerifyFedoraRunning.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Fedora/Requests/VerifyFedoraRunning.cs
@@ -1,0 +1,20 @@
+﻿using MediatR;
+using Storage.API.Fedora;
+
+namespace Storage.API.Features.Fedora.Requests;
+
+/// <summary>
+/// Call Storage API and verify communication. This is temporary only and will be removed once we have 'real' requests
+/// implemented. It's a means to verify deployment only.
+/// </summary>
+// ReSharper disable once ClassNeverInstantiated.Global
+public class VerifyFedoraRunning : IRequest<bool>
+{
+}
+
+public class VerifyFedoraRunningHandler(IFedoraClient fedoraClient)
+    : IRequestHandler<VerifyFedoraRunning, bool>
+{
+    public Task<bool> Handle(VerifyFedoraRunning request, CancellationToken cancellationToken)
+        => fedoraClient.IsAlive(cancellationToken);
+}

--- a/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
@@ -1,0 +1,10 @@
+namespace Storage.API.Fedora;
+
+internal class FedoraClient(HttpClient httpClient) : IFedoraClient
+{
+    public async Task<bool> IsAlive(CancellationToken cancellationToken = default)
+    {
+        var res = await httpClient.GetAsync("./fcr:systeminfo", cancellationToken);
+        return res.IsSuccessStatusCode;
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
@@ -1,10 +1,18 @@
 namespace Storage.API.Fedora;
 
-internal class FedoraClient(HttpClient httpClient) : IFedoraClient
+internal class FedoraClient(HttpClient httpClient, ILogger<FedoraClient> logger) : IFedoraClient
 {
     public async Task<bool> IsAlive(CancellationToken cancellationToken = default)
     {
-        var res = await httpClient.GetAsync("./fcr:systeminfo", cancellationToken);
-        return res.IsSuccessStatusCode;
+        try
+        {
+            var res = await httpClient.GetAsync("./fcr:systeminfo", cancellationToken);
+            return res.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occured while checking if Fedora is alive");
+            return false;
+        }
     }
 }

--- a/src/DigitalPreservation/Storage.API/Fedora/FedoraOptions.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/FedoraOptions.cs
@@ -1,0 +1,26 @@
+namespace Storage.API.Fedora;
+
+public class FedoraOptions
+{
+    public const string Fedora = "Fedora";
+    
+    /// <summary>
+    /// Root URI for Fedora (including /fcrepo/rest/) path
+    /// </summary>
+    public required Uri Root { get; set; }
+    
+    /// <summary>
+    /// Admin username for Fedora
+    /// </summary>
+    public required string AdminUser { get; set; }
+    
+    /// <summary>
+    /// Admin password for Fedora
+    /// </summary>
+    public required string AdminPassword { get; set; }
+
+    /// <summary>
+    /// Timeout, in MS, for requests made to storage client 
+    /// </summary>
+    public double TimeoutMs { get; set; } = 15000;
+}

--- a/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
@@ -1,5 +1,11 @@
 namespace Storage.API.Fedora;
 
+/// <summary>
+/// Interface for interacting with Fedora
+/// </summary>
+/// <remarks>
+/// We may want to split this eventually (ie read/write or for different operations) but single interface for now
+/// </remarks>
 public interface IFedoraClient
 {
     /// <summary>

--- a/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
@@ -1,0 +1,11 @@
+namespace Storage.API.Fedora;
+
+public interface IFedoraClient
+{
+    /// <summary>
+    /// Basic ping to check Fedora API is alive. 
+    /// </summary>
+    /// <remarks>This is intended for testing only, will be removed</remarks>
+    /// <returns>true if alive, else false</returns>
+    Task<bool> IsAlive(CancellationToken cancellationToken = default);
+}

--- a/src/DigitalPreservation/Storage.API/Fedora/ServiceCollectionX.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/ServiceCollectionX.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Http.Headers;
+using DigitalPreservation.Core.Guard;
+using DigitalPreservation.Core.Web;
+using DigitalPreservation.Core.Web.Handlers;
+using Microsoft.Extensions.Options;
+
+namespace Storage.API.Fedora;
+
+public static class ServiceCollectionX
+{
+    /// <summary>
+    /// Add and configure <see cref="IFedoraClient"/> to service collection 
+    /// </summary>
+    /// <param name="serviceCollection">Current <see cref="IServiceCollection"/> object</param>
+    /// <param name="configuration">Current <see cref="IConfiguration"/> object</param>
+    /// <param name="componentName">Calling component name, used for "x-requested-by" header</param>
+    /// <returns>Modified service collection</returns>
+    public static IServiceCollection AddFedoraClient(this IServiceCollection serviceCollection,
+        IConfiguration configuration, string componentName)
+    {
+        serviceCollection.Configure<FedoraOptions>(configuration.GetSection(FedoraOptions.Fedora));
+        serviceCollection
+            .AddTransient<TimingHandler>()
+            .AddHttpClient<IFedoraClient, FedoraClient>((provider, client) =>
+            {
+                var fedoraOptions = provider.GetRequiredService<IOptions<FedoraOptions>>().Value;
+                client.BaseAddress = fedoraOptions.Root.ThrowIfNull(nameof(fedoraOptions.Root));
+                client.DefaultRequestHeaders.WithRequestedBy(componentName);
+                client.Timeout = TimeSpan.FromMilliseconds(fedoraOptions.TimeoutMs);
+                
+                // NOTE - this may change depending on how Auth is handled, may be better suited to something in
+                // http pipeline (e.g. DelegatingHandler) 
+                var credentials = $"{fedoraOptions.AdminUser}:{fedoraOptions.AdminPassword}";
+                var authHeader = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(credentials));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authHeader);
+            }).AddHttpMessageHandler<TimingHandler>();
+
+        return serviceCollection;
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Storage.API.csproj
+++ b/src/DigitalPreservation/Storage.API/Storage.API.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="MediatR" Version="12.4.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
       <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.1" />
     </ItemGroup>

--- a/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
+++ b/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
@@ -1,4 +1,6 @@
-﻿namespace Storage.Client;
+﻿using Microsoft.Extensions.Logging;
+
+namespace Storage.Client;
 
 /// <summary>
 /// Concrete implementation of <see cref="IStorageApiClient"/> for interacting with Storage API
@@ -7,11 +9,19 @@
 /// Marked internal to avoid consumers depending on this implementation, which will allow us to alter how it's
 /// implemented in the future to use, e.g. Refit client instead
 /// </remarks>
-internal class StorageApiClient(HttpClient httpClient) : IStorageApiClient
+internal class StorageApiClient(HttpClient httpClient, ILogger<StorageApiClient> logger) : IStorageApiClient
 {
     public async Task<bool> IsAlive(CancellationToken cancellationToken = default)
     {
-        var res = await httpClient.GetAsync("/", cancellationToken);
-        return res.IsSuccessStatusCode;
+        try
+        {
+            var res = await httpClient.GetAsync("/fedora", cancellationToken);
+            return res.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error occured while checking if API is alive");
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Add `/fedora` endpoint to Storage API. Calling this pings Fedora.

Updated `/storage` endpoint in Preservation to call ^, this completed chain of UI -> Preservation-API -> Storage API -> Fedora (not doing anything - connectivity check only)