### PR TITLE
Fix auth token generation issue

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Infrastructure/RejectSessionCookieWhenAccountNotInCacheEvents.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Infrastructure/RejectSessionCookieWhenAccountNotInCacheEvents.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.TokenCacheProviders;
+
+namespace DigitalPreservation.UI.Infrastructure;
+
+/// <summary>
+/// This fixes a bug in MS Auth with DelegatingHandler and token generation
+/// </summary>
+public class RejectSessionCookieWhenAccountNotInCacheEvents : CookieAuthenticationEvents
+{
+    public override async Task ValidatePrincipal(CookieValidatePrincipalContext context)
+    {
+        var msalTokenCacheProvider = context.HttpContext.RequestServices.GetRequiredService<IMsalTokenCacheProvider>();
+        var configuration = context.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
+
+        /* Build a confidential application to be able to access the token cache. */
+
+        ConfidentialClientApplicationOptions options = new();
+        configuration.GetSection(Constants.AzureAd).Bind(options);
+
+        var app = ConfidentialClientApplicationBuilder
+            .CreateWithApplicationOptions(options)
+            .Build();
+
+        /* Check in the cache if the current user is present. */
+
+        msalTokenCacheProvider.Initialize(app.UserTokenCache);
+        var accountId = (context.Principal ?? throw new InvalidOperationException("Missing cookie principal")).GetMsalAccountId();
+        var account = await app.GetAccountAsync(accountId);
+        if (account == null)
+        {
+            /* The current user is not present in the token cache, and needs to authenticate again in order to get security tokens. */
+            context.RejectPrincipal();
+        }
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -1,4 +1,4 @@
-using DigitalPreservation.CommonApiClient;
+﻿using DigitalPreservation.CommonApiClient;
 using DigitalPreservation.Core.Configuration;
 using DigitalPreservation.Core.Web.Headers;
 using DigitalPreservation.UI.Infrastructure;
@@ -49,6 +49,8 @@ try
             null)
         .EnableTokenAcquisitionToCallDownstreamApi(initialScopes)
         .AddSessionTokenCaches();
+
+    builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, options => options.Events = new RejectSessionCookieWhenAccountNotInCacheEvents());
 
     // <ms_docref_add_default_controller_for_sign-in-out>
     builder.Services.AddRazorPages().AddMvcOptions(options =>
@@ -110,13 +112,13 @@ try
         .UseHttpsRedirection()
         .UseStaticFiles()
         .UseRouting()
-        .UseAuthorization()
         .UseForwardedHeaders();
     app.UseSession();
     app.MapRazorPages();
     app.MapControllers();
     app.UseHealthChecks("/health");
     app.UseAuthentication();
+    app.UseAuthorization();
 
 
 

--- a/src/DigitalPreservation/Preservation.Client/AuthTokenInjector.cs
+++ b/src/DigitalPreservation/Preservation.Client/AuthTokenInjector.cs
@@ -1,7 +1,11 @@
 ﻿using System.Net.Http.Headers;
+using System.Security.Claims;
 using DigitalPreservation.CommonApiClient;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
+using Microsoft.IdentityModel.Abstractions;
 
 namespace Preservation.Client;
 
@@ -25,7 +29,7 @@ public class AuthTokenInjector(ITokenAcquisition tokenAcquisition, ITokenScope t
         catch (Exception e)
         {
             logger.LogError(e, "Failed to obtain Bearer Token");
-            return null;
+            throw;
         }
     }
 

--- a/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
+++ b/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
@@ -21,8 +21,8 @@ public static class ServiceCollectionX
     {
         serviceCollection.Configure<PreservationOptions>(configuration.GetSection(PreservationOptions.Preservation));
         serviceCollection
-            .AddScoped<TimingHandler>()
-            .AddScoped<AuthTokenInjector>()
+            .AddTransient<TimingHandler>()
+            .AddTransient<AuthTokenInjector>()
             .AddHttpClient<IPreservationApiClient, PreservationApiClient>((provider, client) =>
             {
                 var preservationOptions = provider.GetRequiredService<IOptions<PreservationOptions>>().Value;

--- a/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
+++ b/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
@@ -21,8 +21,8 @@ public static class ServiceCollectionX
     {
         serviceCollection.Configure<PreservationOptions>(configuration.GetSection(PreservationOptions.Preservation));
         serviceCollection
-            .AddTransient<TimingHandler>()
-            .AddTransient<AuthTokenInjector>()
+            .AddScoped<TimingHandler>()
+            .AddScoped<AuthTokenInjector>()
             .AddHttpClient<IPreservationApiClient, PreservationApiClient>((provider, client) =>
             {
                 var preservationOptions = provider.GetRequiredService<IOptions<PreservationOptions>>().Value;


### PR DESCRIPTION
**Fix**

see: https://dev.azure.com/universityofleeds/Library/_workitems/edit/93159

- Add Session Cookie When Account Not In Cache Events  handler
- Add to step 1 to CookieAuthenticationOptions in builder services
- Change AuthTokenInjector (and TimingHandler) to Scoped DI
- Change AuthTokenInjector so throws exception.


**Test**
Tested locally across 4 sessions 