### PR TITLE
Fix bugs 90783 and 90777

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Container.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Container.cs
@@ -32,11 +32,11 @@ public class Container : PreservedResource
     {
         var allExistingContainers = new List<Container>();
         var allExistingBinaries = new List<Binary>();
-        FlatternInternal(allExistingContainers, allExistingBinaries, this);
+        FlattenInternal(allExistingContainers, allExistingBinaries, this);
         return (allExistingContainers, allExistingBinaries);
     }
 
-    private static void FlatternInternal(
+    private static void FlattenInternal(
         List<Container> allExistingContainers,
         List<Binary> allExistingBinaries,
         Container traverseContainer)
@@ -44,7 +44,7 @@ public class Container : PreservedResource
         foreach (var container in traverseContainer.Containers)
         {
             allExistingContainers.Add(container.CloneForFlatten());
-            FlatternInternal(allExistingContainers, allExistingBinaries, container);
+            FlattenInternal(allExistingContainers, allExistingBinaries, container);
         }
         allExistingBinaries.AddRange(traverseContainer.Binaries);
     }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedDirectory.cs
@@ -247,4 +247,31 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
         Mets
     }
 
+    
+    
+    public (List<CombinedDirectory>, List<CombinedFile>) Flatten()
+    {
+        var directories = new List<CombinedDirectory>();
+        var files = new List<CombinedFile>();
+        FlattenInternal(directories, files, this);
+        return (directories, files);
+    }
+
+    private static void FlattenInternal(
+        List<CombinedDirectory> directories,
+        List<CombinedFile> files,
+        CombinedDirectory traverseDirectory)
+    {
+        foreach (var directory in traverseDirectory.Directories)
+        {
+            directories.Add(directory.CloneForFlatten());
+            FlattenInternal(directories, files, directory);
+        }
+        files.AddRange(traverseDirectory.Files);
+    }
+
+    private CombinedDirectory CloneForFlatten()
+    {
+        return new CombinedDirectory(DirectoryInDeposit, DirectoryInMets);
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -427,7 +427,7 @@ ViewData["section"] = "deposits";
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="deleteFrom" value="@Whereabouts.Deposit" id="deleteFromDeposit">
                             <label class="form-check-label" for="deleteFromDeposit">
-                                Delete from Deposit only
+                                Delete from Deposit only @(Model.ArchivalGroupExists ? "" : "(for updates only)")
                             </label>
                         </div>
                         <div class="form-check">
@@ -559,6 +559,8 @@ ViewData["section"] = "deposits";
 
 
 <script>
+    
+    const archivalGroupExists = @(Model.ArchivalGroupExists ? "true" : "false");
     const rows = document.getElementsByClassName("deposit-row");
 
     const newFolderContext = document.getElementById("newFolderContext");
@@ -610,6 +612,8 @@ ViewData["section"] = "deposits";
         deleteFromDepositRadio.checked = false;
         deleteFromMetsAndDepositRadio.checked = false;
         deleteButton.setAttribute("disabled", "true");
+        deleteFromDepositRadio.setAttribute("disabled", "true");
+        deleteFromMetsAndDepositRadio.setAttribute("disabled", "true");
         
         const itemSelectors = document.getElementsByClassName("item-selector");
         const deleteSelectionObject = { items: [] };
@@ -639,7 +643,16 @@ ViewData["section"] = "deposits";
             }
         }
         summary += "</table>";
-        deleteItemHelp.innerHTML = summary;
+
+        if (deleteSelectionObject.items.length > 0){
+            deleteItemHelp.innerHTML = summary;
+            deleteFromMetsAndDepositRadio.removeAttribute("disabled");
+            if (archivalGroupExists){
+                deleteFromDepositRadio.removeAttribute("disabled");
+            }
+        } else {
+            deleteItemHelp.innerHTML = "<p>There are no items selected.</p>"
+        }
         document.getElementById("deleteSelectionObject").value = JSON.stringify(deleteSelectionObject);
     });
 
@@ -676,10 +689,12 @@ ViewData["section"] = "deposits";
             }
         }
         summary += "</table>";
-        addToMetsHelp.innerHTML = summary;
         document.getElementById("addToMetsObject").value = JSON.stringify(addToMetsObject);
         if (addToMetsObject.length > 0){
+            addToMetsHelp.innerHTML = summary;
             addToMetsButton.removeAttribute("disabled");
+        } else {
+            addToMetsHelp.innerHTML = "<p>There are no items selected.</p>"
         }
     });
     
@@ -729,6 +744,7 @@ ViewData["section"] = "deposits";
             }
         });
     }
+
 
 </script>
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -26,7 +26,9 @@ public class DepositModel(
     public required WorkspaceManager WorkspaceManager { get; set; }
     public Deposit? Deposit { get; set; }
     public string? ArchivalGroupTestWarning { get; set; }
-    
+
+    public bool ArchivalGroupExists => Deposit is not null && Deposit.ArchivalGroupExists;
+
     public async Task OnGet(
         [FromRoute] string id,
         [FromQuery] bool readFromStorage = false,

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
@@ -147,7 +147,7 @@ public class GetDiffImportJobHandler(
             logger.LogWarning(message);
             return Result.FailNotNull<ImportJob>(ErrorCodes.Unprocessable, message);
         }
-
+        
         foreach (var container in sourceContainers)
         {
             var relativePath = container.Id!.ToString().RemoveStart(agStringWithSlash);
@@ -167,7 +167,6 @@ public class GetDiffImportJobHandler(
             }
         }
 
-        // var callerIdentity = ClaimsPrincipal.Current.GetCallerIdentity();
         var callerIdentity = request.Principal.GetCallerIdentity();
         var now = DateTime.UtcNow;
         var importJob = new ImportJob
@@ -195,6 +194,12 @@ public class GetDiffImportJobHandler(
             // This is a new object
             importJob.ContainersToAdd = sourceContainers;
             importJob.BinariesToAdd = sourceBinaries;
+        }
+
+        var validateMetsResult = workspace.ValidateImportJob(importJob, combined, existingArchivalGroup);
+        if (validateMetsResult.Failure)
+        {
+            return Result.FailNotNull<ImportJob>(ErrorCodes.BadRequest, validateMetsResult.ErrorMessage);
         }
 
         logger.LogInformation("Diff Import Job created: " + importJob.LogSummary());


### PR DESCRIPTION
The fix to 90777 makes 90783 harder to get to. The UI disables removing from deposit only for a NEW archival group. But you can still do it in an update (new version) of an existing deposit, and then you'll see this:

> BadRequest: File objects/372705s_004.jpg is in deposit METS but not in existing Archival Group or Deposit.