### PR TITLE
Feature/premis as xml

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.XmlGen/Extensions/XElementX.cs
+++ b/src/DigitalPreservation/DigitalPreservation.XmlGen/Extensions/XElementX.cs
@@ -28,7 +28,7 @@ public static class XElementX
     /// </summary>
     /// <param name="rawPremisXml"></param>
     /// <returns></returns>
-    public static PremisComplexType? GetPremisComplexObject(this XmlElement rawPremisXml)
+    public static PremisComplexType? GetPremisComplexType(this XmlElement rawPremisXml)
     {
         // I think that Goobi's example is incompatible with the generated classes.
         // We need a `PremisComplexType` to deserialise, rather than ObjectComplexType

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -657,26 +657,6 @@ public class MetsManager(
         return mets;
     }
     
-    // const string PremisFixityWrapper = """
-    //                                    <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
-    //                                        <premis:objectCharacteristics>
-    //                                            <premis:fixity>
-    //                                                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
-    //                                                <premis:messageDigest>{sha256}</premis:messageDigest>
-    //                                            </premis:fixity>
-    //                                            <premis:size>{size}</premis:size>
-    //                                        </premis:objectCharacteristics>
-    //                                        <premis:originalName>{localPath}</premis:originalName>
-    //                                    </premis:object>
-    //                                    """;
-    //
-    // const string PremisOriginalNameWrapper = """
-    //                                    <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
-    //                                        <premis:originalName>{localPath}</premis:originalName>
-    //                                    </premis:object>
-    //                                    """;
-
-
     private static XmlSerializerNamespaces GetNamespaces()
     {
         var ns = new XmlSerializerNamespaces();
@@ -687,29 +667,6 @@ public class MetsManager(
         ns.Add("xsi", "http://www.w3.org/2001/XMLSchema-instance");
         return ns;
     }
-    
-    // [Obsolete]
-    // private static AmdSecType GetAmdSecType(string reducedPremisForObjectDir, string admId, string techId)
-    // {
-    //     var reducedPremisX = GetElement(reducedPremisForObjectDir);
-    //     var amdSec = new AmdSecType
-    //     {
-    //         Id = admId,
-    //         TechMd =
-    //         {
-    //             new MdSecType
-    //             {
-    //                 Id = techId,
-    //                 MdWrap = new MdSecTypeMdWrap
-    //                 {
-    //                     Mdtype = MdSecTypeMdWrapMdtype.PremisObject,
-    //                     XmlData = new MdSecTypeMdWrapXmlData { Any = { reducedPremisX } }
-    //                 }
-    //             }
-    //         }
-    //     };
-    //     return amdSec;
-    // }
     
     
     private static AmdSecType GetAmdSecType(PremisFile premisFile, string admId, string techId)

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -10,8 +10,11 @@ using DigitalPreservation.Common.Model.Mets;
 using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Utils;
+using DigitalPreservation.XmlGen.Extensions;
 using DigitalPreservation.XmlGen.Mets;
+using DigitalPreservation.XmlGen.Premis.V3;
 using Checksum = DigitalPreservation.Utils.Checksum;
+using File = System.IO.File;
 
 namespace Storage.Repository.Common.Mets;
 
@@ -87,8 +90,7 @@ public class MetsManager(
                     Admid = { admId }
                 };
                 div.Div.Add(childDirectoryDiv);
-                var reducedPremisForObjectDir = PremisOriginalNameWrapper
-                    .Replace("{localPath}", localPath);
+                var reducedPremisForObjectDir = new PremisFile { OriginalName = localPath };
                 mets.AmdSec.Add(GetAmdSecType(reducedPremisForObjectDir, admId, techId));
             }
             AddResourceToMets(mets, archivalGroup, childDirectoryDiv, childContainer);
@@ -112,10 +114,6 @@ public class MetsManager(
                 Fptr = { new DivTypeFptr{ Fileid = fileId } }
             };
             div.Div.Add(childItemDiv);
-            var reducedPremis = PremisFixityWrapper
-                .Replace("{sha256}", binary.Digest)
-                .Replace("{size}", binary.Size.ToString())
-                .Replace("{localPath}", localPath);
             mets.FileSec.FileGrp[0].File.Add(
                 new FileType
                 {
@@ -129,7 +127,13 @@ public class MetsManager(
                         } 
                     }
                 });
-            mets.AmdSec.Add(GetAmdSecType(reducedPremis, admId, techId));
+            var premisFile = new PremisFile
+            {
+                Digest = binary.Digest,
+                Size = binary.Size,
+                OriginalName = localPath
+            };
+            mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId));
         }
     }
 
@@ -448,16 +452,25 @@ public class MetsManager(
                     }
 
                     var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == file.Admid[0]);
-                    
-                    // This replaces the Premis metadata, which won't be OK later when it gets richer
-                    // from pipeline decorators.
-                    // TODO: Instead, need to merge the premis metadata.
-                    var reducedPremis = PremisFixityWrapper
-                        .Replace("{sha256}", workingFile.Digest)
-                        .Replace("{size}", workingFile.Size.ToString())
-                        .Replace("{localPath}", workingFile.LocalPath);
-                    var reducedPremisX = GetElement(reducedPremis);
-                    amdSec.TechMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { reducedPremisX } };
+                    var premisXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault();
+                    var patchPremis = new PremisFile
+                    {
+                        Digest = workingFile.Digest,
+                        Size = workingFile.Size,
+                        OriginalName = workingFile.LocalPath
+                    };  
+                    PremisComplexType? premisType;
+                    if (premisXml is not null)
+                    {
+                        premisType = premisXml.GetPremisComplexType()!;
+                        PremisManager.Patch(premisType, patchPremis);
+                    }
+                    else
+                    {
+                        premisType = PremisManager.Create(patchPremis);
+                    }
+                    premisXml = PremisManager.GetXmlElement(premisType, true);
+                    amdSec.TechMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { premisXml } };
                 }
                 else if (workingBase is WorkingDirectory workingDirectory)
                 {
@@ -511,10 +524,6 @@ public class MetsManager(
                     Fptr = { new DivTypeFptr{ Fileid = fileId } }
                 };
                 div.Div.Add(childItemDiv);
-                var reducedPremis = PremisFixityWrapper
-                    .Replace("{sha256}", workingFile.Digest)
-                    .Replace("{size}", workingFile.Size.ToString())
-                    .Replace("{localPath}", workingFile.LocalPath);
                 fullMets.Mets.FileSec.FileGrp[0].File.Add(
                     new FileType
                     {
@@ -528,7 +537,13 @@ public class MetsManager(
                             } 
                         }
                     });
-                fullMets.Mets.AmdSec.Add(GetAmdSecType(reducedPremis, admId, techId));
+                var premisFile = new PremisFile
+                {
+                    Digest = workingFile.Digest,
+                    Size = workingFile.Size,
+                    OriginalName = workingFile.LocalPath
+                };
+                fullMets.Mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId));
             }
             else if (workingBase is WorkingDirectory workingDirectory)
             {
@@ -540,9 +555,11 @@ public class MetsManager(
                     Admid = { admId }
                 };
                 div.Div.Add(childDirectoryDiv);
-                var reducedPremisForObjectDir = PremisOriginalNameWrapper
-                    .Replace("{localPath}", workingDirectory.LocalPath);
-                fullMets.Mets.AmdSec.Add(GetAmdSecType(reducedPremisForObjectDir, admId, techId));
+                var premisFile = new PremisFile
+                {
+                    OriginalName = workingDirectory.LocalPath
+                };
+                fullMets.Mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId));
             }
             else
             {
@@ -580,8 +597,6 @@ public class MetsManager(
 
     private DigitalPreservation.XmlGen.Mets.Mets GetEmptyMets()
     {
-        var reducedPremisForObjectDir = PremisOriginalNameWrapper
-            .Replace("{localPath}", "objects");
         var mets = new DigitalPreservation.XmlGen.Mets.Mets
         {
             MetsHdr = new()
@@ -634,7 +649,7 @@ public class MetsManager(
             },
             AmdSec =
             {
-                GetAmdSecType(reducedPremisForObjectDir, $"{AdmIdPrefix}objects", $"{TechIdPrefix}objects")
+                GetAmdSecType(new PremisFile { OriginalName = "objects" }, $"{AdmIdPrefix}objects", $"{TechIdPrefix}objects")
             }
             // NB we don't have a structLink because we have no logical structMap (yet)
         };
@@ -642,30 +657,25 @@ public class MetsManager(
         return mets;
     }
     
-    const string PremisFixityWrapper = """
-                                       <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
-                                           <premis:objectCharacteristics>
-                                               <premis:fixity>
-                                                   <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
-                                                   <premis:messageDigest>{sha256}</premis:messageDigest>
-                                               </premis:fixity>
-                                               <premis:size>{size}</premis:size>
-                                           </premis:objectCharacteristics>
-                                           <premis:originalName>{localPath}</premis:originalName>
-                                       </premis:object>
-                                       """;
-    
-    const string PremisOriginalNameWrapper = """
-                                       <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
-                                           <premis:originalName>{localPath}</premis:originalName>
-                                       </premis:object>
-                                       """;
-    private static XmlElement GetElement(string xml)
-    {
-        var doc = new XmlDocument();
-        doc.LoadXml(xml);
-        return doc.DocumentElement!;
-    }
+    // const string PremisFixityWrapper = """
+    //                                    <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+    //                                        <premis:objectCharacteristics>
+    //                                            <premis:fixity>
+    //                                                <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+    //                                                <premis:messageDigest>{sha256}</premis:messageDigest>
+    //                                            </premis:fixity>
+    //                                            <premis:size>{size}</premis:size>
+    //                                        </premis:objectCharacteristics>
+    //                                        <premis:originalName>{localPath}</premis:originalName>
+    //                                    </premis:object>
+    //                                    """;
+    //
+    // const string PremisOriginalNameWrapper = """
+    //                                    <premis:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+    //                                        <premis:originalName>{localPath}</premis:originalName>
+    //                                    </premis:object>
+    //                                    """;
+
 
     private static XmlSerializerNamespaces GetNamespaces()
     {
@@ -678,9 +688,34 @@ public class MetsManager(
         return ns;
     }
     
-    private static AmdSecType GetAmdSecType(string reducedPremisForObjectDir, string admId, string techId)
+    // [Obsolete]
+    // private static AmdSecType GetAmdSecType(string reducedPremisForObjectDir, string admId, string techId)
+    // {
+    //     var reducedPremisX = GetElement(reducedPremisForObjectDir);
+    //     var amdSec = new AmdSecType
+    //     {
+    //         Id = admId,
+    //         TechMd =
+    //         {
+    //             new MdSecType
+    //             {
+    //                 Id = techId,
+    //                 MdWrap = new MdSecTypeMdWrap
+    //                 {
+    //                     Mdtype = MdSecTypeMdWrapMdtype.PremisObject,
+    //                     XmlData = new MdSecTypeMdWrapXmlData { Any = { reducedPremisX } }
+    //                 }
+    //             }
+    //         }
+    //     };
+    //     return amdSec;
+    // }
+    
+    
+    private static AmdSecType GetAmdSecType(PremisFile premisFile, string admId, string techId)
     {
-        var reducedPremisX = GetElement(reducedPremisForObjectDir);
+        var premis = PremisManager.Create(premisFile);
+        var xElement = PremisManager.GetXmlElement(premis, true);
         var amdSec = new AmdSecType
         {
             Id = admId,
@@ -692,11 +727,19 @@ public class MetsManager(
                     MdWrap = new MdSecTypeMdWrap
                     {
                         Mdtype = MdSecTypeMdWrapMdtype.PremisObject,
-                        XmlData = new MdSecTypeMdWrapXmlData { Any = { reducedPremisX } }
+                        XmlData = new MdSecTypeMdWrapXmlData { Any = { xElement }}
                     }
                 }
             }
         };
         return amdSec;
+    }
+    
+    [Obsolete("Make a ModsManager like PremisManager")]
+    private static XmlElement GetElement(string xml)
+    {
+        var doc = new XmlDocument();
+        doc.LoadXml(xml);
+        return doc.DocumentElement!;
     }
 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -413,6 +413,7 @@ public class MetsParser(
                     string? digest = null;
                     long size = 0;
                     string? originalName = null;
+                    FileFormat? fileFormat = null;
                     if (!haveUsedAdmIdAlready)
                     {
                         var techMd = xMets.Descendants(XNames.MetsTechMD).SingleOrDefault(t => t.Attribute("ID")!.Value == admId);
@@ -437,6 +438,21 @@ public class MetsParser(
                         }
                         originalName = techMd.Descendants(XNames.PremisOriginalName).SingleOrDefault()?.Value;
                         haveUsedAdmIdAlready = true;
+                        var format = techMd.Descendants(XNames.PremisFormat).SingleOrDefault();
+                        if (format != null)
+                        {
+                            var name = format.Descendants(XNames.PremisFormatName).SingleOrDefault()?.Value;
+                            var key = format.Descendants(XNames.PremisFormatRegistryKey).SingleOrDefault()?.Value;
+                            if (name.HasText() && key.HasText())
+                            {
+                                fileFormat = new FileFormat
+                                {
+                                    Name = name, Key = key
+                                };
+                            }
+                        }
+
+                        fileFormat ??= new FileFormat { Name = "[Not Identified]", Key = "dlip/unknown" };
                     }
                     var parts = flocat.Split('/');
                     if (string.IsNullOrEmpty(mimeType))
@@ -462,11 +478,7 @@ public class MetsParser(
                             AdmId = admId,
                             PhysDivId = div.Attribute("ID")?.Value,
                             OriginalPath = originalName,
-                            FileFormat = new FileFormat
-                            {
-                                Name = "TODO",
-                                Key = "TODO"
-                            },
+                            FileFormat = fileFormat,
                             VirusScan = new VirusScan
                             {
                                 HasVirus = false

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -1,0 +1,235 @@
+﻿using System.Xml;
+using System.Xml.Serialization;
+using DigitalPreservation.Utils;
+using DigitalPreservation.XmlGen.Premis.V3;
+using File = DigitalPreservation.XmlGen.Premis.V3.File;
+
+namespace Storage.Repository.Common.Mets;
+
+public class PremisManager
+{
+    private static readonly XmlSerializerNamespaces Namespaces;
+    public const string Pronom = "PRONOM";
+    public const string Sha256 = "SHA256";
+    
+    static PremisManager()
+    {
+        Namespaces = new XmlSerializerNamespaces();
+        Namespaces.Add("premis", "http://www.loc.gov/premis/v3");
+        Namespaces.Add("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+    }
+    
+    public static PremisFile? Read(PremisComplexType premis)
+    {
+        var file = premis.Object.FirstOrDefault(po => po is File);
+        return file == null ? null : Read((File)file);
+    }
+    
+    public static PremisFile Read(File file)
+    {
+        var premisFile = new PremisFile();
+        var objectCharacteristics = file.ObjectCharacteristics.FirstOrDefault();
+        
+        var fixity = objectCharacteristics?.Fixity?.FirstOrDefault(f => f.MessageDigestAlgorithm.Value?.ToUpperInvariant() == Sha256);
+        if (fixity != null)
+        {
+            premisFile.Digest = fixity.MessageDigest;
+        }
+
+        if (objectCharacteristics?.Size is > 0)
+        {
+            premisFile.Size = objectCharacteristics.Size;
+        }
+        var pronomFormat = objectCharacteristics?.Format.FirstOrDefault(
+            f => f.FormatRegistry.FirstOrDefault(
+                fr => fr.FormatRegistryName.Value == Pronom) != null);
+
+        if (pronomFormat != null)
+        {
+            premisFile.FormatName = pronomFormat.FormatDesignation.FormatName.Value;
+        }
+        var registry = pronomFormat?.FormatRegistry.FirstOrDefault(fr => fr.FormatRegistryName.Value == Pronom);
+        if (registry != null)
+        {
+            premisFile.PronomKey = registry.FormatRegistryKey.Value;
+        }
+
+        if (file.OriginalName?.Value != null)
+        {
+            premisFile.OriginalName = file.OriginalName.Value;
+        }
+
+        return premisFile;
+
+    }
+    
+    public static PremisComplexType Create(PremisFile premisFile)
+    {
+        var premis = new PremisComplexType();
+        var file = new File();
+        premis.Object.Add(file);
+        var objectCharacteristics = new ObjectCharacteristicsComplexType();
+        file.ObjectCharacteristics.Add(objectCharacteristics);
+
+        if (premisFile.Digest.HasText())
+        {
+            var fixity = new FixityComplexType
+            {
+                MessageDigestAlgorithm = new MessageDigestAlgorithm{ Value = Sha256 },
+                MessageDigest = premisFile.Digest
+            };
+            objectCharacteristics.Fixity.Add(fixity);
+        }
+
+        if (premisFile.Size is > 0)
+        {
+            objectCharacteristics.Size = premisFile.Size;
+        }
+
+        if (premisFile.PronomKey.HasText())
+        {
+            var format = new FormatComplexType
+            {
+                FormatDesignation = new FormatDesignationComplexType
+                {
+                    FormatName = new FormatName { Value = premisFile.FormatName }
+                }
+            };
+            var registry = new FormatRegistryComplexType
+            {
+                FormatRegistryName = new FormatRegistryName { Value = Pronom },
+                FormatRegistryKey = new FormatRegistryKey { Value = premisFile.PronomKey }
+            };
+            format.FormatRegistry.Add(registry);
+            objectCharacteristics.Format.Add(format);
+        }
+
+        if (premisFile.OriginalName.HasText())
+        {
+            file.OriginalName = new OriginalNameComplexType
+            {
+                Value = premisFile.OriginalName
+            };
+        }
+
+        return premis;
+    }
+
+    public static void Patch(PremisComplexType premis, PremisFile premisFile)
+    {
+        // This is not just the same as Create because it shouldn't touch any fields existing
+        // in the premis:file already, other than those supplied
+        if (premis.Object.FirstOrDefault(po => po is File) is not File file)
+        {
+            file = new File();
+            premis.Object.Add(file);
+        }
+        
+        var objectCharacteristics = file.ObjectCharacteristics.FirstOrDefault();
+        if (objectCharacteristics == null)
+        {
+            objectCharacteristics = new ObjectCharacteristicsComplexType();
+            file.ObjectCharacteristics.Add(objectCharacteristics);
+        }
+        
+        if (premisFile.Digest.HasText())
+        {
+            var fixity = objectCharacteristics.Fixity.FirstOrDefault(f => f.MessageDigestAlgorithm.Value?.ToUpperInvariant() == Sha256);
+            if (fixity == null)
+            {
+                fixity = new FixityComplexType
+                {
+                    MessageDigestAlgorithm = new MessageDigestAlgorithm{ Value = Sha256 }
+                };
+                objectCharacteristics.Fixity.Add(fixity);
+            }
+            fixity.MessageDigest = premisFile.Digest;
+        }
+
+        if (premisFile.Size is > 0)
+        {
+            objectCharacteristics.Size = premisFile.Size;
+        }
+
+        if (premisFile.PronomKey.HasText())
+        {
+            var pronomFormat = EnsurePronomFormat(objectCharacteristics);
+            var registry = pronomFormat.FormatRegistry.FirstOrDefault(fr => fr.FormatRegistryName.Value == Pronom);
+            if (registry == null)
+            {
+                registry = new FormatRegistryComplexType
+                {
+                    FormatRegistryName = new FormatRegistryName { Value = Pronom }
+                };
+                pronomFormat.FormatRegistry.Add(registry);
+            }
+            registry.FormatRegistryKey = new FormatRegistryKey { Value = premisFile.PronomKey };
+        }
+
+        if (premisFile.FormatName.HasText())
+        {
+            var pronomFormat = EnsurePronomFormat(objectCharacteristics);
+            pronomFormat.FormatDesignation = new FormatDesignationComplexType
+            {
+                FormatName = new FormatName { Value = premisFile.FormatName }
+            };
+        }
+
+        if (premisFile.OriginalName.HasText())
+        {
+            file.OriginalName = new OriginalNameComplexType
+            {
+                Value = premisFile.OriginalName
+            };
+        }
+    }
+
+    private static FormatComplexType EnsurePronomFormat(ObjectCharacteristicsComplexType objectCharacteristics)
+    {
+        var pronomFormat = objectCharacteristics.Format.FirstOrDefault(
+            f => f.FormatRegistry.FirstOrDefault(
+                fr => fr.FormatRegistryName.Value == Pronom) != null);
+        if (pronomFormat == null)
+        {
+            pronomFormat = new FormatComplexType();
+            objectCharacteristics.Format.Add(pronomFormat);
+        }
+
+        return pronomFormat;
+    }
+
+    public static string Serialise(PremisComplexType premis)
+    {
+        var serializer = new XmlSerializer(typeof(PremisComplexType));
+        var sw = new StringWriter();
+        serializer.Serialize(sw, premis, Namespaces);
+        return sw.ToString();
+    }
+
+    public static XmlElement? GetXmlElement(PremisComplexType premis, bool fileElement)
+    {
+        var serializer = new XmlSerializer(typeof(PremisComplexType));
+        var doc = new XmlDocument();
+        using (var xw = doc.CreateNavigator()!.AppendChild()) {
+            serializer.Serialize(xw,  premis, Namespaces);
+        }
+        if (fileElement)
+        {
+            return doc.DocumentElement?.FirstChild as XmlElement;
+        }
+        return doc.DocumentElement;
+    }
+}
+
+/// <summary>
+/// Represents only the Premis fields we are interested in WRITING to METS
+/// </summary>
+public class PremisFile
+{
+    public string? Digest { get; set; } // must be sha256
+    public long? Size { get; set; }
+    public string? FormatName { get; set; }
+    public string? PronomKey { get; set; }
+    public string? OriginalName { get; set; }
+}
+

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/XNames.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/XNames.cs
@@ -54,6 +54,7 @@ public static class XNames
     public static readonly XName PremisSignificantPropertiesType = premis + "significantPropertiesType";
     public static readonly XName PremisSignificantPropertiesValue = premis + "significantPropertiesValue";
     public static readonly XName PremisSize = premis + "size";
+    public static readonly XName PremisFormat = premis + "format";
     public static readonly XName PremisFormatName = premis + "formatName";
     public static readonly XName PremisFormatVersion = premis + "formatVersion";
     public static readonly XName PremisFormatRegistryKey = premis + "formatRegistryKey";

--- a/src/DigitalPreservation/XmlGen.Tests/GoobiMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/GoobiMetsParsing.cs
@@ -198,7 +198,7 @@ public class GoobiMetsParsing
         premisXml.Name.Should().Be("premis:object");
         
         // Now turn it into typed PremisComplexObject
-        var premis = premisXml.GetPremisComplexObject()!;
+        var premis = premisXml.GetPremisComplexType()!;
         premis.Should().NotBeNull();
 
         var premisFile = premis.Object[0] as File;

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
@@ -1,0 +1,70 @@
+﻿using Amazon.S3;
+using DigitalPreservation.Common.Model.Transit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Storage.Repository.Common.Mets;
+
+namespace XmlGen.Tests;
+
+public class MetsManagerWithPremis
+{
+    private readonly MetsManager metsManager;
+    private readonly MetsParser parser;
+
+    public MetsManagerWithPremis()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var s3Client = new Mock<IAmazonS3>().Object;
+        parser = new MetsParser(s3Client, parserLogger);
+        metsManager = new MetsManager(parser, s3Client);
+    }
+    
+    
+    [Fact]
+    public async Task Can_Update_Premis()
+    {
+        var premisMetsFi = new FileInfo("Outputs/premis-mets.xml");
+        var metsUri = new Uri(premisMetsFi.FullName);
+        var result = await metsManager.CreateStandardMets(
+            metsUri, "Empty Mets File - Premis tests");
+        
+        result.Success.Should().BeTrue();
+        var metsWrapper = result.Value!;
+        metsWrapper.PhysicalStructure!.Directories.Should().HaveCount(1);
+        metsWrapper.PhysicalStructure.Directories.Should().Contain(wd => wd.Name == "objects");
+        
+        var file = new WorkingFile
+        {
+            ContentType = "text/plain",
+            Digest = "801d4a031510adb61ae11412c1554fbaa769a6b4428225ad87a489f92889f105",
+            LocalPath = "objects/readme.txt",
+            Size = 9999,
+            Name = "readme.txt",
+            Modified = DateTime.UtcNow
+        };
+        var addResult = await metsManager.HandleSingleFileUpload(metsUri, file, metsWrapper.ETag!);
+        addResult.Success.Should().BeTrue();
+        
+        var parseResult = await parser.GetMetsFileWrapper(metsUri);
+        parseResult.Success.Should().BeTrue();
+
+        var updatedWrapper = parseResult.Value!;
+        var objectsDir = updatedWrapper.PhysicalStructure!.Directories[0];
+        objectsDir.Directories.Should().HaveCount(0);
+        objectsDir.Files.Should().HaveCount(1);
+        objectsDir.Files[0].Name.Should().Be("readme.txt");
+        objectsDir.Files[0].LocalPath.Should().Be("objects/readme.txt");
+        objectsDir.Files[0].Size.Should().Be(9999);
+        objectsDir.Files[0].ContentType.Should().Be("text/plain");
+        objectsDir.Files[0].Digest.Should().Be("801d4a031510adb61ae11412c1554fbaa769a6b4428225ad87a489f92889f105");
+        
+        // TODO: Validate result.Value.XDocument
+    }
+}


### PR DESCRIPTION
Previously the PREMIS XML sections of our METS were made by substituting strings into a string XML template.

(This was to avoid or rather kick-down-the-road some XML Namespace issues I was having).

Now the Premis is constructed using the XmlGen-created classes and incorporated into the bigger METS Object as an XmlElement.

A new class `PremisManager` provides a simplified way of modifying just the PREMIS properties we care about.

