### PR TITLE
Better capture errors when UI calls Preservation API

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
@@ -58,7 +58,7 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
                 }
                 return Result.Fail<PreservedResource?>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailResult<PreservedResource>();
+            return await response.ToFailResult<PreservedResource>("Unable to GET Resource");
         }
         catch (Exception e)
         {
@@ -130,7 +130,7 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
                 }
                 return Result.Fail<Container?>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailResult<Container>();
+            return await response.ToFailResult<Container>("Unable to create Container");
         }
         catch (Exception e)
         {
@@ -151,7 +151,7 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
             {
                 return Result.Ok();
             }
-            return await response.ToFailResult();
+            return await response.ToFailResult("Unable to delete Container");
         }
         catch (Exception e)
         {
@@ -176,7 +176,7 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
                 }
                 return Result.Fail<ArchivalGroup>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailResult<ArchivalGroup>();
+            return await response.ToFailResult<ArchivalGroup>("Unable to test archival group path");
         }
         catch (Exception e)
         {

--- a/src/DigitalPreservation/DigitalPreservation.Core/Web/ProblemDetailsX.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core/Web/ProblemDetailsX.cs
@@ -6,30 +6,54 @@ namespace DigitalPreservation.Core.Web;
 
 public static class ProblemDetailsX
 {
-    public static async Task<Result<T>> ToFailNotNullResult<T>(this HttpResponseMessage response)
+    private static async Task<ProblemDetails> GetProblemDetails(HttpResponseMessage response, string messageIfNoProblemDetails)
     {
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        return problem!.ToFailNotNullResult<T>();
+        var statusCode = (int)response.StatusCode;
+        var message = messageIfNoProblemDetails;
+        try
+        {
+            var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+            if (problem != null)
+            {
+                return problem;
+            }
+        }
+        catch (Exception e)
+        {
+            message = $"{message} => {e.Message}";
+        }
+
+        return new ProblemDetails
+        {
+            Status = statusCode,
+            Detail = message,
+            Title = messageIfNoProblemDetails
+        };
+    }
+    public static async Task<Result<T>> ToFailNotNullResult<T>(this HttpResponseMessage response, string messageIfNoProblemDetails)
+    {
+        var problem = await GetProblemDetails(response, messageIfNoProblemDetails);
+        return problem.ToFailNotNullResult<T>();
     }
     
-    public static async Task<Result<T?>> ToFailResult<T>(this HttpResponseMessage response)
+    public static async Task<Result<T?>> ToFailResult<T>(this HttpResponseMessage response, string messageIfNoProblemDetails)
     {
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        return problem!.ToFailResult<T>();
+        var problem = await GetProblemDetails(response, messageIfNoProblemDetails);
+        return problem.ToFailResult<T>();
     }
 
-    public static async Task<Result> ToFailResult(this HttpResponseMessage response)
+    public static async Task<Result> ToFailResult(this HttpResponseMessage response, string messageIfNoProblemDetails)
     {
-        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        return problem!.ToFailResult();
+        var problem = await GetProblemDetails(response, messageIfNoProblemDetails);
+        return problem.ToFailResult();
     }
-    
+
     public static Result<T> ToFailNotNullResult<T>(this ProblemDetails problemDetails)
     {
         var errorCode = ErrorCodes.GetErrorCode(problemDetails.Status);
         return Result.FailNotNull<T>(errorCode, problemDetails.Detail);
     }
-    
+
     public static Result<T?> ToFailResult<T>(this ProblemDetails problemDetails)
     {
         var errorCode = ErrorCodes.GetErrorCode(problemDetails.Status);

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
@@ -220,6 +220,11 @@ public class BrowseModel(
             testPath = testPath.GetParent();
         }
 
+        if (CachedArchivalGroup != null && Request.Headers.CacheControl == "no-cache")
+        {
+            CachedArchivalGroup = null;
+        }
+
         if (CachedArchivalGroup == null)
         {
             // If not, get the resource.

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Index.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Index.cshtml
@@ -3,7 +3,6 @@
 @using DigitalPreservation.Common.Model.PreservationApi
 @using DigitalPreservation.UI.Features
 @using DigitalPreservation.Utils
-@using Microsoft.AspNetCore.WebUtilities
 @model IndexModel
 
 @{
@@ -329,7 +328,16 @@
     <p><a href="/deposits?status=error&showAll=true">See all deposits with errors</a></p>
 </div>
 
-@await Component.InvokeAsync("Pager", new { values = Model.PagerValues })
+@if (Model.PagerValues != null)
+{
+    @await Component.InvokeAsync("Pager", new { values = Model.PagerValues })
+}
+else
+{
+    <div class="alert alert-danger" role="alert">
+        <p>No PagerValues Present - are any deposits returned?</p>
+    </div>
+}
 
 
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Index.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Index.cshtml.cs
@@ -6,7 +6,6 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Primitives;
 
 namespace DigitalPreservation.UI.Pages.Deposits;
 
@@ -55,7 +54,10 @@ public class IndexModel(IMediator mediator) : PageModel
             PagerValues = new PagerValues(Request.QueryString, QueryPage.Total, QueryPage.PageSize);
             
             var agentResult = await mediator.Send(new GetAllAgents());
-            Agents = agentResult.Value!.Select(uri => uri.GetSlug()).OrderBy(s => s).ToList()!;
+            if (agentResult.Success)
+            {
+                Agents = agentResult.Value!.Select(uri => uri.GetSlug()).OrderBy(s => s).ToList()!;
+            }
         }
         else
         {

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -55,7 +55,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<List<Uri>>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<List<Uri>>();
+            return await response.ToFailNotNullResult<List<Uri>>("Unable to get agents");
         }
         catch (Exception e)
         {
@@ -80,7 +80,7 @@ internal class PreservationApiClient(
                 }
                 return Result.Fail<Deposit>(ErrorCodes.UnknownError, "No deposit returned");
             }
-            return await response.ToFailResult<Deposit>();
+            return await response.ToFailResult<Deposit>("Unable to update deposit");
         }
         catch (Exception e)
         {
@@ -100,7 +100,7 @@ internal class PreservationApiClient(
             {
                 return Result.Ok();
             }
-            return await response.ToFailResult();
+            return await response.ToFailResult("Unable to delete deposit");
         }
         catch (Exception e)
         {
@@ -125,7 +125,7 @@ internal class PreservationApiClient(
                 }
                 return Result.Fail<Deposit>(ErrorCodes.UnknownError, "No deposit returned");
             }
-            return await response.ToFailResult<Deposit>();
+            return await response.ToFailResult<Deposit>("Unable to create deposit from identifier");
         }
         catch (Exception e)
         {
@@ -173,7 +173,7 @@ internal class PreservationApiClient(
                 }
                 return Result.Fail<Deposit>(ErrorCodes.UnknownError, "No deposit returned");
             }
-            return await response.ToFailResult<Deposit>();
+            return await response.ToFailResult<Deposit>("Unable to create deposit");
         }
         catch (Exception e)
         {
@@ -185,7 +185,8 @@ internal class PreservationApiClient(
     
 
     public async Task<Result<DepositQueryPage>> GetDeposits(DepositQuery? query, CancellationToken cancellationToken = default)
-    {        
+    {
+        var responseStatusCode = -1;
         try
         {
             var relPath = "/deposits";
@@ -197,6 +198,7 @@ internal class PreservationApiClient(
             var uri = new Uri(relPath, UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await preservationHttpClient.SendAsync(req, cancellationToken);
+            responseStatusCode = (int)response.StatusCode;
             if (response.IsSuccessStatusCode)
             {
                 var deposits = await response.Content.ReadFromJsonAsync<DepositQueryPage>(cancellationToken: cancellationToken);
@@ -206,12 +208,13 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<DepositQueryPage>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<DepositQueryPage>();
+            return await response.ToFailNotNullResult<DepositQueryPage>("Unable to get Deposits");
         }
         catch (Exception e)
         {
-            logger.LogError(e, e.Message);
-            return Result.FailNotNull<DepositQueryPage>(ErrorCodes.UnknownError, e.Message);
+            var errorCode = ErrorCodes.GetErrorCode(responseStatusCode);
+            logger.LogError(e, "status code was {status}, error was {message}", responseStatusCode, e.Message);
+            return Result.FailNotNull<DepositQueryPage>(errorCode, e.Message);
         }
     }
 
@@ -231,7 +234,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<List<ImportJobResult>>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<List<ImportJobResult>>();
+            return await response.ToFailNotNullResult<List<ImportJobResult>>("Unable to get import job results");
         }
         catch (Exception e)
         {
@@ -256,7 +259,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<ImportJobResult>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<ImportJobResult>();
+            return await response.ToFailNotNullResult<ImportJobResult>("Unable to get import job result");
         }
         catch (Exception e)
         {
@@ -282,7 +285,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<ImportJob>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<ImportJob>();
+            return await response.ToFailNotNullResult<ImportJob>("Unable to get diff import job");
         }
         catch (Exception e)
         {
@@ -311,7 +314,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<ImportJobResult>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<ImportJobResult>();
+            return await response.ToFailNotNullResult<ImportJobResult>("Unable to send diff import job");
         }
         catch (Exception e)
         {
@@ -337,7 +340,7 @@ internal class PreservationApiClient(
                 }
                 return Result.Fail<Deposit>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailResult<Deposit>();
+            return await response.ToFailResult<Deposit>("Unable to get deposit");
         }
         catch (Exception e)
         {
@@ -360,7 +363,7 @@ internal class PreservationApiClient(
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
                 return Result.OkNotNull((content, eTag));
             }
-            return await response.ToFailResult<(string, string)>();
+            return await response.ToFailResult<(string, string)>("Unable to get mets with ETag");
         }
         catch (Exception e)
         {

--- a/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
+++ b/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
@@ -41,7 +41,7 @@ public class StorageApiClient(
                     return Result.OkNotNull(stream);
                     
                 }
-                return await response.ToFailNotNullResult<Stream>();
+                return await response.ToFailNotNullResult<Stream>("Unable to get Binary stream");
             }
             catch (Exception e)
             {
@@ -97,7 +97,7 @@ public class StorageApiClient(
                 }
                 return Result.FailNotNull<ImportJobResult>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailNotNullResult<ImportJobResult>();
+            return await response.ToFailNotNullResult<ImportJobResult>("Unable to get import job result");
         }
         catch (Exception e)
         {
@@ -125,7 +125,7 @@ public class StorageApiClient(
                 }
                 return Result.FailNotNull<ImportJobResult>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailNotNullResult<ImportJobResult>();
+            return await response.ToFailNotNullResult<ImportJobResult>("Unable to execute import job");
         }
         catch (Exception e)
         {
@@ -179,7 +179,7 @@ public class StorageApiClient(
                 }
                 return Result.FailNotNull<Export>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailNotNullResult<Export>();
+            return await response.ToFailNotNullResult<Export>("Unable to export archival group");
         }
         catch (Exception e)
         {
@@ -204,7 +204,7 @@ public class StorageApiClient(
                 }
                 return Result.FailNotNull<Export>(ErrorCodes.UnknownError, "Resource could not be parsed.");
             }
-            return await response.ToFailNotNullResult<Export>();
+            return await response.ToFailNotNullResult<Export>("Unable to get export result");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Previously relied on the API sending back a valid ProblemDetails, but what if it doesn't?