### PR TITLE
Bugs with non ascii file names, and very large files

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -15,7 +15,7 @@
                 <text>@binary.Name</text>
                 @if (binary.Name != binary.GetSlug())
                 {
-                    <text> (@binary.GetSlug())</text>
+                    <br/><small>@binary.GetSlug()</small>
                 }
             } 
             else if (workingFile != null)
@@ -23,7 +23,7 @@
                 <text>@workingFile.Name</text>
                 @if (workingFile.Name != workingFile.GetSlug())
                 {
-                    <text> (@workingFile.GetSlug())</text>
+                    <br/><small>@workingFile.GetSlug()</small>
                 }
             }
             else
@@ -35,7 +35,7 @@
     @if (workingFile != null)
     {
         <tr>
-            <th scope="row">Original path</th>
+            <th scope="row">Path</th>
             <td>@workingFile.MetsExtensions?.OriginalPath</td>
         </tr>
     }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -33,6 +33,8 @@ try
             .Enrich.FromLogContext()
             .Enrich.WithCorrelationId());
 
+    // Don't impose any limit for file uploads
+    builder.WebHost.ConfigureKestrel(options => options.Limits.MaxRequestBodySize = long.MaxValue);
 
     IEnumerable<string>? initialScopes = new List<string>();
     builder.Configuration.GetSection("DownstreamApi:Scopes").Bind(initialScopes);

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/CreateFolder.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/CreateFolder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Text.Encodings.Web;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
@@ -52,7 +53,7 @@ public class CreateFolderHandler(
             BucketName = s3Uri.Bucket,
             Key = fullKey
         };
-        pReq.Metadata.Add(S3Helpers.OriginalNameMetadataKey, request.Name);
+        pReq.Metadata.Add(S3Helpers.OriginalNameMetadataKey, WebUtility.UrlEncode(request.Name));
         try
         {
             var response = await s3Client.PutObjectAsync(pReq, cancellationToken);

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.S3;
+﻿using System.Net;
+using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
 using DigitalPreservation.Common.Model;
@@ -52,7 +53,7 @@ public class UploadFileToDepositHandler(
             ChecksumAlgorithm = ChecksumAlgorithm.SHA256,
             InputStream = request.Stream
         };
-        req.Metadata.Add(S3Helpers.OriginalNameMetadataKey, request.DepositFileName);
+        req.Metadata.Add(S3Helpers.OriginalNameMetadataKey, WebUtility.UrlEncode(request.DepositFileName));
         try
         {
             var response = await s3Client.PutObjectAsync(req, cancellationToken);

--- a/src/DigitalPreservation/Storage.API/Fedora/Http/RequestX.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/Http/RequestX.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Net;
+using System.Net.Http.Headers;
 using DigitalPreservation.Utils;
 using Storage.API.Fedora.Model;
 using Storage.API.Fedora.Vocab;
@@ -175,7 +176,8 @@ public static class RequestX
     {
         if (!string.IsNullOrWhiteSpace(contentDisposition))
         {
-            httpContent.Headers.Add("Content-Disposition", $"attachment; filename=\"{contentDisposition}\""); 
+            var encoded = WebUtility.UrlEncode(contentDisposition);
+            httpContent.Headers.Add("Content-Disposition", $"attachment; filename=\"{encoded}\""); 
         }
         return httpContent;
     }

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -319,7 +319,7 @@ public class Storage(
                     if (metadata == null) continue;
                     if (metadata.Keys.Contains(S3Helpers.OriginalNameMetadataResponseKey))
                     {
-                        dir.Name = metadata[S3Helpers.OriginalNameMetadataResponseKey];
+                        dir.Name = WebUtility.UrlDecode(metadata[S3Helpers.OriginalNameMetadataResponseKey]);
                     }
                 }
                 else
@@ -340,7 +340,7 @@ public class Storage(
                     {
                         if (metadata.Keys.Contains(S3Helpers.OriginalNameMetadataResponseKey))
                         {
-                            wf.Name = metadata[S3Helpers.OriginalNameMetadataResponseKey];
+                            wf.Name = WebUtility.UrlDecode(metadata[S3Helpers.OriginalNameMetadataResponseKey]);
                         }
                     }
                     dir!.Files.Add(wf);


### PR DESCRIPTION
Example filename that was causing Chris issues:

慷獹琠散敬牢瑡圣浯湥䡳獩潴祲潍瑮㼿䄠摮愠猠敮歡瀠敥瑡匠䍉敮⁷牡�.msg

7 ways to celebrate #WomensHistoryMonth 💜 And a sneak peek at SICK new art.htm