### PR TITLE
Allow search deposits by AG slug

### DIFF
--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposits.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposits.cs
@@ -41,8 +41,17 @@ public class GetDepositsHandler(
                 var predicate = PredicateBuilder.New<DepositEntity>();
                 if (q.ArchivalGroupPath.HasText())
                 {
-                    predicate = predicate.And(x =>
-                        x.ArchivalGroupPathUnderRoot == q.ArchivalGroupPath.GetPathUnderRoot(false));
+                    if (q.ArchivalGroupPath.Contains('/'))
+                    {
+                        predicate = predicate.And(x =>
+                            x.ArchivalGroupPathUnderRoot == q.ArchivalGroupPath.GetPathUnderRoot(false));
+                    }
+                    else
+                    {
+                        predicate = predicate.And(x =>
+                            x.ArchivalGroupPathUnderRoot != null &&
+                            x.ArchivalGroupPathUnderRoot.EndsWith(q.ArchivalGroupPath));
+                    }
                 }
                 if (q.ArchivalGroupPathParent.HasText())
                 {


### PR DESCRIPTION
The UI claims you can just put the slug but it previously needed the full path.