### PR TITLE
Escape chars in RDF Turtle statements going to Fedora

### DIFF
--- a/src/DigitalPreservation/Storage.API.Tests/Fedora/RequestXTests.cs
+++ b/src/DigitalPreservation/Storage.API.Tests/Fedora/RequestXTests.cs
@@ -1,0 +1,40 @@
+﻿using Storage.API.Fedora.Http;
+
+namespace Storage.API.Tests.Fedora;
+
+public class RequestXTests
+{
+    [Fact]
+    public void Single_Rdf_Statement_Simple_Name()
+    {
+        // Arrange
+        var msg = new HttpRequestMessage();
+
+        // Act
+        msg.WithName("Simple name");
+        
+        // Assert
+        ((StringContent)msg.Content!).ReadAsStringAsync().Result.Should()
+            .Be($"""
+                 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                 <> dc:title "Simple name" .
+                 """);
+    }
+    
+    [Fact]
+    public void Single_Rdf_Statement_Dodgy_Name()
+    {
+        // Arrange
+        var msg = new HttpRequestMessage();
+
+        // Act
+        msg.WithName("Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156");
+        
+        // Assert
+        ((StringContent)msg.Content!).ReadAsStringAsync().Result.Should()
+            .Be($"""
+                 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+                 <> dc:title "Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156" .
+                 """);
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Features/Import/Requests/ExecuteImportJob.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Import/Requests/ExecuteImportJob.cs
@@ -68,7 +68,8 @@ public class ExecuteImportJobHandler(
 
             if (archivalGroupResult.Failure || archivalGroupResult.Value is null)
             {
-                return await FailEarly("Failed to create archival group: " + archivalGroupPathUnderRoot);
+                return await FailEarly(
+                    $"Failed to create archival group: {archivalGroupPathUnderRoot}, message: {archivalGroupResult.CodeAndMessage()}");
             }
         }
         else

--- a/src/DigitalPreservation/Storage.API/Fedora/Http/RdfBodyBuilder.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/Http/RdfBodyBuilder.cs
@@ -8,6 +8,44 @@ namespace Storage.API.Fedora.Http;
 public static partial class RdfBodyBuilder
 {
     private static readonly MediaTypeHeaderValue Turtle = MediaTypeHeaderValue.Parse("text/turtle");
+
+    public static string EscapeForLiteralRdf(this string s, bool stripLineBreaks)
+    {
+        var sb = new StringBuilder();
+        foreach (var c in s)
+        {
+            switch (c)
+            {
+                case '\"':
+                    sb.Append("\\\"");
+                    break;
+                case '\r' when stripLineBreaks:
+                    sb.Append(" - ");
+                    break;
+                case '\r' when !stripLineBreaks:
+                    sb.Append("\\r");
+                    break;
+                case '\n' when stripLineBreaks:
+                    sb.Append(" - ");
+                    break;
+                case '\n' when !stripLineBreaks:
+                    sb.Append("\\n");
+                    break;
+                case '\t':
+                    sb.Append( "\\t" );
+                    break;
+                default:
+                {
+                    if( c < 32 || c >= 127 )
+                        sb.Append($"\\u{(int)c:x4}");
+                    else
+                        sb.Append(c);
+                    break;
+                }
+            }
+        }
+        return sb.ToString();
+    }
     
     public static void AppendRdf(this HttpRequestMessage requestMessage, string prefix, string uri, string statement)
     {


### PR DESCRIPTION
Starting adding real content to Fedora and it revealed this bug, created this test for it:

```
    [Fact]
    public void Single_Rdf_Statement_Dodgy_Name()
    {
        // Arrange
        var msg = new HttpRequestMessage();

        // Act
        msg.WithName("Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156");
        
        // Assert
        ((StringContent)msg.Content!).ReadAsStringAsync().Result.Should()
            .Be($"""
                 PREFIX dc: <http://purl.org/dc/elements/1.1/>
                 <> dc:title "Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156" .
                 """);
    }
```

(Note that the \" escape in the final Assert section are LITERAL - they are really there in the string. The $""" escaped string makes it look like the // Act string but it isn't!

![image](https://github.com/user-attachments/assets/2c057f10-8c4c-4947-9f6f-70ab28490e18)
