### PR TITLE
Remove versioning from API apart from Storage Maps and single resources

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
@@ -15,7 +15,6 @@ public interface IMetsManager
     Task<Result<MetsFileWrapper>> CreateStandardMets(Uri metsLocation, string? agNameFromDeposit);
     // Reverse-engineer a METS file from an existing AG. This is OK for now but likely to be an error scenario
     Task<Result<MetsFileWrapper>> CreateStandardMets(Uri metsLocation, ArchivalGroup archivalGroup, string? agNameFromDeposit);
-    bool IsMetsFile(string fileName);
     
     Task<Result> HandleSingleFileUpload(Uri workingRoot, WorkingFile workingFile, string depositETag); // , Uri? storageLocation
     Task<Result> HandleDeleteObject(Uri workingRoot, string localPath, string depositETag);

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedDirectory.cs
@@ -337,53 +337,45 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
         };
         foreach (var combinedDirectory in Directories)
         {
-            var directoryInDeposit = combinedDirectory.DirectoryInDeposit;
-            if (directoryInDeposit != null)
-            {
-                var childResult = combinedDirectory.ToContainer(
-                    repositoryUri.AppendEscapedSlug(directoryInDeposit.GetSlug().EscapeForUriNoHashes()), // For Fedora
-                    origin.AppendEscapedSlug(directoryInDeposit.GetSlug().EscapeForUri()), // Regular S3 URI
-                    uris);
-                if (childResult is { Success: true, Value: not null })
-                {
-                    container.Containers.Add(childResult.Value);
-                }
-                else
-                {
-                    return childResult;
-                }
-            }
+            string slug = combinedDirectory.LocalPath!.GetSlug();
+            var childResult = combinedDirectory.ToContainer(
+                 repositoryUri.AppendEscapedSlug(slug.EscapeForUriNoHashes()), // For Fedora
+                 origin.AppendEscapedSlug(slug.EscapeForUri()), // Regular S3 URI
+                 uris);
+             if (childResult is { Success: true, Value: not null })
+             {
+                 container.Containers.Add(childResult.Value);
+             }
+             else
+             {
+                 return childResult;
+             }
         }
         foreach (var combinedFile in Files)
         {
-            var fileInDeposit = combinedFile.FileInDeposit;
-            if (fileInDeposit == null)
-            {
-                continue;
-                // Is this a FAIL?
-            }
-            var binaryId = repositoryUri.AppendEscapedSlug(fileInDeposit.GetSlug().EscapeForUriNoHashes());
+            var slug = combinedFile.LocalPath!.GetSlug();
+            var binaryId = repositoryUri.AppendEscapedSlug(slug.EscapeForUriNoHashes());
             uris?.Add(binaryId);
             
             var size = combinedFile.GetSingleSize();
             if (size <= 0)
             {
                 return Result.FailNotNull<Container>(ErrorCodes.BadRequest, 
-                    $"File {fileInDeposit.LocalPath} has different sizes in deposit and mets or does not have a size at all");
+                    $"File {combinedFile.LocalPath} has different sizes in deposit and mets or does not have a size at all");
             }
             
             var contentType = combinedFile.GetSingleContentType();
             if (contentType is null)
             {
                 return Result.FailNotNull<Container>(ErrorCodes.BadRequest, 
-                    $"File {fileInDeposit.LocalPath} has different content types in deposit and mets - " + string.Join(", ", combinedFile.GetAllContentTypes()));
+                    $"File {combinedFile.LocalPath} has different content types in deposit and mets - " + string.Join(", ", combinedFile.GetAllContentTypes()));
             }
 
             var digest = combinedFile.GetSingleDigest();
             if (digest is null)
             {
                 return Result.FailNotNull<Container>(ErrorCodes.BadRequest, 
-                    $"File {fileInDeposit.LocalPath} has different digests in deposit and mets");
+                    $"File {combinedFile.LocalPath} has different digests in deposit and mets");
             }
 
             var name = combinedFile.GetName();
@@ -395,7 +387,7 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
                 ContentType = contentType,
                 Digest = digest,
                 Size = size,
-                Origin = origin.AppendEscapedSlug(fileInDeposit.GetSlug().EscapeForUri())  // We'll need to unescape this back to a key
+                Origin = origin.AppendEscapedSlug(slug.EscapeForUri())  // We'll need to unescape this back to a key
             });
         }
         return Result.OkNotNull(container);

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/Metadata.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/Metadata.cs
@@ -7,6 +7,7 @@ namespace DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 [JsonDerivedType(typeof(ExifMetadata), typeDiscriminator: "ExifMetadata")]
 [JsonDerivedType(typeof(DigestMetadata), typeDiscriminator: "DigestMetadata")]
 [JsonDerivedType(typeof(VirusScanMetadata), typeDiscriminator: "VirusScanMetadata")]
+[JsonDerivedType(typeof(StorageMetadata), typeDiscriminator: "StorageMetadata")]
 public abstract class Metadata : IMetadata
 {
     [JsonPropertyName("source")]

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FolderNames.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FolderNames.cs
@@ -33,6 +33,10 @@ public static class FolderNames
 
     public static bool IsMetadata(string localPath)
     {
-        return localPath.StartsWith($"{BagItData}/{Metadata}/") || localPath.StartsWith($"{Metadata}/");
+        return 
+            localPath.StartsWith($"{BagItData}/{Metadata}/") || 
+            localPath.StartsWith($"{Metadata}/") || 
+            localPath == $"{BagItData}/{Metadata}" || 
+            localPath == Metadata;
     }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/MetadataException.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/MetadataException.cs
@@ -1,0 +1,6 @@
+﻿namespace DigitalPreservation.Common.Model.Transit;
+
+public class MetadataException(string message) : Exception(message)
+{
+    
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -155,7 +155,7 @@ public class WorkingFile : WorkingBase
         }
         // What to do if we have MISMATCHED digests?
         // Going to throw an exception for now but come back to this
-        throw new Exception($"Digests for {LocalPath} are not all the same");
+        throw new MetadataException($"Digests for {LocalPath} are not all the same");
     }
 
     public VirusScanMetadata? GetVirusScanMetadata()

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ViewValues.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ViewValues.cs
@@ -1,0 +1,7 @@
+﻿namespace DigitalPreservation.Common.Model;
+
+public class ViewValues
+{
+    public const string Mets = "mets";
+    public const string Lightweight = "lightweight";
+}

--- a/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
@@ -20,30 +20,27 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
 
     public async Task<Result<PreservedResource?>> GetResource(string path)
     {
-        return await GetResourceInternal(path, null);
+        return await GetResourceInternal(path);
     }
 
-    public async Task<Result<ArchivalGroup?>> GetArchivalGroup(string path, string? version)
+    public async Task<Result<ArchivalGroup?>> GetArchivalGroup(string path)
     {
-        logger.LogInformation("Getting ArchivalGroup " + path + ", version " + version);
-        var result = await GetResourceInternal(path, version);
+        logger.LogInformation("Getting ArchivalGroup " + path);
+        var result = await GetResourceInternal(path);
         if (result.Success)
         {
             return Result.Ok<ArchivalGroup?>(result.Value as ArchivalGroup);
         }
-        logger.LogWarning("Failed to get ArchivalGroup " + path + ", version " + version + ": " + result.CodeAndMessage());
+        logger.LogWarning("Failed to get ArchivalGroup " + path + ": " + result.CodeAndMessage());
         return Result.Cast<PreservedResource?, ArchivalGroup?>(result);
     }
+
     
-    private async Task<Result<PreservedResource?>> GetResourceInternal(string path, string? version)
+    private async Task<Result<PreservedResource?>> GetResourceInternal(string path)
     {        
         // path MUST be the full /repository... path, which we just pass through as-is
         try
         {
-            if(!string.IsNullOrWhiteSpace(version))
-            {
-                path += "?version=" + version;
-            }
             var uri = new Uri(path, UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
 

--- a/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.CommonApiClient/CommonApiBase.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Json;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
 using DigitalPreservation.Core.Web;
 using DigitalPreservation.Utils;
 using Microsoft.Extensions.Logging;
@@ -44,6 +45,37 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
             var uri = new Uri(path, UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
 
+            var response = await httpClient.SendAsync(req);
+            var stream = await response.Content.ReadAsStreamAsync();
+            if (response.IsSuccessStatusCode)
+            {
+                var parsed = PreservedResourceDeserializer.Parse(stream);
+                if (parsed != null)
+                {
+                    return Result.Ok<PreservedResource?>(parsed);
+                }
+                return Result.Fail<PreservedResource?>(ErrorCodes.UnknownError, "Resource could not be parsed.");
+            }
+            return await response.ToFailResult<PreservedResource>("Unable to GET Resource");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, e.Message);
+            return Result.Fail<PreservedResource?>(ErrorCodes.UnknownError, e.Message);
+        }
+    }
+    
+    public async Task<Result<PreservedResource?>> GetLightweightResource(string pathUnderRoot, string? version)
+    {        
+        var reqPath = $"{PreservedResource.BasePathElement}/{pathUnderRoot}?view=lightweight";
+        if (version.HasText())
+        {
+            reqPath = $"{reqPath}&version={version}";
+        }
+        try
+        {
+            var uri = new Uri(reqPath, UriKind.Relative);
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await httpClient.SendAsync(req);
             var stream = await response.Content.ReadAsStreamAsync();
             if (response.IsSuccessStatusCode)
@@ -179,6 +211,34 @@ public abstract class CommonApiBase(HttpClient httpClient, ILogger logger)
         {
             logger.LogError(e, e.Message);
             return Result.Fail<ArchivalGroup>(ErrorCodes.UnknownError, e.Message);
+        }
+    }
+    
+    public async Task<Result<StorageMap>> GetStorageMap(string archivalGroupPathUnderRoot, string? version = null)
+    {
+        var reqPath = $"ocfl/storagemap/{archivalGroupPathUnderRoot}";
+        if (version.HasText())
+        {
+            reqPath = $"{reqPath}?version={version}";
+        }
+        try
+        {
+            var uri = new Uri(reqPath, UriKind.Relative);
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = await httpClient.SendAsync(req);
+            var storageMap = await response.Content.ReadFromJsonAsync<StorageMap>();
+            if(storageMap != null)
+            {
+                logger.LogInformation("Received storageMap for ArchivalGroup {archivalGroupPathUnderRoot}, version {version}",
+                    archivalGroupPathUnderRoot, version);
+                return Result.OkNotNull(storageMap);
+            }
+            return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, "Resource could not be parsed.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, e.Message);
+            return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, e.Message);
         }
     }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/NewDepositModel.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/NewDepositModel.cs
@@ -22,4 +22,5 @@ public class NewDepositModel
     public bool UseObjectTemplate { get; set; }
     public bool UseBagItTemplate { get; set; }
     public bool Export { get; set; }
+    public string? Version { get; set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/Requests/GetStorageMap.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/Requests/GetStorageMap.cs
@@ -1,0 +1,21 @@
+﻿using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
+using MediatR;
+using Preservation.Client;
+
+namespace DigitalPreservation.UI.Features.Preservation.Requests;
+
+public class GetStorageMap(string pathUnderRoot, string? version) : IRequest<Result<StorageMap>>
+{
+    public string PathUnderRoot { get; } = pathUnderRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetStorageMapHandler(IPreservationApiClient preservationApiClient) : IRequestHandler<GetStorageMap, Result<StorageMap>>
+{
+    public async Task<Result<StorageMap>> Handle(GetStorageMap request, CancellationToken cancellationToken)
+    {
+        var result = await preservationApiClient.GetStorageMap(request.PathUnderRoot, request.Version);
+        return result;
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.UI/Features/Repository/Requests/GetLightweightResource.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Features/Repository/Requests/GetLightweightResource.cs
@@ -1,0 +1,21 @@
+﻿using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Results;
+using MediatR;
+using Preservation.Client;
+
+namespace DigitalPreservation.UI.Features.Repository.Requests;
+
+public class GetLightweightResource(string pathUnderRoot, string? version) : IRequest<Result<PreservedResource?>>
+{
+    public string PathUnderRoot { get; } = pathUnderRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetLightweightResourceHandler(IPreservationApiClient preservationApiClient) : IRequestHandler<GetLightweightResource, Result<PreservedResource?>>
+{
+    public async Task<Result<PreservedResource?>> Handle(GetLightweightResource request, CancellationToken cancellationToken)
+    {
+        var result = await preservationApiClient.GetLightweightResource(request.PathUnderRoot, request.Version);
+        return result;
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml
@@ -28,7 +28,7 @@
             }
             @if (Model.Resource is ArchivalGroup)
             {
-                <a class="btn btn-sm btn-outline-primary me-2 disabled">
+                <a class="btn btn-sm btn-outline-primary me-2" href="/ocfl/@Model.ArchivalGroupPath">
                     📦 Versions
                 </a>
                 <a class="btn btn-sm btn-outline-primary me-2 @(Model.HasPredictableIIIFPath ? "" : " disabled")"
@@ -196,8 +196,8 @@
                                     <text> class="table-primary" </text>
                                 }
                             >
-                                <td><a href="/ocfl/@(ViewBag.Path)?version=@version.OcflVersion">@version.OcflVersion</a></td>
-                                <td><a href="/ocfl/@(ViewBag.Path)?version=@version.OcflVersion">@version.MementoDateTime.GetDateDisplay()</a></td>
+                                <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.OcflVersion</a></td>
+                                <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.MementoDateTime.GetDateDisplay()</a></td>
                                 <td>
                                     @if (version.Equals(ag.StorageMap?.Version))
                                     {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
@@ -57,7 +57,7 @@ public class BrowseModel(
         }
         await TrySetWorkingFileAndDirectoryFromMets(pathUnderRoot, version);
         if(
-            view != "mets" && 
+            view != ViewValues.Mets && 
             CachedArchivalGroup != null && 
             WorkingDirectory == null && 
             WorkingFile == null && 
@@ -105,7 +105,7 @@ public class BrowseModel(
         {
             case nameof(ArchivalGroup):
                 
-                if (view == "mets")
+                if (view == ViewValues.Mets)
                 {
                     var metsResult = await preservationApiClient.GetMetsStream(resourcePath, version);
                     if (metsResult is { Item1: not null, Item2: not null })

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
@@ -320,8 +320,6 @@ public class BrowseModel(
                     }
                     CachedArchivalGroup = archivalGroupToBeCached;
                 }
-                // Might as well use the resource we just got rather than do any more with the cached version
-                return preservedResource;
             }
         }
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/DepositNew.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/DepositNew.cshtml.cs
@@ -20,18 +20,23 @@ public class DepositNewModel(IMediator mediator, ILogger<DepositNewModel> logger
         // list deposits
     }
 
-    public async Task<IActionResult> OnPostCreateForArchivalGroup(string archivalGroupPath, bool export, string? submissionText)
+    public async Task<IActionResult> OnPostCreateForArchivalGroup(string archivalGroupPath, bool export, string? submissionText, string? archivalGroupVersion)
     {
         var resourcePath = $"{PreservedResource.BasePathElement}/{archivalGroupPath}";
         var result = await mediator.Send(new GetResource(resourcePath));
         if (result.Success)
         {
+            if (archivalGroupVersion.HasText())
+            {
+                export = true;
+            }
             var model = new NewDepositModel
             {
                 ArchivalGroupPathUnderRoot = archivalGroupPath,
                 ArchivalGroupProposedName = result.Value!.Name!,
                 SubmissionText = submissionText,
                 Export = export,
+                Version = archivalGroupVersion,
                 UseObjectTemplate = true
             };
             return await OnPostCreate(model);
@@ -68,7 +73,7 @@ public class DepositNewModel(IMediator mediator, ILogger<DepositNewModel> logger
                     newDepositModel.SubmissionText,
                     templateType,
                     newDepositModel.Export,
-                    exportVersion: null // always do this from UI; only supports exporting HEAD
+                    exportVersion: newDepositModel.Version 
                 ));
             }
         }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -766,12 +766,18 @@ ViewData["section"] = "deposits";
         const itemSelectors = document.getElementsByClassName("item-selector");
         const deleteSelectionObject = { items: [] };
         let summary = "<table>";
+        let metadataCount = 0;
         for(const itemSelector of itemSelectors)
         {
             if (itemSelector.checked){
                 const row = itemSelector.closest("tr");
                 const type = row.getAttribute("data-type");
                 const relativePath = row.getAttribute("data-path");
+                const isMetadata = row.getAttribute("data-metadata").toLowerCase() === "true";
+                if(isMetadata){
+                    metadataCount++;
+                    continue;
+                }
                 if (relativePath && (type === "directory" || type === "file")){
                     const whereabouts = row.getAttribute("data-whereabouts");
                     const item = {
@@ -791,17 +797,25 @@ ViewData["section"] = "deposits";
             }
         }
         summary += "</table>";
-
-        if (deleteSelectionObject.items.length > 0){
-            deleteItemHelp.innerHTML = summary;
-            deleteFromMetsAndDepositRadio.removeAttribute("disabled");
-            if (archivalGroupExists){
-                deleteFromDepositRadio.removeAttribute("disabled");
-            }
-        } else {
-            deleteItemHelp.innerHTML = "<p>There are no items selected.</p>"
+        
+        if(metadataCount > 0)
+        {
+            deleteItemHelp.innerHTML = `<div class="alert alert-danger" role="alert"><p>${metadataCount} item(s) are in the metadata folder, these cannot be deleted.</p></div>`;
+            document.getElementById("deleteSelectionObject").value = "";            
         }
-        document.getElementById("deleteSelectionObject").value = JSON.stringify(deleteSelectionObject);
+        else
+        {
+            if (deleteSelectionObject.items.length > 0){
+                deleteItemHelp.innerHTML = summary;
+                deleteFromMetsAndDepositRadio.removeAttribute("disabled");
+                if (archivalGroupExists){
+                    deleteFromDepositRadio.removeAttribute("disabled");
+                }
+            } else {
+                deleteItemHelp.innerHTML = "<p>There are no items selected.</p>"
+            }
+            document.getElementById("deleteSelectionObject").value = JSON.stringify(deleteSelectionObject);
+        }
     });
 
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -496,7 +496,7 @@ ViewData["section"] = "deposits";
                         <div class="form-check">
                             <input class="form-check-input" type="radio" name="deleteFrom" value="@Whereabouts.Both" id="deleteFromMetsAndDeposit">
                             <label class="form-check-label" for="deleteFromMetsAndDeposit">
-                                Delete from METS file and Deposit
+                                Delete from Deposit and METS file (if present)
                             </label>
                         </div>
                     </div>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -34,7 +34,7 @@ File is in both
             }
         </td>
         <td class="dep-actions">
-            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && combinedDirectory.LocalPath != FolderNames.Metadata)
+            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !FolderNames.IsMetadata(combinedDirectory.LocalPath))
             {
                 <a class="link-primary" role="button" data-bs-toggle="modal" data-bs-target="#newFolderModal" aria-label="new folder">
                     <svg class="bi"><use xlink:href="#folder-plus"/></svg>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -27,7 +27,7 @@ File is in both
                    <tr class="deposit-row @("where-" + where)" 
         data-path="@combinedDirectory.LocalPath" data-type="directory" data-whereabouts="@combinedDirectory.Whereabouts" data-metadata="@isMetadata">
         <td aria-label="select-row">
-            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !isMetadata)
+            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !FolderNames.PathIsKnownFirstLevelDirectory(combinedDirectory.LocalPath))
             {
                 <input class="form-check-input item-selector item-directory" type="checkbox" 
                        value="@combinedDirectory.LocalPath" id="@("is-" + Model.RowCounter.Count)">
@@ -35,7 +35,7 @@ File is in both
             }
         </td>
         <td class="dep-actions">
-            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !FolderNames.IsMetadata(combinedDirectory.LocalPath))
+            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !isMetadata)
             {
                 <a class="link-primary" role="button" data-bs-toggle="modal" data-bs-target="#newFolderModal" aria-label="new folder">
                     <svg class="bi"><use xlink:href="#folder-plus"/></svg>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -21,12 +21,13 @@ File is in both
 -->
 @if (combinedDirectory.LocalPath.HasText())
 {
+    var isMetadata = FolderNames.IsMetadata(combinedDirectory.LocalPath);
     depth = combinedDirectory.LocalPath.Split('/').Length;
     string where = combinedDirectory.Whereabouts.ToString().ToLowerInvariant();
                    <tr class="deposit-row @("where-" + where)" 
-        data-path="@combinedDirectory.LocalPath" data-type="directory" data-whereabouts="@combinedDirectory.Whereabouts">
+        data-path="@combinedDirectory.LocalPath" data-type="directory" data-whereabouts="@combinedDirectory.Whereabouts" data-metadata="@isMetadata">
         <td aria-label="select-row">
-            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !FolderNames.PathIsKnownFirstLevelDirectory(combinedDirectory.LocalPath))
+            @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && !isMetadata)
             {
                 <input class="form-check-input item-selector item-directory" type="checkbox" 
                        value="@combinedDirectory.LocalPath" id="@("is-" + Model.RowCounter.Count)">
@@ -82,13 +83,15 @@ File is in both
 }
 @foreach (var file in combinedDirectory.Files)
 {
+    
+    var isMetadata = FolderNames.IsMetadata(file.LocalPath!);
     if (file.LocalPath?.GetSlug() == IStorage.DepositFileSystem)
     {
         continue; // this file is hidden
     }
     string where = file.Whereabouts.ToString().ToLowerInvariant();
     <tr class="deposit-row @("where-" + where)" 
-        data-path="@file.LocalPath" data-type="file" data-whereabouts="@file.Whereabouts">
+        data-path="@file.LocalPath" data-type="file" data-whereabouts="@file.Whereabouts" data-metadata="@isMetadata">
         <td aria-label="select-row">
             @if (Model is { Editable: true, Active: true, LockedByOtherUser: false } && file.LocalPath != "mets.xml")
             {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml
@@ -41,7 +41,7 @@ else
     </p>
 
         <h2>Versions</h2>
-        <table class="table table-sm small">
+        <table class="table table-sm small" aria-label="table-versions">
             <thead>
             <tr>
                 <th>OCFL version</th>
@@ -54,10 +54,10 @@ else
             @foreach (var version in Model.StorageMap.AllVersions.OrderByDescending(v => v.MementoDateTime))
             {
                 <tr class="@Model.GetVersionRowClass(version)">
-                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.OcflVersion</a></td>
-                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.MementoTimestamp</a></td>
-                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@StringUtils.GetLocalDate(version.MementoDateTime)</a></td>
-                    <td>
+                    <td aria-label="td-ocfl-version"><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.OcflVersion</a></td>
+                    <td aria-label="td-memento-version"><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.MementoTimestamp</a></td>
+                    <td aria-label="td-version-date"><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@StringUtils.GetLocalDate(version.MementoDateTime)</a></td>
+                    <td aria-label="td-version-info">
                         @if (version.Equals(Model.StorageMap.Version))
                         {
                             <text><strong>Currently viewing</strong></text>
@@ -74,7 +74,7 @@ else
 
         <h4>Version @Model.Version.OcflVersion - @StringUtils.GetFriendlyAge(Model.Version.MementoDateTime)</h4>
         <hr/>
-        <table class="table table-sm small">
+        <table class="table table-sm small" aria-label="table-version-files">
             <thead>
             <tr>
                 <th>File path</th>
@@ -87,10 +87,10 @@ else
             @foreach (var fileEntry in Model.StorageMap.Files.OrderBy(kvp => kvp.Key))
             {
                 <tr>
-                    <td>@fileEntry.Key</td>
-                    <td><span title="@fileEntry.Value.Hash">@fileEntry.Value.Hash.Substring(0, 8)</span></td>
-                    <td>@fileEntry.Value.FullPath.Split('/')[0]</td>
-                    <td>@fileEntry.Value.FullPath</td>
+                    <td aria-label="td-path">@fileEntry.Key</td>
+                    <td aria-label="td-hash"><span title="@fileEntry.Value.Hash">@fileEntry.Value.Hash.Substring(0, 8)</span></td>
+                    <td aria-label="td-version">@fileEntry.Value.FullPath.Split('/')[0]</td>
+                    <td aria-label="td-versioned-path">@fileEntry.Value.FullPath</td>
                 </tr>
             }
             </tbody>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml
@@ -1,0 +1,140 @@
+﻿@page "{*pathUnderRoot}"
+@using DigitalPreservation.Utils
+@model DigitalPreservation.UI.Pages.Ocfl
+
+@{
+    ViewData["section"] = "browse";
+}
+
+@if (TempData["Error"] != null || Model.Version == null || Model.StorageMap == null)
+{
+    <h1 class="h2">Unable to show storage history</h1>
+    <div class="alert alert-danger" role="alert">
+        <p>@Html.Raw(TempData["Error"])</p>
+    </div>
+}
+else
+{
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">📦 Version @Model.Version.OcflVersion of @Model.Title</h1>
+
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <button type="button" class="btn btn-sm btn-outline-primary me-2" data-bs-toggle="modal" data-bs-target="#newDepositModal">
+                <svg class="bi"><use xlink:href="#box-seam"/></svg><span class="ms-2">New Deposit from @Model.Version.OcflVersion</span>
+            </button>
+            <a class="btn btn-sm btn-primary me-2" href="/browse/@Model.PathUnderRoot">
+                📦 Go to Archival Group (@Model.StorageMap.HeadVersion.OcflVersion)
+            </a>
+        </div>
+    </div>
+
+
+    <p>
+        @if (Model.Version.Equals(Model.StorageMap.HeadVersion))
+        {
+            <em>This is the current (head) version.</em>
+        }
+        else
+        {
+            <em>This is a <strong>previous</strong> version.</em>
+        }
+    </p>
+
+        <h2>Versions</h2>
+        <table class="table table-sm small">
+            <thead>
+            <tr>
+                <th>OCFL version</th>
+                <th>Memento</th>
+                <th>Date</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach (var version in Model.StorageMap.AllVersions.OrderByDescending(v => v.MementoDateTime))
+            {
+                <tr class="@Model.GetVersionRowClass(version)">
+                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.OcflVersion</a></td>
+                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@version.MementoTimestamp</a></td>
+                    <td><a href="/ocfl/@(Model.PathUnderRoot)?version=@version.OcflVersion">@StringUtils.GetLocalDate(version.MementoDateTime)</a></td>
+                    <td>
+                        @if (version.Equals(Model.StorageMap.Version))
+                        {
+                            <text><strong>Currently viewing</strong></text>
+                        }
+                        @if (version.Equals(Model.StorageMap.HeadVersion))
+                        {
+                            <text> Latest (head) version</text>
+                        }
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+
+        <h4>Version @Model.Version.OcflVersion - @StringUtils.GetFriendlyAge(Model.Version.MementoDateTime)</h4>
+        <hr/>
+        <table class="table table-sm small">
+            <thead>
+            <tr>
+                <th>File path</th>
+                <th>Hash</th>
+                <th>Version</th>
+                <th>Versioned path</th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach (var fileEntry in Model.StorageMap.Files.OrderBy(kvp => kvp.Key))
+            {
+                <tr>
+                    <td>@fileEntry.Key</td>
+                    <td><span title="@fileEntry.Value.Hash">@fileEntry.Value.Hash.Substring(0, 8)</span></td>
+                    <td>@fileEntry.Value.FullPath.Split('/')[0]</td>
+                    <td>@fileEntry.Value.FullPath</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+
+    <div class="modal fade" id="newDepositModal" tabindex="-1" aria-labelledby="newDepositModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="newDepositModalLabel"><svg class="bi"><use xlink:href="#box-seam"/></svg><span class="ms-2">New Deposit (Export)</span></h1>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <form class="single-submit" method="post" asp-page="DepositNew" asp-page-handler="CreateForArchivalGroup">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <p>
+                                Creating a new Deposit for an existing Archival Group.<br/>
+                                <code>@Model.PathUnderRoot</code><br/>
+                                All content of version @Model.Version.OcflVersion will be exported to the Deposit.
+                                
+                                @if (Model.Version.Equals(Model.StorageMap.HeadVersion))
+                                {    
+                                    <div class="alert alert-info" role="alert">
+                                        <p>You are exporting the latest version of this resource.</p>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="alert alert-warning" role="alert">
+                                        <p>You are <strong>not</strong> exporting the latest version of this resource.</p>
+                                    </div>
+                                }
+                                
+                            </p>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <input type="hidden" name="archivalGroupPath" value="@Model.PathUnderRoot"/>
+                        <input type="hidden" name="archivalGroupVersion" value="@Model.Version.OcflVersion"/>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="submit" class="btn btn-primary"><svg class="bi"><use xlink:href="#box-seam"/></svg><span class="ms-2">Export version to Deposit</span></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+}

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Ocfl.cshtml.cs
@@ -1,0 +1,62 @@
+﻿using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Storage;
+using DigitalPreservation.UI.Features.Preservation.Requests;
+using DigitalPreservation.UI.Features.Repository.Requests;
+using DigitalPreservation.Utils;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DigitalPreservation.UI.Pages;
+
+public class Ocfl(IMediator mediator) : PageModel
+{
+    public async Task OnGet(string pathUnderRoot, [FromQuery] string? version)
+    {
+        PathUnderRoot = pathUnderRoot;
+        var lightweightAgResult = await mediator.Send(new GetLightweightResource(pathUnderRoot, version));
+        if (lightweightAgResult is { Success: true, Value: ArchivalGroup })
+        {
+            ArchivalGroupLightweight = (ArchivalGroup)lightweightAgResult.Value;
+            Title = ArchivalGroupLightweight.Name ?? PathUnderRoot.GetSlug();
+            var storageMapResult = await mediator.Send(new GetStorageMap(pathUnderRoot, version));
+            if (storageMapResult is { Success: true, Value: not null })
+            {
+                StorageMap = storageMapResult.Value;
+                Version = StorageMap.Version;
+                ViewData["Title"] = $"VERSION {Version.OcflVersion} of {Title}";
+            }
+            else
+            {
+                TempData["Error"] = "Could not retrieve Storage Map: " + storageMapResult.CodeAndMessage();
+            }
+        }
+        else
+        {
+            TempData["Error"] = "Could not retrieve 'Lightweight' Archival Group: " + lightweightAgResult.CodeAndMessage();
+        }
+    }
+    
+    public ArchivalGroup? ArchivalGroupLightweight { get; set; }
+
+    public required string PathUnderRoot { get; set; }
+    public ObjectVersion? Version { get; set; }
+
+    public string? Title { get; set; }
+    
+    public StorageMap? StorageMap { get; set; }
+
+    public string GetVersionRowClass(ObjectVersion version)
+    {
+        if (version.Equals(Version))
+        {
+            return "table-info";
+        }
+
+        if (version.Equals(StorageMap!.HeadVersion))
+        {
+            return "table-primary";
+        }
+        return "";
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
@@ -227,4 +227,51 @@ public static class StringUtils
     {
         return GetCommonPrefix(strings.ToArray());
     }
+    
+    public static string GetFriendlyAge(DateTime? dtn)
+    {
+        if (dtn.HasValue)
+        {
+            return GetFriendlyAge(dtn.Value);
+        }
+        return "(no date)";
+    }
+
+    public static string GetLocalDate(DateTime dt)
+    {
+        DateTime localTime = dt.ToLocalTime();
+        return localTime.ToString("yyyy-MM-dd HH:mm:ss");
+    }
+
+    public static string GetLocalDate(DateTime? dt)
+    {
+        if (!dt.HasValue)
+        {
+            return "";
+        }
+
+        return GetLocalDate(dt.Value);
+    }
+
+    public static string GetFriendlyAge(DateTime dt)
+    {
+        DateTime localTime = dt.ToLocalTime();
+        var s = localTime.ToString("yyyy-MM-dd HH:mm:ss") + " (";
+        var dtNow = DateTime.Now;
+        if (localTime.Date == dtNow.Date)
+        {
+            s += "today";
+        }
+        else if (localTime.Date == dtNow.AddDays(-1).Date)
+        {
+            s += "yesterday";
+        }
+        else
+        {
+            var td = (dtNow.Date - localTime).TotalDays;
+            var d = Math.Ceiling(td);
+            s += d + " days ago";
+        }
+        return s + ")";
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
@@ -190,7 +190,7 @@ public class WorkspaceManager(
                 new DeleteItems(IsBagItLayout, deposit.Files!, deleteSelection, combinedResult.Value, deposit.MetsETag!));
             // refresh the file system again
             // need to see how long this operation takes on large deposits
-            await GetFileSystemWorkingDirectory(true);
+            await GetCombinedDirectory(true);
             return deleteResult;
         }
         return Result.FailNotNull<ItemsAffected>(combinedResult.ErrorCode ?? ErrorCodes.UnknownError, combinedResult.ErrorMessage);

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
@@ -278,6 +278,7 @@ public class DepositsController(
     [ProducesResponseType(204)]
     [ProducesResponseType(404)]
     [ProducesResponseType(401)]
+    [ProducesResponseType(409)]
     public async Task<IActionResult> CreateLock([FromRoute] string id, [FromQuery] bool force = false)
     {
         var lockDepositResult = await mediator.Send(new LockDeposit(id, force, User));

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
@@ -94,7 +94,7 @@ public class GetDiffImportJobHandler(
 
         var origin = FolderNames.GetFilesLocation(request.Deposit.Files, workspace.IsBagItLayout);
         var allEncounteredProcessedUris = new List<Uri>();
-        var importContainerResult = combined!.ToContainer(request.Deposit.ArchivalGroup, origin, allEncounteredProcessedUris);
+        var importContainerResult = combined!.ToContainer(request.Deposit.ArchivalGroup, origin, workspace.MetsPath, allEncounteredProcessedUris);
         if (importContainerResult.Failure || importContainerResult.Value is null)
         {
             return Result.FailNotNull<ImportJob>(importContainerResult.ErrorCode ?? ErrorCodes.BadRequest, importContainerResult.ErrorMessage);

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
@@ -46,7 +46,7 @@ public class GetDiffImportJobHandler(
 
         ArchivalGroup? existingArchivalGroup = null;
         var agPathUnderRoot = request.Deposit.ArchivalGroup.GetPathUnderRoot()!;
-        var archivalGroupResult = await storageApi.GetArchivalGroup(request.Deposit.ArchivalGroup.AbsolutePath, null);
+        var archivalGroupResult = await storageApi.GetArchivalGroup(request.Deposit.ArchivalGroup.AbsolutePath);
         if (archivalGroupResult is { Success: true, Value: not null })
         {
             logger.LogInformation("Archival group is valid");

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
@@ -118,10 +118,14 @@ public class GetDiffImportJobHandler(
         {
             agLocalPathWithSlash += "/";
         }
+        
+        var combinedFilesByBinaryId = new Dictionary<Uri, CombinedFile>();
         foreach (var binary in sourceBinaries)
         {
             var relativeLocalPath = binary.Id!.LocalPath.RemoveStart(agLocalPathWithSlash)!.UnEscapePathElementsNoHashes();
             var combinedFile = combined.FindFile(relativeLocalPath)!; // because it came from a URI not a file path
+            combinedFilesByBinaryId[binary.Id] = combinedFile;
+            
             if (combinedFile.FileInMets is null)
             {
                 var message = $"Could not find file {relativeLocalPath} in METS file.";
@@ -150,11 +154,6 @@ public class GetDiffImportJobHandler(
             {
                 throw new Exception("We should have set this by now");
             }
-            // This was old and wrong:
-            // if (combinedFile.FileInMets.ContentType.HasText()) // need to set this
-            // {
-            //     binary.ContentType = combinedFile.FileInMets.ContentType;
-            // }
         }
 
         var missingTheirChecksum = sourceBinaries
@@ -215,6 +214,21 @@ public class GetDiffImportJobHandler(
             // This is a new object
             importJob.ContainersToAdd = sourceContainers;
             importJob.BinariesToAdd = sourceBinaries;
+        }
+        
+        // Now validate that any binary that needs adding or patching is present in the Deposit
+        var binariesToCheck = new List<Binary>();
+        binariesToCheck.AddRange(importJob.BinariesToAdd);
+        binariesToCheck.AddRange(importJob.BinariesToPatch);
+        foreach (var binary in binariesToCheck)
+        {
+            var fileInDeposit = combinedFilesByBinaryId[binary.Id!].FileInDeposit;
+            if (fileInDeposit == null)
+            {
+                var message = $"Binary {binary.Id!.LocalPath} has no file in the Deposit.";
+                logger.LogWarning(message);
+                return Result.FailNotNull<ImportJob>(ErrorCodes.BadRequest, message);
+            }
         }
 
         var validateMetsResult = workspace.ValidateImportJob(importJob, combined, existingArchivalGroup);

--- a/src/DigitalPreservation/Preservation.API/Features/Ocfl/GetStorageMap.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Ocfl/GetStorageMap.cs
@@ -1,0 +1,21 @@
+﻿using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
+using MediatR;
+using Storage.Client;
+
+namespace Preservation.API.Features.Ocfl;
+
+public class GetStorageMap(string archivalGroupPathUnderRoot, string? version) : IRequest<Result<StorageMap>>
+{
+    public string ArchivalGroupPathUnderRoot { get; } = archivalGroupPathUnderRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetStorageMapHandler(IStorageApiClient storageApiClient) : IRequestHandler<GetStorageMap, Result<StorageMap>>
+{
+    public async Task<Result<StorageMap>> Handle(GetStorageMap request, CancellationToken cancellationToken)
+    {
+        var result = await storageApiClient.GetStorageMap(request.ArchivalGroupPathUnderRoot, request.Version);
+        return result;
+    }
+}

--- a/src/DigitalPreservation/Preservation.API/Features/Ocfl/OcflController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Ocfl/OcflController.cs
@@ -1,0 +1,25 @@
+﻿using DigitalPreservation.Common.Model.Storage;
+using DigitalPreservation.Core.Web;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Preservation.API.Features.Ocfl;
+
+[Route("ocfl")]
+[ApiController]
+public class OcflController(IMediator mediator) : Controller
+{
+
+    [HttpGet("storagemap/{*path}", Name = "GetStorageMap")]
+    [Produces<StorageMap>]
+    [Produces("application/json")]
+    public async Task<IActionResult> GetStorageMap(
+        [FromRoute] string path,
+        [FromQuery] string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        var mapResult = await mediator.Send(new GetStorageMap(path, version), cancellationToken);
+        return this.StatusResponseFromResult(mapResult);
+    }
+    
+}

--- a/src/DigitalPreservation/Preservation.API/Features/Repository/RepositoryController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Repository/RepositoryController.cs
@@ -19,7 +19,6 @@ public class RepositoryController(IMediator mediator) : Controller
     [ProducesResponseType<Container>(200, "application/json")]
     [ProducesResponseType<Binary>(200, "application/json")]
     [ProducesResponseType<ArchivalGroup>(200, "application/json")]
-    [Produces("text/xml")]
     [ProducesResponseType(400)]
     [ProducesResponseType(404)]
     [ProducesResponseType(401)]

--- a/src/DigitalPreservation/Preservation.API/Features/Repository/RepositoryController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Repository/RepositoryController.cs
@@ -19,6 +19,8 @@ public class RepositoryController(IMediator mediator) : Controller
     [ProducesResponseType<Container>(200, "application/json")]
     [ProducesResponseType<Binary>(200, "application/json")]
     [ProducesResponseType<ArchivalGroup>(200, "application/json")]
+    [Produces("text/xml")]
+    [ProducesResponseType(400)]
     [ProducesResponseType(404)]
     [ProducesResponseType(401)]
     [ProducesResponseType(410)]
@@ -29,7 +31,7 @@ public class RepositoryController(IMediator mediator) : Controller
     {
         if (version.HasText())
         {
-            if (view != "lightweight")
+            if (view != ViewValues.Lightweight)
             {
                 var problem = new ProblemDetails
                 {
@@ -39,12 +41,14 @@ public class RepositoryController(IMediator mediator) : Controller
                 };
                 return BadRequest(problem);
             }
-
+        }
+        if (view == ViewValues.Lightweight)
+        {
             var lwResult = await mediator.Send(new GetLightweightResource(path!, version));
             return this.StatusResponseFromResult(lwResult);
         }
         var result = await mediator.Send(new GetResource(Request.Path));
-        if (view == "mets" && result is { Success: true, Value: ArchivalGroup archivalGroup })
+        if (view == ViewValues.Mets && result is { Success: true, Value: ArchivalGroup archivalGroup })
         {
             var mets = archivalGroup.Binaries.SingleOrDefault(b => MetsUtils.IsMetsFile(b.Id!.GetSlug()!, true));
             if (mets is null)

--- a/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetBinaryStream.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetBinaryStream.cs
@@ -4,16 +4,15 @@ using Storage.Client;
 
 namespace Preservation.API.Features.Repository.Requests;
 
-public class GetBinaryStream(string path, string? version = null) : IRequest<Result<Stream>>
+public class GetBinaryStream(string path) : IRequest<Result<Stream>>
 {
     public string Path { get; } = path;
-    public string? Version { get; } = version;
 }
 
 public class GetBinaryStreamHandler(IStorageApiClient storageApiClient) : IRequestHandler<GetBinaryStream, Result<Stream>>
 {
     public async Task<Result<Stream>> Handle(GetBinaryStream request, CancellationToken cancellationToken)
     {
-        return await storageApiClient.GetBinaryStream(request.Path, request.Version);
+        return await storageApiClient.GetBinaryStream(request.Path);
     }
 }

--- a/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetLightweightResource.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetLightweightResource.cs
@@ -1,0 +1,21 @@
+﻿using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Results;
+using MediatR;
+using Storage.Client;
+
+namespace Preservation.API.Features.Repository.Requests;
+
+public class GetLightweightResource(string pathUnderRoot, string? version) : IRequest<Result<PreservedResource?>>
+{
+    public string PathUnderRoot { get; } = pathUnderRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetLightweightResourceHandler(IStorageApiClient storageApiClient) : IRequestHandler<GetLightweightResource, Result<PreservedResource?>>
+{
+    public async Task<Result<PreservedResource?>> Handle(GetLightweightResource request, CancellationToken cancellationToken)
+    {
+        var result = await storageApiClient.GetLightweightResource(request.PathUnderRoot, request.Version);
+        return result;
+    }
+}

--- a/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetResource.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Repository/Requests/GetResource.cs
@@ -1,5 +1,4 @@
-﻿using System.Xml.XPath;
-using DigitalPreservation.Common.Model;
+﻿using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
 using MediatR;
 using Preservation.API.Mutation;

--- a/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
@@ -3,6 +3,7 @@ using DigitalPreservation.Common.Model.ChangeDiscovery;
 using DigitalPreservation.Common.Model.Import;
 using DigitalPreservation.Common.Model.PreservationApi;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
 using Storage.Repository.Common;
 
 namespace Preservation.Client;
@@ -22,6 +23,10 @@ public interface IPreservationApiClient
     /// <param name="path">The full path including the /repository/ initial path element</param>
     /// <returns></returns>
     Task<Result<string?>> GetResourceType(string path);
+    
+    Task<Result<StorageMap>> GetStorageMap(string path, string? version);
+    
+    Task<Result<PreservedResource?>> GetLightweightResource(string requestPathUnderRoot, string? requestVersion);
     
     Task<Result<Container?>> CreateContainer(string path, string? name = null);
     Task<Result<Deposit?>> CreateDeposit(

--- a/src/DigitalPreservation/Registrant/Program.cs
+++ b/src/DigitalPreservation/Registrant/Program.cs
@@ -55,7 +55,7 @@ class Program
         var storageApi = new StorageApiClient(
             GetHttpClient("https://storage-dev.dlip.digirati.io"),
             GetLogger<StorageApiClient>());
-        var archivalGroupResult = await storageApi.GetArchivalGroup(archivalGroupPath, null);
+        var archivalGroupResult = await storageApi.GetArchivalGroup(archivalGroupPath);
         if (archivalGroupResult.Failure || archivalGroupResult.Value == null)
         {
             Console.WriteLine("Archive group " + archivalGroupPath + " could not be found.");

--- a/src/DigitalPreservation/Storage.API/Features/Export/Requests/ExecuteExport.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Export/Requests/ExecuteExport.cs
@@ -30,7 +30,7 @@ public class ExecuteExportHandler(
     {
         var export = request.Export;
         
-        logger.LogInformation("Exporting Archival Group {archivalGroup}", export.ArchivalGroup);;
+        logger.LogInformation("Exporting Archival Group {archivalGroup}", export.ArchivalGroup);
         var destination = new AmazonS3Uri(export.Destination);
         var destinationBucket = destination.Bucket;
         var destinationKey = destination.Key;

--- a/src/DigitalPreservation/Storage.API/Features/Export/Requests/ExecuteExport.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Export/Requests/ExecuteExport.cs
@@ -87,11 +87,6 @@ public class ExecuteExportHandler(
                     });
                 }
             }
-
-            // Remove this, so that a new export DOES NOT have a __metslike.json - which is a Preservation API concern.
-            // The Preservation API can attempt to create one if this file is absent.
-            // var newWd = await storage.GenerateDepositFileSystem(destination, true, cancellationToken);
-            // TODO: validate that newWd.Value matches what we expected from storageMap.Files
             export.DateFinished = DateTime.UtcNow;
         }
         catch (Exception ex)

--- a/src/DigitalPreservation/Storage.API/Features/Ocfl/GetStorageMap.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Ocfl/GetStorageMap.cs
@@ -1,0 +1,41 @@
+﻿using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
+using MediatR;
+using Storage.API.Fedora;
+using Storage.API.Fedora.Model;
+
+namespace Storage.API.Features.Ocfl;
+
+public class GetStorageMap(string archivalGroupPathUnderRoot, string? version) : IRequest<Result<StorageMap>>
+{
+    public string ArchivalGroupPathUnderRoot { get; } = archivalGroupPathUnderRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetStorageMapHandler(
+    ILogger<GetStorageMapHandler> logger,
+    Converters converters,
+    IStorageMapper storageMapper) : IRequestHandler<GetStorageMap, Result<StorageMap>>
+{
+    public async Task<Result<StorageMap>> Handle(GetStorageMap request, CancellationToken cancellationToken)
+    {
+        var uri = converters.RepositoryUriFromPathUnderRoot(request.ArchivalGroupPathUnderRoot);
+        try
+        {
+            var map = await storageMapper.GetStorageMap(uri, request.Version);
+            if (request.Version != null && map.Version.OcflVersion != request.Version)
+            {
+                return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, 
+                    "Returned storage map is version " + map.Version.OcflVersion + " but " + request.Version + " was requested.");
+            }
+            return Result.OkNotNull(map);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to get storage map");
+            return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, 
+                "Could not get storage map: " + e.Message);
+        }
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Features/Ocfl/OcflController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Ocfl/OcflController.cs
@@ -1,0 +1,25 @@
+﻿using DigitalPreservation.Common.Model.Storage;
+using DigitalPreservation.Core.Web;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Storage.API.Features.Ocfl;
+
+[Route("ocfl")]
+[ApiController]
+public class OcflController(IMediator mediator) : Controller
+{
+
+    [HttpGet("storagemap/{*path}", Name = "GetStorageMap")]
+    [Produces<StorageMap>]
+    [Produces("application/json")]
+    public async Task<IActionResult> GetStorageMap(
+        [FromRoute] string path,
+        [FromQuery] string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        var mapResult = await mediator.Send(new GetStorageMap(path, version), cancellationToken);
+        return this.StatusResponseFromResult(mapResult);
+    }
+    
+}

--- a/src/DigitalPreservation/Storage.API/Features/Repository/RepositoryController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Repository/RepositoryController.cs
@@ -1,4 +1,5 @@
-﻿using DigitalPreservation.Common.Model;
+﻿using System.Net;
+using DigitalPreservation.Common.Model;
 using DigitalPreservation.Core.Auth;
 using DigitalPreservation.Core.Web;
 using DigitalPreservation.Core.Web.Headers;
@@ -19,10 +20,38 @@ public class RepositoryController(IMediator mediator) : Controller
     [ProducesResponseType<ArchivalGroup>(200, "application/json")]
     [ProducesResponseType(404)]
     [ProducesResponseType(401)]
-    public async Task<IActionResult> Browse([FromRoute] string? path)
+    public async Task<IActionResult> Browse(
+        [FromRoute] string? path,
+        [FromQuery] string? view = null,
+        [FromQuery] string? version = null)
     {
+        if (view == null && version == null)
+        {
+            // Almost all requests on repository paths will take this form
+            var result = await mediator.Send(new GetResourceFromFedora(path));
+            return this.StatusResponseFromResult(result);
+        }
+        // We want a specific version, and/or just the lightweight view
+        return await ViewLightweightResource(path, view, version);
+    }
+    
+    private async Task<IActionResult> ViewLightweightResource(
+        string? path,
+        string? view = null,
+        string? version = null)
+    {
+        if (view != "lightweight")
+        {
+            var problem = new ProblemDetails
+            {
+                Status = (int)HttpStatusCode.BadRequest,
+                Title = "Unsupported view",
+                Detail = "View " + view + " is not a valid value."
+            };
+            return BadRequest(problem);
+        }
        
-        var result = await mediator.Send(new GetResourceFromFedora(path));
+        var result = await mediator.Send(new GetResourceFromFedoraLightweight(path, version));
         return this.StatusResponseFromResult(result);
     }
     

--- a/src/DigitalPreservation/Storage.API/Features/Repository/RepositoryController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Repository/RepositoryController.cs
@@ -40,7 +40,7 @@ public class RepositoryController(IMediator mediator) : Controller
         string? view = null,
         string? version = null)
     {
-        if (view != "lightweight")
+        if (view != ViewValues.Lightweight)
         {
             var problem = new ProblemDetails
             {

--- a/src/DigitalPreservation/Storage.API/Features/Repository/Requests/GetResourceFromFedora.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Repository/Requests/GetResourceFromFedora.cs
@@ -1,13 +1,14 @@
 ﻿using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Utils;
 using MediatR;
+using Microsoft.Extensions.Caching.Memory;
 using Storage.API.Fedora;
-using Storage.API.Fedora.Model;
 
 namespace Storage.API.Features.Repository.Requests;
 
 /// <summary>
-/// 
+/// Returns the latest current version of the resource
 /// </summary>
 /// <param name="pathUnderFedoraRoot">The Fedora sub path, not including any fedora or storage URI prefix</param>
 public class GetResourceFromFedora(string? pathUnderFedoraRoot) : IRequest<Result<PreservedResource?>>
@@ -15,10 +16,102 @@ public class GetResourceFromFedora(string? pathUnderFedoraRoot) : IRequest<Resul
     public string? PathUnderFedoraRoot { get; } = pathUnderFedoraRoot;
 }
 
-public class GetResourceFromFedoraHandler(IFedoraClient fedoraClient) : IRequestHandler<GetResourceFromFedora, Result<PreservedResource?>>
+public class GetResourceFromFedoraHandler(
+    ILogger<GetResourceFromFedoraHandler> logger,
+    IMemoryCache memoryCache,
+    IFedoraClient fedoraClient) : IRequestHandler<GetResourceFromFedora, Result<PreservedResource?>>
 {
     public async Task<Result<PreservedResource?>> Handle(GetResourceFromFedora request, CancellationToken cancellationToken)
     {
-        return await fedoraClient.GetResource(request.PathUnderFedoraRoot, cancellationToken: cancellationToken);
+        // Only cache Archival Groups, and only then by version. Cache key must always include the version.
+        // But we don't want to be checking everything to see if it's an AG (FedoraClient gets type later)
+        // So we can also store a cached string of what version is cached, at the path.
+        // We may not have been given a version in which case it's the latest one we want.
+        // But we must never return a superseded version as the latest.
+        
+        // Is it in the cache?
+        // If so, it must be an AG. What is its version in the cache?
+        // This code is quite complex because we don't want to be getting versions, etc., for every resource,
+        // ONLY when it's an Archival Group. But we don't know whether it's an Archival Group up front.
+
+        // Do we have a token indicating that we have a version cached for the raw path?
+        var possibleAgVersion = memoryCache.Get<string>(CacheKey(request.PathUnderFedoraRoot, null));
+        if (possibleAgVersion.HasText())
+        {
+            logger.LogInformation("There is a cached token for {pathUnderFedoraRoot}: {version}",
+                request.PathUnderFedoraRoot, possibleAgVersion);
+            var possibleAg = memoryCache.Get<ArchivalGroup>(CacheKey(request.PathUnderFedoraRoot, possibleAgVersion));
+            if (possibleAg != null)
+            {
+                logger.LogInformation("Retrieved cached Archival Group {pathUnderFedoraRoot} for cached version string {version}",
+                    request.PathUnderFedoraRoot, possibleAgVersion);
+                // It is HIGHLY LIKELY that this is the current version. But we can't guarantee it.
+                // But we know it must be an archival group (we wouldn't have cached it otherwise).
+                logger.LogInformation("Checking if this is indeed the HEAD version:");
+                var versionResult = await fedoraClient.GetArchivalGroupVersion(request.PathUnderFedoraRoot);
+                if (versionResult is { Success: true, Value: not null } &&
+                    versionResult.Value.OcflVersion == possibleAgVersion)
+                {
+                    logger.LogInformation("HEAD version of {pathUnderFedoraRoot} is {version}",
+                        request.PathUnderFedoraRoot, versionResult.Value.OcflVersion);
+                    return Result.Ok<PreservedResource?>(possibleAg);
+                }
+                logger.LogWarning("Latest cached HEAD version value is {cachedVersion} but actual version is {actualVersion}",
+                    possibleAgVersion, versionResult.Value?.OcflVersion);
+            }
+            logger.LogWarning("No Archival Group in cache for cached version string {pathUnderFedoraRoot} at path {version}",
+                request.PathUnderFedoraRoot, possibleAgVersion);
+        }
+        
+        // OK, so now we have to get the resource
+        var result = await fedoraClient.GetResource(request.PathUnderFedoraRoot, cancellationToken: cancellationToken);
+
+        if (result is { Success: true, Value.Type: nameof(ArchivalGroup) })
+        {
+            // We can cache this because it is an archival group. But it might not be the HEAD version
+            var ag = result.Value as ArchivalGroup;
+            var version = ag?.Version?.OcflVersion;
+            if (ag != null && version.HasText())
+            {
+                var expiry = TimeSpan.FromHours(1);
+                var versionedCacheKey = CacheKey(request.PathUnderFedoraRoot, version);
+                // We can still cache this specific version, though, at its version key
+                logger.LogInformation("Setting versioned cache entry for {pathUnderFedoraRoot}, version {version}",
+                    request.PathUnderFedoraRoot, version);
+                memoryCache.Set(versionedCacheKey, ag, expiry);
+                // But we only set the path-only cached token if we just retrieved the LATEST, HEAD version
+                if (ag.StorageMap?.HeadVersion.OcflVersion == version)
+                {
+                    logger.LogInformation("Version {version} is the HEAD for {pathUnderFedoraRoot}, so will cache the path-only token",
+                        version, request.PathUnderFedoraRoot);
+                    var pathCacheKey = CacheKey(request.PathUnderFedoraRoot, null);
+                    memoryCache.Set(pathCacheKey, version, expiry);
+                }
+                else
+                {
+                    logger.LogInformation("The HEAD version for {pathUnderFedoraRoot} is {headVersion}, so will NOT CACHE the path-only token",
+                        request.PathUnderFedoraRoot, ag.StorageMap?.HeadVersion.OcflVersion);
+                }
+            }
+            else
+            {
+                // This should never happen?
+                logger.LogWarning(
+                    "The resource at {PathUnderFedoraRoot} is an Archival Group but does not have a version",
+                    request.PathUnderFedoraRoot);
+            }
+        }
+        return result;
+    }
+
+    private string CacheKey(string? path, string? version)
+    {
+        // This must avoid any possible (though very unlikely) collisions with other actual paths
+        if (version != null)
+        {
+            return $"AG_///_{path ?? ""}_///_{version}";
+        }
+
+        return $"AG_///_{path ?? ""}";
     }
 }

--- a/src/DigitalPreservation/Storage.API/Features/Repository/Requests/GetResourceFromFedoraLightweight.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Repository/Requests/GetResourceFromFedoraLightweight.cs
@@ -1,0 +1,22 @@
+﻿using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Results;
+using MediatR;
+using Storage.API.Fedora;
+
+namespace Storage.API.Features.Repository.Requests;
+
+public class GetResourceFromFedoraLightweight(string? pathUnderFedoraRoot, string? version) : IRequest<Result<PreservedResource?>>
+{
+    public string? PathUnderFedoraRoot { get; } = pathUnderFedoraRoot;
+    public string? Version { get; } = version;
+}
+
+public class GetResourceFromFedoraLightweightHandler(
+    IFedoraClient fedoraClient) : IRequestHandler<GetResourceFromFedoraLightweight, Result<PreservedResource?>>
+{
+    public async Task<Result<PreservedResource?>> Handle(GetResourceFromFedoraLightweight request, CancellationToken cancellationToken)
+    {
+        var result = await fedoraClient.GetResourceLightweight(request.PathUnderFedoraRoot, request.Version);
+        return result;
+    }
+}

--- a/src/DigitalPreservation/Storage.API/Fedora/Http/RequestX.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/Http/RequestX.cs
@@ -217,6 +217,17 @@ public static class RequestX
     }
     
     
+    public static Uri AtVersion(this Uri resourceUri, string? mementoVersion)
+    {
+        if (mementoVersion.HasText())
+        {
+            return new Uri($"{resourceUri}/fcr:versions/{mementoVersion}");
+        }
+
+        return resourceUri;
+    }
+    
+    
     /// <summary>
     /// Same comments as above
     /// </summary>

--- a/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/IFedoraClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
 using Storage.API.Fedora.Model;
 using Storage.Repository.Common;
 
@@ -29,25 +30,20 @@ public interface IFedoraClient
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<Result<PreservedResource?>> GetResource(string? pathUnderFedoraRoot, Transaction? transaction = null, CancellationToken cancellationToken = default);
-
     Task<Result<string?>> GetResourceType(string? pathUnderFedoraRoot, Transaction? transaction = null);
-    // Task<Result<Container?>> ContainerCanBeCreatedAtPath(string pathUnderFedoraRoot, Transaction? transaction = null);
+    Task<Result<ObjectVersion>> GetArchivalGroupVersion(string? pathUnderFedoraRoot, Transaction? transaction = null);
+    
+    // This is the only operation that takes a version
+    Task<Result<PreservedResource?>> GetResourceLightweight(string? pathUnderFedoraRoot, string? version, Transaction? transaction = null);
+    
     Task<Result<Container?>> CreateContainer(string pathUnderFedoraRoot, string callerIdentity, string? name, Transaction? transaction = null, CancellationToken cancellationToken = default);
     Task<Result<Container?>> CreateContainerWithinArchivalGroup(string pathUnderFedoraRoot, string callerIdentity, string? name, Transaction? transaction = null, CancellationToken cancellationToken = default);
     Task<Result<ArchivalGroup?>> CreateArchivalGroup(string pathUnderFedoraRoot, string callerIdentity, string name, Transaction transaction, CancellationToken cancellationToken = default);
-
     Task<Result<Binary?>> PutBinary(Binary binary, string callerIdentity, Transaction transaction, CancellationToken cancellationToken = default);
-    
-    Task<Result<ArchivalGroup?>> GetPopulatedArchivalGroup(string pathUnderFedoraRoot, string? version = null, Transaction? transaction = null);
-
     Task<Result<ArchivalGroup?>> GetValidatedArchivalGroupForImportJob(string pathUnderFedoraRoot, Transaction? transaction = null);
-    
-    Task<Result<PreservedResource>> Delete(PreservedResource resource, string callerIdentity, Transaction transaction, CancellationToken cancellationToken = default);
-    
-    Task<Result> DeleteContainerOutsideOfArchivalGroup(string pathUnderFedoraRoot, string callerIdentity, bool purge, CancellationToken cancellationToken);
-    
-    Task<Result> UpdateContainerMetadata(string pathUnderFedoraRoot, string? name, string callerIdentity, Transaction transaction, CancellationToken cancellationToken = default);
-
+   Task<Result<PreservedResource>> Delete(PreservedResource resource, string callerIdentity, Transaction transaction, CancellationToken cancellationToken = default);
+   Task<Result> DeleteContainerOutsideOfArchivalGroup(string pathUnderFedoraRoot, string callerIdentity, bool purge, CancellationToken cancellationToken);
+   Task<Result> UpdateContainerMetadata(string pathUnderFedoraRoot, string? name, string callerIdentity, Transaction transaction, CancellationToken cancellationToken = default);
     
     // Transactions
     Task<Transaction> BeginTransaction();

--- a/src/DigitalPreservation/Storage.Client/IStorageApiClient.cs
+++ b/src/DigitalPreservation/Storage.Client/IStorageApiClient.cs
@@ -3,6 +3,7 @@ using DigitalPreservation.Common.Model.ChangeDiscovery;
 using DigitalPreservation.Common.Model.Export;
 using DigitalPreservation.Common.Model.Import;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
 using Storage.Repository.Common;
 
 namespace Storage.Client;
@@ -26,9 +27,11 @@ public interface IStorageApiClient
     /// 
     /// </summary>
     /// <param name="path">The full path including the /repository/ initial path element</param>
-    /// <param name="version">v1, v2 etc (optional - latest will be returned by default)</param>
     /// <returns></returns>
-    Task<Result<ArchivalGroup?>> GetArchivalGroup(string path, string? version);
+    Task<Result<ArchivalGroup?>> GetArchivalGroup(string path);
+    
+    Task<Result<StorageMap>> GetStorageMap(string archivalGroupPathUnderRoot, string? version = null);
+    Task<Result<string?>> GetArchivalGroupName(string archivalGroupPathUnderRoot, string? version = null);
     
     Task<Result<Container?>> CreateContainer(string path, string? name = null);
     
@@ -56,9 +59,8 @@ public interface IStorageApiClient
     /// 
     /// </summary>
     /// <param name="path">The full path including the /repository/ initial path element</param>
-    /// <param name="version">v1, v2 etc (optional - latest will be returned by default)</param>
     /// <returns></returns>
-    Task<Result<Stream>> GetBinaryStream(string path, string? version);
+    Task<Result<Stream>> GetBinaryStream(string path);
 
     Task<Result<ArchivalGroup?>> TestArchivalGroupPath(string archivalGroupPathUnderRoot);
     

--- a/src/DigitalPreservation/Storage.Client/IStorageApiClient.cs
+++ b/src/DigitalPreservation/Storage.Client/IStorageApiClient.cs
@@ -17,6 +17,8 @@ public interface IStorageApiClient
     /// <returns></returns>
     Task<Result<PreservedResource?>> GetResource(string path);
     
+    Task<Result<PreservedResource?>> GetLightweightResource(string requestPathUnderRoot, string? requestVersion);
+    
     /// <summary>
     /// A low-cost way to determine the type of a resource, or whether a resource exists at the path.
     /// </summary>

--- a/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
+++ b/src/DigitalPreservation/Storage.Client/StorageApiClient.cs
@@ -6,8 +6,10 @@ using DigitalPreservation.Common.Model.Export;
 using DigitalPreservation.Common.Model.Import;
 using DigitalPreservation.Common.Model.LogHelpers;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Storage;
 using DigitalPreservation.CommonApiClient;
 using DigitalPreservation.Core.Web;
+using DigitalPreservation.Utils;
 using Microsoft.Extensions.Logging;
 using Storage.Repository.Common;
 
@@ -26,11 +28,11 @@ public class StorageApiClient(
 {
     private readonly HttpClient storageHttpClient = httpClient;
 
-    public async Task<Result<Stream>> GetBinaryStream(string path, string? version)
+    public async Task<Result<Stream>> GetBinaryStream(string path)
     {
-        if (path.StartsWith("/repository/"))
+        if (path.StartsWith($"/{PreservedResource.BasePathElement}/"))
         {
-            var contentPath = path.Replace("/repository/", "/content/");
+            var contentPath = path.Replace($"/{PreservedResource.BasePathElement}/", "/content/");
             try
             {
                 var req = new HttpRequestMessage(HttpMethod.Get, new Uri(contentPath, UriKind.Relative));
@@ -131,6 +133,63 @@ public class StorageApiClient(
         {
             logger.LogError(e, e.Message);
             return Result.FailNotNull<ImportJobResult>(ErrorCodes.UnknownError, e.Message);
+        }
+    }
+
+    public async Task<Result<string?>> GetArchivalGroupName(string archivalGroupPathUnderRoot, string? version = null)
+    {
+        // version may have to be a memento timestamp rather than an OCFL version
+        var reqPath = $"{PreservedResource.BasePathElement}/{archivalGroupPathUnderRoot}?view=lightweight";
+        if (version.HasText())
+        {
+            reqPath = $"{reqPath}&version={version}";
+        }
+        try
+        {
+            var uri = new Uri(reqPath, UriKind.Relative);
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = await httpClient.SendAsync(req);
+            var container = await response.Content.ReadFromJsonAsync<Container>();
+            if(container != null)
+            {
+                logger.LogInformation("Received container to read name of ArchivalGroup {archivalGroupPathUnderRoot}, version {version}",
+                    archivalGroupPathUnderRoot, version);
+                return Result.Ok(container.Name);
+            }
+            return Result.Fail<string>(ErrorCodes.UnknownError, "Resource could not be parsed.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, e.Message);
+            return Result.Fail<string>(ErrorCodes.UnknownError, e.Message);
+        }
+    }
+
+    public async Task<Result<StorageMap>> GetStorageMap(string archivalGroupPathUnderRoot, string? version = null)
+    {
+        var reqPath = $"ocfl/storagemap/{archivalGroupPathUnderRoot}";
+        if (version.HasText())
+        {
+            reqPath = $"{reqPath}?version={version}";
+        }
+        try
+        {
+            var uri = new Uri(reqPath, UriKind.Relative);
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = await httpClient.SendAsync(req);
+            var storageMap = await response.Content.ReadFromJsonAsync<StorageMap>();
+            if(storageMap != null)
+            {
+                logger.LogInformation("Received storageMap for ArchivalGroup {archivalGroupPathUnderRoot}, version {version}",
+                    archivalGroupPathUnderRoot, version);
+                return Result.OkNotNull(storageMap);
+            }
+            return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, "Resource could not be parsed.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, e.Message);
+            return Result.FailNotNull<StorageMap>(ErrorCodes.UnknownError, e.Message);
         }
     }
 

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -13,7 +13,6 @@ using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Extensions;
 using DigitalPreservation.XmlGen.Mets;
-using DigitalPreservation.XmlGen.Mods.V3;
 using DigitalPreservation.XmlGen.Premis.V3;
 using Checksum = DigitalPreservation.Utils.Checksum;
 using File = System.IO.File;
@@ -109,7 +108,7 @@ public class MetsManager(
         foreach (var binary in container.Binaries)
         {
             var localPath = binary.Id!.LocalPath.RemoveStart(agLocalPath).RemoveStart("/");
-            if (IsMetsFile(localPath!))
+            if (MetsUtils.IsMetsFile(localPath!, true))
             {
                 continue;
             }
@@ -637,13 +636,6 @@ public class MetsManager(
             StorageLocation = null // storageLocation
         };
     }
-
-
-    public bool IsMetsFile(string fileName)
-    {
-        return MetsUtils.IsMetsFile(fileName);
-    }
-
 
     private DigitalPreservation.XmlGen.Mets.Mets GetEmptyMets()
     {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -51,7 +51,7 @@ public class MetsManager(
     {
         var (file, mets) = await GetStandardMets(metsLocation, agNameFromDeposit);
         
-        AddResourceToMets(mets, archivalGroup, mets.StructMap[0].Div, archivalGroup);
+        AddResourceToMets(mets, archivalGroup.Id!, mets.StructMap[0].Div, archivalGroup);
         
         var writeResult = await WriteMets(new FullMets{ Mets = mets, Uri = file });
         if (writeResult.Success)
@@ -67,12 +67,12 @@ public class MetsManager(
     /// This will likely never be used in production
     /// </summary>
     /// <param name="mets"></param>
-    /// <param name="archivalGroup"></param>
+    /// <param name="archivalGroupUri"></param>
     /// <param name="div"></param>
     /// <param name="container"></param>
-    private void AddResourceToMets(DigitalPreservation.XmlGen.Mets.Mets mets, ArchivalGroup archivalGroup, DivType div, Container container)
+    private void AddResourceToMets(DigitalPreservation.XmlGen.Mets.Mets mets, Uri archivalGroupUri, DivType div, Container container)
     {
-        var agLocalPath = archivalGroup.Id!.LocalPath;
+        var agLocalPath = archivalGroupUri.LocalPath;
         foreach (var childContainer in container.Containers)
         {
             DivType? childDirectoryDiv = null;
@@ -103,7 +103,7 @@ public class MetsManager(
                 };
                 mets.AmdSec.Add(GetAmdSecType(reducedPremisForObjectDir, admId, techId));
             }
-            AddResourceToMets(mets, archivalGroup, childDirectoryDiv, childContainer);
+            AddResourceToMets(mets, archivalGroupUri, childDirectoryDiv, childContainer);
         }
 
         foreach (var binary in container.Binaries)

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -464,7 +464,15 @@ public class MetsManager(
 
                     var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == file.Admid[0]);
                     var premisXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault();
-                    var patchPremis = GetFileFormatMetadata(workingFile, operationPath);  
+                    FileFormatMetadata patchPremis;
+                    try
+                    {
+                        patchPremis = GetFileFormatMetadata(workingFile, operationPath);
+                    }
+                    catch (MetadataException mex)
+                    {
+                        return Result.Fail(ErrorCodes.BadRequest, mex.Message);
+                    }
                     PremisComplexType? premisType;
                     if (premisXml is not null)
                     {
@@ -530,7 +538,15 @@ public class MetsManager(
                     Fptr = { new DivTypeFptr{ Fileid = fileId } }
                 };
                 div.Div.Add(childItemDiv);
-                var premisFile = GetFileFormatMetadata(workingFile, operationPath);
+                FileFormatMetadata premisFile;
+                try
+                {
+                    premisFile = GetFileFormatMetadata(workingFile, operationPath);
+                }
+                catch (MetadataException mex)
+                {
+                    return Result.Fail(ErrorCodes.BadRequest, mex.Message);
+                }
                 fullMets.Mets.FileSec.FileGrp[0].File.Add(
                     new FileType
                     {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -101,7 +101,7 @@ public class MetsParser(
                 var resp = await s3Client.ListObjectsV2Async(listObjectsReq);
                 var files = resp.S3Objects.Where(s => !s.Key.EndsWith('/')).ToList();
                 var firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), true));
-                if (firstXmlKey != null)
+                if (firstXmlKey == null)
                 {
                     firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), false));
                 }
@@ -117,9 +117,9 @@ public class MetsParser(
                     resp = await s3Client.ListObjectsV2Async(listObjectsReq);
                     files = resp.S3Objects.Where(s => !s.Key.EndsWith('/')).ToList();
                     firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), true));
-                    if (firstXmlKey != null)
+                    if (firstXmlKey == null)
                     {
-                        firstXmlKey =files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), false));
+                        firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), false));
                     }
                 }
 

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -60,11 +60,11 @@ public class MetsParser(
             
                 // Need to find the METS. Look for "mets.xml" by preference
                 var firstXmlFile = dir.EnumerateFiles().FirstOrDefault(
-                    f => MetsUtils.IsMetsFile(f.Name, true));
+                    f => MetsUtils.IsMetsFile(f.Name.GetSlug(), true));
                 if (firstXmlFile == null)
                 {
                     firstXmlFile = dir.EnumerateFiles().FirstOrDefault(
-                    f => MetsUtils.IsMetsFile(f.Name, false));
+                        f => MetsUtils.IsMetsFile(f.Name.GetSlug(), false));
                 }
 
                 if (firstXmlFile == null)
@@ -73,11 +73,11 @@ public class MetsParser(
                     if (childDirs is [{ Name: FolderNames.BagItData }]) // one and one only child directory, called data
                     {                
                         firstXmlFile = childDirs[0].EnumerateFiles().FirstOrDefault(
-                            f => MetsUtils.IsMetsFile(f.Name, true));
+                            f => MetsUtils.IsMetsFile(f.Name.GetSlug(), true));
                         if (firstXmlFile == null)
                         {
                             firstXmlFile = childDirs[0].EnumerateFiles().FirstOrDefault(
-                                f => MetsUtils.IsMetsFile(f.Name, false));
+                                f => MetsUtils.IsMetsFile(f.Name.GetSlug(), false));
                         }
                     }
                 }
@@ -99,10 +99,11 @@ public class MetsParser(
                     Delimiter = "/" // first "children" only ... does that return "data/" no?                       
                 };
                 var resp = await s3Client.ListObjectsV2Async(listObjectsReq);
-                var firstXmlKey = resp.S3Objects.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key, true));
+                var files = resp.S3Objects.Where(s => !s.Key.EndsWith('/')).ToList();
+                var firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), true));
                 if (firstXmlKey != null)
                 {
-                    firstXmlKey = resp.S3Objects.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key, false));
+                    firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), false));
                 }
                 
                 if (firstXmlKey == null)
@@ -114,10 +115,11 @@ public class MetsParser(
                         Delimiter = "/"                       
                     };
                     resp = await s3Client.ListObjectsV2Async(listObjectsReq);
-                    firstXmlKey = resp.S3Objects.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key, true));
+                    files = resp.S3Objects.Where(s => !s.Key.EndsWith('/')).ToList();
+                    firstXmlKey = files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), true));
                     if (firstXmlKey != null)
                     {
-                        firstXmlKey = resp.S3Objects.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key, false));
+                        firstXmlKey =files.FirstOrDefault(s => MetsUtils.IsMetsFile(s.Key.GetSlug(), false));
                     }
                 }
 

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsUtils.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsUtils.cs
@@ -7,7 +7,7 @@ public static class MetsUtils
         var name = fileName.ToLowerInvariant();
         if (mustBeStandardName)
         {
-            return name.EndsWith("mets.xml");
+            return name == "mets.xml";
         }
         return name.EndsWith(".xml") && name.Contains("mets");
     }

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -205,7 +205,7 @@ public class Storage(
         }
         catch (AmazonS3Exception s3E)
         {
-            var exResult = ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Could not add directory to METS", location);
+            var exResult = ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Could not add directory to Deposit files", location);
             return Result.Generify<WorkingDirectory>(exResult);
         }
     }
@@ -218,7 +218,8 @@ public class Storage(
             if (currentResult.Success)
             {
                 var root = currentResult.Value!;
-                var parentDir = root.FindDirectory(fileToAdd.LocalPath.GetParent(), false);
+                // Going to set create to true here (it was false) otherwise you can't add to a METS-only file layout.
+                var parentDir = root.FindDirectory(fileToAdd.LocalPath.GetParent(), true);
                 if (parentDir == null)
                 {
                     return Result.FailNotNull<WorkingDirectory>(ErrorCodes.NotFound, "Parent directory does not exist");
@@ -231,7 +232,7 @@ public class Storage(
         }
         catch (AmazonS3Exception s3E)
         {
-            var exResult = ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Could not add file to METS", location);
+            var exResult = ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Could not add file to Deposit files", location);
             return Result.Generify<WorkingDirectory>(exResult);
         }
     }


### PR DESCRIPTION
(built on top of keep-transaction-alive-in-commit)

This PR started out as the ability to cache archival groups to avoid expensive builds of things that by definition should only ever change with a new version.

But to do this properly I needed to address some things that had been put on the back burner - properly dealing with versions and deciding what to expose and what not to expose.

The Preservation API and Storage API now do not accept version parameters except for:

* obtaining the OCFL storage map for an Archival Group. This is the only way to see the file layout for previous versions. You can't see names of files (dc:title) but you can of course read whatever information is relevant from METS.
* requesting a single resource (no enumeration of child items; the `containers[] and binaries[] properties will always be null). The reason to do this is to find the name (dc:title) of a previous version of a resource, typically an Archival Group. However I think there is still some thinking to do around this and I have created a PBI for phase 2

Update:

Christine has been testing the behaviour in this PR.

Summary:

- Caching archival groups - for last part of Fedora perf issues
- Removing API signatures for requesting AGs at versions
- adding lightweight view - request individual resource at version (eg to see title)
- Adding OCFL / StorageMap support
- Adding OCFL endpoints and UI
- Fix issues with how the METS file is identified in a deposit and AG
- Change deposit export code to use storage map instead of archival group (so you can export a specific version)

Various bugs fixed while the branch was the latest
