### PR TITLE
Add machine header auth if using machine token

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Core/Auth/AuthFilterIdentifier.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core/Auth/AuthFilterIdentifier.cs
@@ -1,0 +1,38 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Identity.Web;
+
+namespace DigitalPreservation.Core.Auth;
+
+public sealed class AuthFilterIdentifier : IAsyncAuthorizationFilter
+{
+    //This used by PropagateCorrelationIdHandler
+    public const string MachineHeaderName = "xMachineName";
+
+    public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+    {
+        //return if valid standard user user
+        if (!string.IsNullOrEmpty(context.HttpContext.User.GetDisplayName()))
+        {
+            return Task.CompletedTask;
+        }
+
+        //Check if machine token and create new claims identity
+        if (context.HttpContext.Request.Headers.TryGetValue(MachineHeaderName, out var machineName))
+        {
+            ////Set claims  
+            var claims = new List<Claim>
+            {
+                new Claim("Name", machineName.FirstOrDefault() ?? string.Empty)
+            };
+            context.HttpContext.User.AddIdentity(new ClaimsIdentity(claims));
+
+            return Task.CompletedTask;
+        }
+
+        //Must be un unauthorised
+        context.Result = new UnauthorizedObjectResult("Unauthorized: No valid user name or machine header");
+        return Task.CompletedTask;
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Core/Web/Headers/PropagateCorrelationIdHandler.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core/Web/Headers/PropagateCorrelationIdHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Http;
+﻿using DigitalPreservation.Core.Auth;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Primitives;
 
 namespace DigitalPreservation.Core.Web.Headers;
@@ -54,7 +55,12 @@ public class PropagateCorrelationIdHandler(IHttpContextAccessor contextAccessor)
             request.Headers.TryAddWithoutValidation("Authorization", bearerToken);
         }
 
-
+        //Pass Machine Token Downstream
+        var machineToken = contextAccessor.HttpContext.TryGetHeaderValue(AuthFilterIdentifier.MachineHeaderName);
+        if (!string.IsNullOrEmpty(machineToken))
+        {
+            request.Headers.TryAddWithoutValidation(AuthFilterIdentifier.MachineHeaderName, machineToken);
+        }
 
         return base.SendAsync(request, cancellationToken);
     }

--- a/src/DigitalPreservation/Preservation.API/Program.cs
+++ b/src/DigitalPreservation/Preservation.API/Program.cs
@@ -1,4 +1,4 @@
-using DigitalPreservation.Common.Model.Identity;
+﻿using DigitalPreservation.Common.Model.Identity;
 using DigitalPreservation.Core.Configuration;
 using DigitalPreservation.Core.Web.Headers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -14,6 +14,8 @@ using Storage.Client;
 using Storage.Repository.Common;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.S3;
+using Preservation.API;
+using DigitalPreservation.Core.Auth;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -67,6 +69,7 @@ try
             if (useAuthFeatureFlag)
             {
                 config.Filters.Add(new AuthorizeFilter());
+                config.Filters.Add(new AuthFilterIdentifier());
             }
         });
 

--- a/src/DigitalPreservation/Storage.API/Program.cs
+++ b/src/DigitalPreservation/Storage.API/Program.cs
@@ -1,10 +1,12 @@
 ﻿using DigitalPreservation.Common.Model.Identity;
+using DigitalPreservation.Core.Auth;
 using DigitalPreservation.Core.Configuration;
 using DigitalPreservation.Core.Web.Headers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Identity.Web;
 using Serilog;
+using Storage.API;
 using Storage.API.Data;
 using Storage.API.Features.Export;
 using Storage.API.Features.Export.Data;
@@ -72,6 +74,7 @@ try
             if (useAuthFeatureFlag)
             {
                 config.Filters.Add(new AuthorizeFilter());
+                config.Filters.Add(new AuthFilterIdentifier());
             }
         });
 


### PR DESCRIPTION
## Changes 

**Approach**
This adds in an additional authentication filter to both APIs,  if the incoming token does not have a claims principle Name (all user tokens will have this) then it will look for a header with key of "xMachineName" (this name can be changed) . If it finds the header it will use this to create an new Identity in HttpContext.User. The Authorisation filter is applied to BOTH APIs there a machine token could in theory (not sure of any valid use cases for this)  target the Storage API directly. 

Having no claims name in token and no header supplied will result in failed auth on all calls.  This is important to fail all calls as they could be situations that the calls appear to work on fetching data (get) but fail on write (or put/post). 

The Authorisation filter is applied to BOTH APIs there a machine token could in theory (not sure of any valid use cases for this)  target the Storage API directly. 

The current code uses ClaimsPrincipal.GetDisplayName() via ClaimsPrincipalX in both APIs  when creating or posting changes so the  "xMachineName" header is transferred like the Auth token from the Presentation API to the Storage API  in  PropagateCorrelationIdHandler.  

**Testing**

1. Run UI with user create folder: works as expected
2. Fetch with valid machine token and valid header value: get data as expected.
3. Put new container with valid  machine token and valid header value: creates new folder with header value as user
4. Fetch with invalid machine token and valid header: 401 as expected
5. Fetch with valid machine token and no header : 401 custom error as expected
6. Fetch invalid token and no header:  401 as expected.

