### PR TITLE
Add different Auth for ActivityController 

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ChangeDiscovery/Reader/ActivityStreamReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ChangeDiscovery/Reader/ActivityStreamReader.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net.Http.Json;
+using DigitalPreservation.Common.Model.Constants;
+
 
 namespace DigitalPreservation.Common.Model.ChangeDiscovery.Reader;
 
@@ -8,17 +10,26 @@ namespace DigitalPreservation.Common.Model.ChangeDiscovery.Reader;
 /// <param name="httpClient"></param>
 public class ActivityStreamReader(HttpClient httpClient)
 {
+    private readonly string apiKeyHeaderName = AuthConstants.ActivityApiKeyHeader;
+
     public async IAsyncEnumerable<Activity> ReadActivityStream(Uri orderedCollection, DateTime activitiesAfter)
     {
+        //replace api code
+        var code = ToptHelper.GetTotp;
+        httpClient.DefaultRequestHeaders.Remove(apiKeyHeaderName);
+        httpClient.DefaultRequestHeaders.Add(apiKeyHeaderName, code);
+
         var collection = await httpClient.GetFromJsonAsync<OrderedCollection>(orderedCollection);
         var pageUri = collection!.Last?.Id;
         while (pageUri != null)
         {
             var page = await httpClient.GetFromJsonAsync<OrderedCollectionPage>(pageUri);
+            
             if (page?.OrderedItems == null || page.OrderedItems.Count == 0)
             {
                 throw new Exception("Activity Stream Page has no OrderedItems");
             }
+
             foreach (var activity in page.OrderedItems.AsEnumerable().Reverse())
             {
                 if (activity.EndTime > activitiesAfter)

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Constants/AuthConstants.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Constants/AuthConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace DigitalPreservation.Common.Model.Constants;
+
+/// <summary>
+/// Items or values of that will rarely if ever change
+/// </summary>
+public static class AuthConstants
+{
+    public static string ActivityApiKeyHeader = "x-activity-api";
+    public static string ActivityApiTotpSeed = "df$%df34F45jtrtr43435ns#~@fdd&^";
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DigitalPreservation.Common.Model.csproj
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DigitalPreservation.Common.Model.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Otp.NET" Version="1.4.0" />
       <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ToptHelper.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ToptHelper.cs
@@ -1,0 +1,29 @@
+﻿using System.Text;
+using DigitalPreservation.Common.Model.Constants;
+using OtpNet;
+
+namespace DigitalPreservation.Common.Model;
+
+/// <summary>
+/// Generates and verifies totp codes
+/// </summary>
+public static class ToptHelper
+{
+    private static readonly string Seed = AuthConstants.ActivityApiTotpSeed;
+    private static readonly Totp Totp;
+
+    static ToptHelper()
+    {
+        Totp = new Totp(
+            Encoding.ASCII.GetBytes(Seed),
+            mode: OtpHashMode.Sha512,
+            step: 300, //seconds
+            totpSize: 8);
+    }
+    
+    public static string? GetTotp =>
+        Totp.ComputeTotp();
+
+    public static bool Verify(string? code) =>
+        code is not null && Totp.VerifyTotp(code, out _);
+}

--- a/src/DigitalPreservation/DigitalPreservation.Core/Auth/AuthFilterIdentifier.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core/Auth/AuthFilterIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Identity.Web;
@@ -12,6 +13,13 @@ public sealed class AuthFilterIdentifier : IAsyncAuthorizationFilter
 
     public Task OnAuthorizationAsync(AuthorizationFilterContext context)
     {
+        //Controller allows Anonymous so ignore this filter
+        if (context.ActionDescriptor.EndpointMetadata
+            .Any(em => em.GetType() == typeof(AllowAnonymousAttribute)))
+        {
+            return Task.CompletedTask;
+        }
+        
         //return if valid standard user user
         if (!string.IsNullOrEmpty(context.HttpContext.User.GetDisplayName()))
         {

--- a/src/DigitalPreservation/DigitalPreservation.Core/Auth/CustomActivityAuthorize.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core/Auth/CustomActivityAuthorize.cs
@@ -1,0 +1,26 @@
+﻿using System.CodeDom.Compiler;
+using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Constants;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DigitalPreservation.Core.Auth;
+
+public sealed class CustomActivityAuthorize : Attribute, IAuthorizationFilter
+{
+    private readonly string apiKeyHeaderName = AuthConstants.ActivityApiKeyHeader;
+  
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        //Check if machine token and create new claims identity
+        if (context.HttpContext.Request.Headers.TryGetValue(apiKeyHeaderName, out var keyValue))
+        {
+           
+            if (ToptHelper.Verify(keyValue))
+                return;
+        }
+
+        //Must be un unauthorised
+        context.Result = new UnauthorizedObjectResult("Unauthorized");
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Core/DigitalPreservation.Core.csproj
+++ b/src/DigitalPreservation/DigitalPreservation.Core/DigitalPreservation.Core.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Identity.Web" Version="3.4.0" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DigitalPreservation/Storage.API/Features/Activity/ActivityController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Activity/ActivityController.cs
@@ -1,5 +1,7 @@
-﻿using DigitalPreservation.Core.Web;
+﻿using DigitalPreservation.Core.Auth;
+using DigitalPreservation.Core.Web;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Storage.API.Features.Activity.Requests;
 
@@ -7,15 +9,17 @@ namespace Storage.API.Features.Activity;
 
 [Route("[controller]")]
 [ApiController]
+[AllowAnonymous] // ignore standard auth
+[CustomActivityAuthorize] // use filter in api totp instead
 public class ActivityController(IMediator mediator) : Controller
 {
-
     [HttpGet("importjobs/collection", Name = "GetImportJobsCollection")]
     public async Task<IActionResult> GetImportJobsCollection()
     {
         var result = await mediator.Send(new GetImportJobsOrderedCollection());
         return this.StatusResponseFromResult(result);
     }
+
 
     [HttpGet("importjobs/pages/{page}", Name = "GetImportJobsPage")]
     public async Task<IActionResult> GetImportJobsPage(int page)


### PR DESCRIPTION
**Issue**
The PreservationAPI  has a background worker process which calls the SecurityAPI Activity controller.  This controller however does not have have a Bearer Token that it can pass through as its is not called by a user (or machine token).

**Approach**
Implement a separate Authentication method for this (and possibly other controllers).  Generated TOTP tokens from the Presentation API are used for calling the Activity stream via a custom authorisation filter. This has an advantage over a fixed APIKey as the token will constantly change and is shorted lived (300 seconds set in code). Also APIKey management is not required as the token exchange uses the same private seed. 

**Testing***
Looked at calls in code between the layers.