### PR TITLE
convert incoming sha256 to lower, and report case-mismatches in OCFL …

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -96,7 +96,7 @@ public class MetadataReader : IMetadataReader
                 metadataList.Add(new DigestMetadata
                 {
                     Source = "BagIt",
-                    Digest = kvp.Value,
+                    Digest = kvp.Value.ToLowerInvariant(),
                     Timestamp = timestamp
                 });
             }
@@ -149,7 +149,7 @@ public class MetadataReader : IMetadataReader
             metadataList.Add(new FileFormatMetadata
             {
                 Source = source,
-                Digest = file.Sha256,
+                Digest = file.Sha256?.ToLowerInvariant(),
                 Size = file.Filesize,
                 PronomKey = file.Matches[0].Id,
                 FormatName = file.Matches[0].Format,

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
@@ -80,7 +80,7 @@ public class UploadFileToDepositHandler(
                 {
                     LocalPath = fullKey.RemoveStart(s3Uri.Key)!,
                     ContentType = request.ContentType,
-                    Digest = request.Checksum,
+                    Digest = request.Checksum.ToLowerInvariant(),
                     Size = request.Size,
                     Name = request.DepositFileName,
                     Modified = headResponse.LastModified.ToUniversalTime() // keep an eye on https://github.com/aws/aws-sdk-net/issues/1885

--- a/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
@@ -1058,16 +1058,38 @@ internal class FedoraClient(
         }
     }
     
-    private static void PopulateOrigin(StorageMap storageMap, Binary binary)
+    private void PopulateOrigin(StorageMap storageMap, Binary binary)
     {
         if (storageMap.StorageType == StorageTypes.S3)
         {
             // Fedora replaces spaces in the key with actual "%20" strings that I don't think are escape sequences
             // e4267807db7270096340540b93834d3c47d56c964d5b5b27fa9a398fde52165e: "v1/content/objects/awkward/7%20ways%20to%20celebrate%20-_-percent-23-_-WomensHistoryMonth%20💜%20And%20a%20sneak%20peek%20at%20SICK%20new%20art.htm"
-            var storageMapFilePath = storageMap.Hashes[binary.Digest!];
-            // "v1/content/objects/awkward/7%20ways%20to%20celebrate%20-_-percent-23-_-WomensHistoryMonth%20💜%20And%20a%20sneak%20peek%20at%20SICK%20new%20art.htm"
-            var backToUriSafe = storageMapFilePath.EscapePathElements(); // because those %20s are really there!
-            binary.Origin = new Uri($"s3://{storageMap.Root}/{storageMap.ObjectPath}/{backToUriSafe}");
+            var storageMapKey = binary.Digest!;
+            if (storageMap.Hashes.TryGetValue(storageMapKey, out var storageMapFilePath))
+            {
+                // "v1/content/objects/awkward/7%20ways%20to%20celebrate%20-_-percent-23-_-WomensHistoryMonth%20💜%20And%20a%20sneak%20peek%20at%20SICK%20new%20art.htm"
+                var backToUriSafe = storageMapFilePath.EscapePathElements(); // because those %20s are really there!
+                binary.Origin = new Uri($"s3://{storageMap.Root}/{storageMap.ObjectPath}/{backToUriSafe}");
+            }
+            else
+            {
+                if (storageMap.Hashes.TryGetValue(storageMapKey.ToLowerInvariant(), out var storageMapFilePathFromLoweredHash))
+                {
+                    // Do we want to consider this valid? Fedora reports the hash given at ingest time on the API,
+                    // which is valid if upper case, but the OCFL has a lower case hash always.
+                    // So they are equivalent as SHA256 hashes but not as strings/keys.
+                    // We could allow this and just do the same as above, but for now I will throw:
+                    logger.LogError("Binary has a non-lowercase (but valid) SHA256 hash for {file}: {hash}", 
+                        storageMapFilePathFromLoweredHash, storageMapKey);
+                    throw new NotSupportedException(
+                        $"Binary has a non-lowercase (but valid) SHA256 hash for {storageMapFilePathFromLoweredHash}: {storageMapKey}");
+                }
+
+                logger.LogError("StorageMap has no entry for hash: {hash}, expected for binary {binaryId}", 
+                    storageMapKey, binary.Id);
+                throw new NotSupportedException(
+                    $"StorageMap has no entry for hash: {storageMapKey}, expected for binary {binary.Id}");
+            }
         }
         // filesystem later
     }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -222,7 +222,7 @@ public class MetsParser(
                         ContentType = "application/xml",
                         LocalPath = fi.Name, // because mets must be in the root
                         Name = fi.Name,
-                        Digest = Checksum.Sha256FromFile(fi)
+                        Digest = Checksum.Sha256FromFile(fi)?.ToLowerInvariant()
                     };
                 }
 
@@ -249,7 +249,7 @@ public class MetsParser(
                 }
                 
                 var s3Stream = await s3Client.GetObjectStreamAsync(fileS3Uri.Bucket, fileS3Uri.Key, null);
-                var digest = Checksum.Sha256FromStream(s3Stream);
+                var digest = Checksum.Sha256FromStream(s3Stream)?.ToLowerInvariant();
                 var name = fileS3Uri.Key.GetSlug(); // because mets is in root - whether apparent (BagIt) or real
                 return new WorkingFile
                 {


### PR DESCRIPTION
Fixes 96374

I am throwing a very clear error message if this comes across hashes that are different in case only.
The behaviour of https://github.com/uol-dlip/digital-preservation/pull/64/files#diff-42c0d4b83d33fb970734324b5d2c24d24aca00d98c104f88295d93130ba0580e is the same, for now.