### PR TITLE
Allow UI users to see METS XML

### DIFF
--- a/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
@@ -46,6 +46,7 @@ public interface IPreservationApiClient
     
     Task<Result<ArchivalGroup?>> TestArchivalGroupPath(string archivalGroupPathUnderRoot);
     Task<(Stream?, string?)> GetContentStream(string repositoryPath, CancellationToken cancellationToken);
+    Task<(Stream?, string?)> GetMetsStream(string archivalGroupPathUnderRoot, CancellationToken cancellationToken = default);
     
     
     // Healthchecks and housekeeping

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -330,8 +330,25 @@ internal class PreservationApiClient(
 
     public async Task<(Stream?, string?)> GetContentStream(string repositoryPath, CancellationToken cancellationToken)
     {
-        var path = "/content/" + repositoryPath.RemoveStart("/").RemoveStart(PreservedResource.BasePathElement);
+        var path = "/content/" + repositoryPath
+            .RemoveStart("/")
+            .RemoveStart(PreservedResource.BasePathElement)
+            .RemoveStart("/");
         var uri = new Uri(path, UriKind.Relative);
+        var req = new HttpRequestMessage(HttpMethod.Get, uri);
+        var response = await preservationHttpClient.SendAsync(req, cancellationToken);
+        if (response.IsSuccessStatusCode)
+        {
+            return (await response.Content.ReadAsStreamAsync(cancellationToken), 
+                response.Content.Headers.ContentType?.ToString() ?? "application/octet-stream");
+        }
+
+        return (null, null);
+    }
+
+    public async Task<(Stream?, string?)> GetMetsStream(string archivalGrouprepositoryPath, CancellationToken cancellationToken)
+    {
+        var uri = new Uri(archivalGrouprepositoryPath + "?view=mets", UriKind.Relative);
         var req = new HttpRequestMessage(HttpMethod.Get, uri);
         var response = await preservationHttpClient.SendAsync(req, cancellationToken);
         if (response.IsSuccessStatusCode)


### PR DESCRIPTION
As a user of the Preservation **UI**, this is the only repository content I can see. But it's useful!

https://dev.azure.com/universityofleeds/Library/_boards/board/t/Digirati/Backlog%20items?workitem=87702