### PR TITLE
Some optimisations for ExecutePipelineJob; temp fix for METS ADMID issue

### DIFF
--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -6,8 +6,6 @@ using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Utils;
 using DigitalPreservation.Workspace;
 using MediatR;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Options;
 using Pipeline.API.Config;
 using Preservation.Client;
@@ -17,11 +15,11 @@ using Checksum = DigitalPreservation.Utils.Checksum;
 
 namespace Pipeline.API.Features.Pipeline.Requests;
 
-public class ExecutePipelineJob(string jobIdentifier, string depositName, string? runUser) : IRequest<Result>
+public class ExecutePipelineJob(string jobIdentifier, string depositId, string? runUser) : IRequest<Result>
 {
     public string JobIdentifier { get; } = jobIdentifier;
-    public string DepositName { get; } = depositName;
-    public string? RunUser { get; set; } = runUser;
+    public string DepositId { get; } = depositId;
+    public string? RunUser { get; } = runUser;
 }
 
 
@@ -34,53 +32,71 @@ public class ProcessPipelineJobHandler(
     IPreservationApiClient preservationApiClient) : IRequestHandler<ExecutePipelineJob, Result>
 
 {
-    //private WorkspaceManager WorkspaceManager { get; set; } = workspaceManager;
     private const string BrunnhildeFolderName = "brunnhilde";
     private readonly string[] filesToIgnore = ["tree.txt"];
-    private WorkspaceManager? workspaceManagerWorker;
+    private string? jobIdentifier;
+    private string? runUser;
 
+    
+    /// <summary>
+    /// Reacquiring a new WorkspaceManager is not expensive, but refreshing the file system is
+    /// (e.g., GetCombinedDirectory(true))
+    /// </summary>
+    /// <param name="depositId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    private async Task<Result<WorkspaceManager>> GetWorkspaceManager(string depositId, CancellationToken cancellationToken = default)
+    {
+        var response = await preservationApiClient.GetDeposit(depositId, cancellationToken);
+        if (response.Failure || response.Value == null)
+        {
+            return Result.FailNotNull<WorkspaceManager>(response.ErrorCode ?? ErrorCodes.UnknownError, 
+                $"Could not process pipeline job for job id {jobIdentifier} and deposit {depositId} as could not find the deposit.");
+        }
+        var deposit = response.Value;
+        var workspaceManager = workspaceManagerFactory.Create(deposit);
+        return Result.OkNotNull(workspaceManager);
+    }
+    
+    
     public async Task<Result> Handle(ExecutePipelineJob request, CancellationToken cancellationToken)
     {
-        var jobId = request.JobIdentifier;
-        var depositId = request.DepositName;
-        var runUser = request.RunUser;
-
+        jobIdentifier = request.JobIdentifier;
+        runUser = request.RunUser ?? "PipelineApi";
+        
+        var workspaceResult = await GetWorkspaceManager(request.DepositId, cancellationToken);
+        if (workspaceResult.Failure || workspaceResult.Value?.Deposit == null)
+        {
+            return Result.Fail(workspaceResult.ErrorCode ?? ErrorCodes.UnknownError, 
+                $"Could not process pipeline job for job id {request.JobIdentifier} and deposit {request.DepositId} as could not find the deposit.");
+        }
         try
         {
-            var response = await preservationApiClient.GetDeposit(depositId, cancellationToken);
-            var deposit = response.Value;
+            await mediator.Send(new LogPipelineJobStatus(
+                request.DepositId, request.JobIdentifier, PipelineJobStates.Running, runUser), cancellationToken);
 
-            if(deposit == null)
-                return Result.FailNotNull<Result>(ErrorCodes.UnknownError, $"Could not publish pipeline job for job id {jobId} and deposit {depositId} as could not find the deposit ");
-
-            workspaceManagerWorker = workspaceManagerFactory.Create(deposit);
-
-            var pipelineJobsResult = await mediator.Send(new LogPipelineJobStatus(depositId, jobId, PipelineJobStates.Running,
-                runUser ?? "PipelineApi"), cancellationToken);
-
-            var result = await ExecuteBrunnhilde(jobId, request.DepositName, runUser);
-
+            var result = await ExecuteBrunnhilde(workspaceResult.Value);
+            
             logger.LogInformation($"Execute Brunnhilde result {result?.Status} {result?.Errors} ");
             return result?.Status == PipelineJobStates.Completed ? Result.Ok() : Result.FailNotNull<Result>(ErrorCodes.UnknownError, $"Could not complete pipeline run {result?.Errors?.FirstOrDefault()?.Message}");
         }
         catch (Exception ex)
         {
-            logger.LogInformation($"Job handler exception message{ex.Message}");
-            logger.LogError(ex, $" Caught error in PipelineJob handler for job id {jobId} and deposit {depositId} blah {ex.Message} {ex.InnerException} {ex.StackTrace} blah");
+            logger.LogError(ex, $"Caught error in PipelineJob handler for job id {request.JobIdentifier} and deposit {request.DepositId}");
 
-            var pipelineJobsResult = await mediator.Send(new LogPipelineJobStatus(depositId, jobId, PipelineJobStates.CompletedWithErrors,
-                runUser ?? "PipelineApi", ex.Message), cancellationToken);
+            var pipelineJobsResult = await mediator.Send(
+                new LogPipelineJobStatus(request.DepositId, request.JobIdentifier, PipelineJobStates.CompletedWithErrors, runUser, ex.Message), cancellationToken);
 
-            if (pipelineJobsResult?.Value?.Errors is { Length: 0 })
-                logger.LogInformation($"Job {jobId} Running status CompletedWithErrors logged");
+            if (pipelineJobsResult.Value?.Errors is { Length: 0 })
+                logger.LogInformation($"Job {request.JobIdentifier} Running status CompletedWithErrors logged");
 
-            return Result.FailNotNull<Result>(ErrorCodes.UnknownError, $"Could not publish pipeline job for job id {jobId} and deposit {depositId}: " + ex.Message);
+            return Result.FailNotNull<Result>(ErrorCodes.UnknownError, 
+                $"Could not publish pipeline job for job id {request.JobIdentifier} and deposit {request.DepositId}: " + ex.Message);
         }
         finally
         {
-            CleanupProcessFolder(depositId);
+            CleanupProcessFolder(request.DepositId);
         }
-
     }
 
     private void CleanupProcessFolder(string depositName)
@@ -91,27 +107,23 @@ public class ProcessPipelineJobHandler(
         Directory.Delete(metadataPathForProcessDelete, true);
     }
 
-    private async Task<ProcessPipelineResult?> ExecuteBrunnhilde(string jobIdentifier, string depositName, string? runUser)
+    private async Task<ProcessPipelineResult?> ExecuteBrunnhilde(WorkspaceManager workspaceManager)
     {
+        var depositId = workspaceManager.DepositSlug!;
         var mountPath = storageOptions.Value.FileMountPath;
         var separator = brunnhildeOptions.Value.DirectorySeparator;
         var processFolder = brunnhildeOptions.Value.ProcessFolder;
 
-        var (metadataPath, metadataProcessPath, objectPath) = await GetFilePaths(depositName);
+        var (metadataPath, metadataProcessPath, objectPath) = GetFilePaths(workspaceManager);
 
         if (!Directory.Exists(objectPath))
         {
-            logger.LogError($"Deposit {depositName} folder and contents could not be found at {objectPath}");
-            logger.LogInformation($"Metadata folder");
-
-            var response = await preservationApiClient.GetDeposit(depositName);
-            var deposit = response.Value;
-
+            logger.LogError($"Deposit {depositId} folder and contents could not be found at {objectPath}");
             return new ProcessPipelineResult
             {
-                Status = "CompletedWithErrors",
-                Errors = [new Error { Message = $" Could not retrieve deposit for {depositName} and could not unlock" }],
-                ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
+                Status = PipelineJobStates.CompletedWithErrors,
+                Errors = [new Error { Message = $" Could not retrieve deposit for {depositId} and could not unlock" }],
+                ArchivalGroup = workspaceManager.Deposit.ArchivalGroupName ?? string.Empty,
             };
         }
 
@@ -132,48 +144,54 @@ public class ProcessPipelineJobHandler(
 
         if (reader == null)
         {
-            var response = await preservationApiClient.GetDeposit(depositName);
-            var deposit = response.Value;
+            logger.LogError("Issue executing Brunnhilde process: process?.StandardOutput is null");
 
-            logger.LogError($" Issue executing Brunnhilde process as the reader is null");
-
-            await mediator.Send(new LogPipelineJobStatus(depositName, jobIdentifier, PipelineJobStates.CompletedWithErrors,
-                runUser ?? "PipelineApi", $" Issue executing Brunnhilde process as the reader is null"));
+            await mediator.Send(new LogPipelineJobStatus(
+                depositId, jobIdentifier!, PipelineJobStates.CompletedWithErrors,
+                runUser!, $" Issue executing Brunnhilde process as the reader is null"));
 
             return new ProcessPipelineResult
             {
-                Status = "CompletedWithErrors",
-                Errors = [new Error { Message = $" Issue executing Brunnhilde process as the reader is null for {depositName} and job id {jobIdentifier}" }],
-                ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
+                Status = PipelineJobStates.CompletedWithErrors,
+                Errors = [new Error { Message = $" Issue executing Brunnhilde process as the reader is null for {depositId} and job id {jobIdentifier}" }],
+                ArchivalGroup = workspaceManager.Deposit.ArchivalGroupName ?? string.Empty
             };
         }
 
         var result = await reader.ReadToEndAsync();
+        var brunnhildeExecutionSuccess = result.Contains("Brunnhilde characterization complete.");
+        logger.LogInformation($"Brunnhilde result success: {brunnhildeExecutionSuccess}");
 
-        var brunnhildeExecutionSuccess = result?.Contains("Brunnhilde characterization complete.");
-
-        logger.LogInformation($"Brunnhilde result success {brunnhildeExecutionSuccess}");
-
-        if (!string.IsNullOrEmpty(result) && result.Contains("Brunnhilde characterization complete."))
+        if (brunnhildeExecutionSuccess)
         {
-            logger.LogInformation($"Brunnhilde creation successful");
-            await workspaceManagerWorker.GetCombinedDirectory(true);
+            logger.LogInformation("Brunnhilde creation successful");
+            var depositPath = $"{mountPath}{separator}{depositId}";
+            
+            // At this point we have not modified the METS file, the ETag for this workspace is still valid
+            var deleteBrunnhildeResult = await DeleteBrunnhildeFoldersAndFiles(workspaceManager);
+            if (deleteBrunnhildeResult.Failure)
+            {
+                logger.LogInformation("Brunnhilde deletion failed: " + deleteBrunnhildeResult.CodeAndMessage());
+                // Do we just go ahead anyway?
+            }
+            
+            // Now our workspaceManager is out of date, because METS has been modified.
+            // So we can't use it again for further *content modifications*.
+            // But we can use it for other properties, e.g. workspaceManager.IsBagItLayout won't have changed.
 
-            var depositPath = $"{mountPath}{separator}{depositName}";
-            await DeleteBrunnhildeFoldersAndFiles(depositName, metadataPath, depositPath, runUser);
-
-            var metadataPathForProcessFiles = workspaceManagerWorker.IsBagItLayout ? $"{processFolder}{separator}{depositName}{separator}data{separator}metadata"  //{separator}{BrunnhildeFolderName}
-                : $"{processFolder}{separator}{depositName}{separator}metadata";
+            var metadataPathForProcessFiles = workspaceManager.IsBagItLayout ? $"{processFolder}{separator}{depositId}{separator}data{separator}metadata"  //{separator}{BrunnhildeFolderName}
+                : $"{processFolder}{separator}{depositId}{separator}metadata";
                                                                                  
-            var metadataPathForProcessDirectories = workspaceManagerWorker.IsBagItLayout ? $"{processFolder}{separator}{depositName}{separator}data{separator}metadata{separator}{BrunnhildeFolderName}"  //{separator}{BrunnhildeFolderName}
-                : $"{processFolder}{separator}{depositName}{separator}metadata{separator}{BrunnhildeFolderName}"; //               
+            var metadataPathForProcessDirectories = workspaceManager.IsBagItLayout ? $"{processFolder}{separator}{depositId}{separator}data{separator}metadata{separator}{BrunnhildeFolderName}"  //{separator}{BrunnhildeFolderName}
+                : $"{processFolder}{separator}{depositId}{separator}metadata{separator}{BrunnhildeFolderName}"; //               
 
             logger.LogInformation($"metadataPathForProcessFiles after brunnhilde process {metadataPathForProcessFiles}");
             logger.LogInformation($"metadataPathForProcessDirectories after brunnhilde process {metadataPathForProcessDirectories}");
-            logger.LogInformation($"depositName after brunnhilde process {depositName}");
+            logger.LogInformation($"depositName after brunnhilde process {depositId}");
 
-            var (createFolderResultList, uploadFilesResultList) = await UploadFilesToMetadataRecursively(depositName, metadataPathForProcessDirectories, metadataPathForProcessFiles, depositPath, runUser ?? "PipelineApi");
-
+            var (createFolderResultList, uploadFilesResultList) = await UploadFilesToMetadataRecursively(
+                depositId, metadataPathForProcessDirectories, metadataPathForProcessFiles, depositPath);
+            
             foreach (var folderResult in createFolderResultList)
             {
                 logger.LogInformation($"{folderResult?.Value?.Context} upload Success: {folderResult?.Success}");
@@ -183,92 +201,55 @@ public class ProcessPipelineJobHandler(
             {
                 logger.LogInformation($"{uploadFileResult?.Value?.Context} upload Success: {uploadFileResult?.Success}");
             }
-            var response = await preservationApiClient.GetDeposit(depositName);
-            var deposit = response.Value;
-
-            if (deposit == null)
-            {
-                logger.LogError($" Could not retrieve deposit for {depositName} and could not unlock");
-
-                await mediator.Send(new LogPipelineJobStatus(depositName, jobIdentifier, PipelineJobStates.CompletedWithErrors,
-                    runUser ?? "PipelineApi", $" Could not retrieve deposit for {depositName} and could not unlock"));
-
-                return new ProcessPipelineResult
-                {
-                    Status = "CompletedWithErrors",
-                    Errors = [ new Error { Message = $" Could not retrieve deposit for {depositName} and could not unlock" }],
-                    ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
-                };
-            }
-
-            var releaseLockResult = await preservationApiClient.ReleaseDepositLock(deposit, new CancellationToken());
+            
+            var releaseLockResult = await preservationApiClient.ReleaseDepositLock(workspaceManager.Deposit, CancellationToken.None);
             logger.LogInformation($"releaseLockResult: {releaseLockResult.Success}");
             if (releaseLockResult is { Failure: true })
             {
                 logger.LogError($"Could not release lock for Job {jobIdentifier} Completed status logged");
             }
 
-            var pipelineJobsResult = await mediator.Send(new LogPipelineJobStatus(depositName, jobIdentifier, PipelineJobStates.Completed,
-                runUser ?? "PipelineApi"));
+            var pipelineJobsResult = await mediator.Send(
+                new LogPipelineJobStatus(depositId, jobIdentifier!, PipelineJobStates.Completed, runUser!));
 
-            if (pipelineJobsResult?.Value?.Errors is { Length: 0 })
-                logger.LogInformation($"Job {jobIdentifier} and deposit {depositName} pipeline run Completed status logged");
+            if (pipelineJobsResult.Value?.Errors is { Length: 0 })
+                logger.LogInformation($"Job {jobIdentifier} and deposit {depositId} pipeline run Completed status logged");
 
-            await AddObjectsToMETS(depositName, depositPath, runUser ?? "PipelineApi");
+            await AddObjectsToMets(depositId, depositPath);
 
             return new ProcessPipelineResult
             {
-                Status = "Completed",
-                ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
+                Status = PipelineJobStates.Completed,
+                ArchivalGroup = workspaceManager.Deposit.ArchivalGroupName ?? string.Empty,
             };
         }
         else
         {
-            var response = await preservationApiClient.GetDeposit(depositName);
-            var deposit = response.Value;
-
-            if (deposit == null)
-            {
-                logger.LogError($" Could not retrieve deposit for {depositName} and could not unlock");
-
-               var logJobsResult = await mediator.Send(new LogPipelineJobStatus(depositName, jobIdentifier, PipelineJobStates.CompletedWithErrors,
-                    runUser ?? "PipelineApi", $" Could not retrieve deposit for {depositName} and could not unlock"));
-
-               if (logJobsResult.Failure)
-                   logger.LogError($"Could not record CompletedWithErrors status for deposit {depositName} job {jobIdentifier}");
-
-                return new ProcessPipelineResult
-                {
-                    Status = "CompletedWithErrors",
-                    Errors = [new Error { Message = $" Could not retrieve deposit for {depositName} and could not unlock" }],
-                    ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
-                };
-            }
-
-            var releaseLockResult = await preservationApiClient.ReleaseDepositLock(deposit, new CancellationToken());
+            var releaseLockResult = await preservationApiClient.ReleaseDepositLock(workspaceManager.Deposit, CancellationToken.None);
             logger.LogInformation($"releaseLockResult: {releaseLockResult.Success}");
             if (releaseLockResult is { Failure: true })
             {
                 logger.LogError($"Could not release lock for Job {jobIdentifier} Completed status logged");
             }
 
-            var pipelineJobsResult = await mediator.Send(new LogPipelineJobStatus(depositName, jobIdentifier, PipelineJobStates.CompletedWithErrors,
-                runUser ?? "PipelineApi", "Issue producing Brunnhilde files."));
+            var pipelineJobsResult = await mediator.Send(new LogPipelineJobStatus(depositId, jobIdentifier!, PipelineJobStates.CompletedWithErrors,
+                runUser!, "Issue producing Brunnhilde files."));
 
             if(pipelineJobsResult.Failure)
-                logger.LogError($"Could not record CompletedWithErrors status for deposit {depositName} job {jobIdentifier}");
+                logger.LogError($"Could not record CompletedWithErrors status for deposit {depositId} job {jobIdentifier}");
 
             return new ProcessPipelineResult
             {
-                Status = "CompletedWithErrors",
-                ArchivalGroup = deposit?.ArchivalGroupName ?? string.Empty,
+                Status = PipelineJobStates.CompletedWithErrors,
+                ArchivalGroup = workspaceManager.Deposit.ArchivalGroupName ?? string.Empty,
                 Errors = [new Error { Message = "Issue producing Brunnhilde files." }],
             };
         }
     }
 
-    private async Task<(string, string, string)> GetFilePaths(string depositName)
+    private (string, string, string) GetFilePaths(WorkspaceManager workspaceManager)
     {
+        var depositId = workspaceManager.DepositSlug;
         var mountPath = storageOptions.Value.FileMountPath;
         var separator = brunnhildeOptions.Value.DirectorySeparator;
         var objectFolder = brunnhildeOptions.Value.ObjectsFolder;
@@ -277,19 +258,17 @@ public class ProcessPipelineJobHandler(
         string metadataProcessPath;
         string objectPath;
 
-        await workspaceManagerWorker.GetCombinedDirectory(true);
-
-        if (workspaceManagerWorker.IsBagItLayout)
+        if (workspaceManager.IsBagItLayout)
         {
-            metadataPath = $"{mountPath}{separator}{depositName}{separator}data{separator}metadata";
-            metadataProcessPath = $"{processFolder}{separator}{depositName}{separator}data{separator}metadata{separator}{BrunnhildeFolderName}";
-            objectPath = $"{mountPath}{separator}{depositName}{separator}data{separator}{objectFolder}";
+            metadataPath = $"{mountPath}{separator}{depositId}{separator}data{separator}metadata";
+            metadataProcessPath = $"{processFolder}{separator}{depositId}{separator}data{separator}metadata{separator}{BrunnhildeFolderName}";
+            objectPath = $"{mountPath}{separator}{depositId}{separator}data{separator}{objectFolder}";
         }
         else
         {
-            metadataPath = $"{mountPath}{separator}{depositName}{separator}metadata";
-            metadataProcessPath = $"{processFolder}{separator}{depositName}{separator}metadata{separator}{BrunnhildeFolderName}";
-            objectPath = $"{mountPath}{separator}{depositName}{separator}{objectFolder}";
+            metadataPath = $"{mountPath}{separator}{depositId}{separator}metadata";
+            metadataProcessPath = $"{processFolder}{separator}{depositId}{separator}metadata{separator}{BrunnhildeFolderName}";
+            objectPath = $"{mountPath}{separator}{depositId}{separator}{objectFolder}";
         }
 
 
@@ -302,106 +281,52 @@ public class ProcessPipelineJobHandler(
         return (metadataPath, metadataProcessPath, objectPath);
     }
 
-    private async Task DeleteBrunnhildeFoldersAndFiles(string depositId, string metadataPath, string depositPath, string? runUser)
+    private async Task<Result<ItemsAffected>> DeleteBrunnhildeFoldersAndFiles(WorkspaceManager workspaceManager)
     {
-        //get deposit to create workspace manager
-        var response = await preservationApiClient.GetDeposit(depositId);
-        var deposit = response.Value;
-
-        if (deposit == null)
-        {
-            logger.LogError($" Could not retrieve deposit for {depositId}");
-            return;
-        }
-
-        await workspaceManagerWorker.GetCombinedDirectory(true);
-
-        if (workspaceManagerWorker.IsBagItLayout)
-            depositPath += "/data";
-
-        foreach (var filePath in Directory.GetFiles(metadataPath, "*.*", SearchOption.AllDirectories))
-        {
-            logger.LogInformation($" filepath {filePath} in DeleteBrunnhildeFoldersAndFiles");
-            if (!filePath.Contains(BrunnhildeFolderName))
-                continue;
-
-            var relativePath = Path.GetRelativePath(
-                depositPath,
-                filePath).Replace(@"\", "/").ToLower();
-
-            logger.LogInformation($"relative path in get files {relativePath} in DeleteBrunnhildeFoldersAndFiles");
-
-            await DeleteFolderOrFile(depositId, relativePath, false, runUser);
-        }
-
-        var metadataContext = "metadata";
-
-        foreach (var dirPath in Directory.GetDirectories(metadataPath, "*", SearchOption.AllDirectories))
-        {
-            if (!dirPath.Contains(BrunnhildeFolderName))
-                continue;
-
-            var relativePath = Path.GetRelativePath(
-                depositPath,
-                dirPath).Replace(@"\", "/").ToLower();
-
-            logger.LogInformation($"relative path in dir {relativePath} in  DeleteBrunnhildeFoldersAndFiles");
-
-            if (relativePath == $"{metadataContext}/{BrunnhildeFolderName}") 
-                continue;
-
-            await DeleteFolderOrFile(depositId, relativePath, true, runUser);
-        }
-
-        await DeleteFolderOrFile(depositId, $"{metadataContext}/{BrunnhildeFolderName}", true, runUser);
-
-    }
-
-    private async Task DeleteFolderOrFile(string depositId, string relativePath, bool isDirectory, string? runUser)
-    {
-        var itemsForDeletion = new List<MinimalItem>();
+        // This is an expensive operation (refresh=true):
+        var root = await workspaceManager.GetCombinedDirectory(true);
+        
+        var (directories, files) = root.Value!.Flatten();
         var deleteSelection = new DeleteSelection
         {
             DeleteFromDepositFiles = true,
             DeleteFromMets = true,
-            Deposit = null
+            Deposit = null,
+            Items = []
         };
-
-        itemsForDeletion.Add(new MinimalItem
+        var testPath = $"{FolderNames.Metadata}/{BrunnhildeFolderName}";
+        foreach (var directory in directories)
         {
-            RelativePath = relativePath,
-            IsDirectory = isDirectory,
-            Whereabouts = Whereabouts.Both
-        });
-
-        var response = await preservationApiClient.GetDeposit(depositId);
-        var deposit = response.Value;
-
-        if (deposit == null)
-        {
-            logger.LogError($" Could not retrieve deposit for {depositId}");
-            return;
+            if (directory.LocalPath!.StartsWith(testPath))
+            {
+                deleteSelection.Items.Add(new MinimalItem
+                {
+                    IsDirectory = true,
+                    RelativePath = directory.LocalPath,
+                    Whereabouts = Whereabouts.Both
+                });
+            }
         }
-
-        workspaceManagerWorker = workspaceManagerFactory.Create(deposit);
-
-        deleteSelection.Items = itemsForDeletion;
-
-        var resultDelete = await workspaceManagerWorker.DeleteItems(deleteSelection, runUser ?? "PipelineApi");
-
-        if (!resultDelete.Success)
+        foreach (var file in files)
         {
-            logger.LogError($"DELETE ITEMS: Error code for relative path {relativePath}: {resultDelete.ErrorCode}");
-            logger.LogError($"Error message for relative path {relativePath}: {resultDelete.ErrorMessage}");
-            logger.LogError($"Error failure for relative path {relativePath}: {resultDelete.Failure}");
+            if (file.LocalPath!.StartsWith(testPath))
+            {
+                deleteSelection.Items.Add(new MinimalItem
+                {
+                    IsDirectory = false,
+                    RelativePath = file.LocalPath,
+                    Whereabouts = Whereabouts.Both
+                });
+            }
         }
-
-        itemsForDeletion.Clear();
-        deleteSelection.Items.Clear();
+        
+        var resultDelete = await workspaceManager.DeleteItems(deleteSelection, runUser!);
+        return resultDelete;
     }
 
     
-    private async Task<(List<Result<CreateFolderResult>?> createSubFolderResult, List<Result<SingleFileUploadResult>?> uploadFileResult)> UploadFilesToMetadataRecursively(string depositId, string sourcePathForDirectories, string sourcePathForFiles, string depositPath, string? runUser)
+    private async Task<(List<Result<CreateFolderResult>?> createSubFolderResult, List<Result<SingleFileUploadResult>?> uploadFileResult)> UploadFilesToMetadataRecursively(
+        string depositId, string sourcePathForDirectories, string sourcePathForFiles, string depositPath)
     {
         try
         {
@@ -413,14 +338,14 @@ public class ProcessPipelineJobHandler(
             //create Brunnhilde folder first
             var createSubFolderResult = new List<Result<CreateFolderResult>?> 
             { 
-                await CreateMetadataSubFolderOnS3(depositId, sourcePathForDirectories, runUser, true) 
+                await CreateMetadataSubFolderOnS3(depositId, sourcePathForDirectories) 
             };
 
             //Now Create all of the directories
             foreach (var dirPath in Directory.GetDirectories(sourcePathForDirectories, "*", SearchOption.AllDirectories))
             {
                 logger.LogInformation($"dir path {dirPath}");
-                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(depositId, dirPath, runUser));
+                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(depositId, dirPath));
             }
 
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
@@ -432,12 +357,12 @@ public class ProcessPipelineJobHandler(
                 if (filesToIgnore.Any(filePath.Contains))
                     continue;
                 
-                uploadFileResult.Add(await UploadFileToDepositOnS3(depositId, filePath, sourcePathForFiles, runUser ?? "PipelineApi"));
+                uploadFileResult.Add(await UploadFileToDepositOnS3(depositId, filePath, sourcePathForFiles));
             }
 
             foreach (var subFolder in createSubFolderResult)
             {
-                logger.LogInformation($"subFolder.ErrorMessage {subFolder?.ErrorMessage} , subFolder?.Value?.Context {subFolder?.Value?.Context} subFolder?.Value?.Created {subFolder?.Value?.Created} hghhjhjsd ");
+                logger.LogInformation($"subFolder.ErrorMessage {subFolder?.ErrorMessage} , subFolder?.Value?.Context {subFolder?.Value?.Context} subFolder?.Value?.Created {subFolder?.Value?.Created}");
             }
 
             foreach (var uploadFile in uploadFileResult)
@@ -456,37 +381,25 @@ public class ProcessPipelineJobHandler(
             logger.LogError(ex, $" Caught error in copy files recursively from {sourcePathForFiles} to {depositPath}");
         }
 
-        return ((List<Result<CreateFolderResult>?> createSubFolderResult, List<Result<SingleFileUploadResult>?> uploadFileResult))(Enumerable.Empty<Result<CreateFolderResult>>(), Enumerable.Empty<Result<SingleFileUploadResult>>());
-
+        return (createSubFolderResult: [], uploadFileResult: []);
     }
 
-    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(string depositId, string dirPath, string? runUser, bool brunnhildeFolder = false)
+    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(string depositId, string dirPath)
     {
+        // This is a content-changing operation
+        var workspaceResult = await GetWorkspaceManager(depositId);
+        var workspaceManager = workspaceResult.Value!;
+        
         var context = new StringBuilder();
-
         var metadataContext = "metadata";
-
         context.Append(metadataContext);
-
         var di = new DirectoryInfo(dirPath);
-
-        var response = await preservationApiClient.GetDeposit(depositId);
-        var deposit = response.Value;
-
-        if (deposit == null)
-        {
-            logger.LogError($" Could not retrieve deposit for {depositId} and could not unlock");
-            return null;
-        }
-
-        workspaceManagerWorker = workspaceManagerFactory.Create(deposit);
-
         if (di.Parent?.Name.ToLower() == BrunnhildeFolderName && !context.ToString().Contains($"/{BrunnhildeFolderName}")) //TODO
             context.Append($"/{BrunnhildeFolderName}");
 
         logger.LogInformation($"BrunnhildeFolderName {BrunnhildeFolderName}");
         logger.LogInformation($"di.Name {di.Name} context {context}");
-        var result = await workspaceManagerWorker.CreateFolder(di.Name, context.ToString(), false, runUser ?? "PipelineApi", true);
+        var result = await workspaceManager.CreateFolder(di.Name, context.ToString(), false, runUser, true);
 
         if (!result.Success)
         {
@@ -496,15 +409,12 @@ public class ProcessPipelineJobHandler(
         }
 
         return result;
-
     }
 
-    private async Task<Result<SingleFileUploadResult>?> UploadFileToDepositOnS3(string depositId, string filePath, string sourcePath, string? runUser)
+    private async Task<Result<SingleFileUploadResult>?> UploadFileToDepositOnS3(string depositId, string filePath, string sourcePath)
     {
         var context = new StringBuilder();
-
-        var metadataContext = $"metadata";
-
+        var metadataContext = "metadata";
         context.Append(metadataContext);
 
         if (!filePath.Contains(BrunnhildeFolderName))
@@ -530,7 +440,7 @@ public class ProcessPipelineJobHandler(
             return null;
 
         var stream = GetFileStream(filePath);
-        var result = await UploadFileToBucketDeposit(depositId, stream, filePath, contextPath, checksum, runUser ?? "PipelineApi");
+        var result = await UploadFileToBucketDeposit(depositId, stream, filePath, contextPath, checksum);
 
 
         if (!result.Success)
@@ -541,29 +451,20 @@ public class ProcessPipelineJobHandler(
         }
         else
         {
-            logger.LogInformation($"uploaded file {result?.Value?.Uploaded} with context {result?.Value?.Context}");
+            logger.LogInformation($"uploaded file {result.Value?.Uploaded} with context {result.Value?.Context}");
         }
 
         await stream.DisposeAsync();
-        return result ?? null;
+        return result;
     }
 
-    private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(string id, Stream stream, string filePath, string contextPath, string checksum, 
-        string runUser)
+    private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(
+        string depositId, Stream stream, string filePath, string contextPath, string checksum)
     {
-        var response = await preservationApiClient.GetDeposit(id);
-        var deposit = response.Value;
-
-        if (deposit == null)
-        {
-            logger.LogError($" Could not retrieve deposit for {id} and could not unlock");
-            return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError, "deposit is null so cant upload file");
-        }
-
-        var workspaceManager = workspaceManagerFactory.Create(deposit);
-
+        // This is potentially expensive as it needs a NEW WorkspaceManager each time
+        // TODO: We need a batch operation on WorkspaceManager to upload a set of small files.
+        
         var fi = new FileInfo(filePath);
-
         try
         {
             MimeTypes.TryGetMimeType(filePath.GetSlug(), out var contentType);
@@ -571,7 +472,9 @@ public class ProcessPipelineJobHandler(
             if(string.IsNullOrEmpty(contentType))
                 return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError, "Could not find file content type");
 
-            var result = await workspaceManager.UploadSingleSmallFile(stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, runUser, true);
+            var workspaceManagerResult = await GetWorkspaceManager(depositId);
+            var result = await workspaceManagerResult.Value!. UploadSingleSmallFile(
+                stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, runUser!, true);
 
             return result;
         }
@@ -581,7 +484,7 @@ public class ProcessPipelineJobHandler(
         }
     }
 
-    public static Stream GetFileStream(string filePath)
+    private static Stream GetFileStream(string filePath)
     {
         if (!File.Exists(filePath)) throw new Exception($"{filePath} file not found.");
         Stream result = File.OpenRead(filePath);
@@ -593,23 +496,17 @@ public class ProcessPipelineJobHandler(
         return result;
     }
 
-    private async Task AddObjectsToMETS(string depositName, string depositPath, string runUser)
+    /// <summary>
+    /// Force the objects/ folder contents to be re-processed - PATCH the METS
+    /// </summary>
+    /// <param name="depositId"></param>
+    /// <param name="depositPath"></param>
+    private async Task AddObjectsToMets(string depositId, string depositPath)
     {
-        var (metadataPath, metadataProcessPath, objectPath) = await GetFilePaths(depositName);
+        var workspaceManagerResult = await GetWorkspaceManager(depositId);
+        var workspaceManager = workspaceManagerResult.Value!;
+        var (_, _, objectPath) = GetFilePaths(workspaceManager);
         var minimalItems = new List<MinimalItem>();
-
-        var response = await preservationApiClient.GetDeposit(depositName);
-        var deposit = response.Value;
-
-        if (deposit == null)
-        {
-            logger.LogError($" Could not retrieve deposit for {depositName}");
-            return;
-        }
-
-        var workspaceManager = workspaceManagerFactory.Create(deposit);
-
-        await workspaceManager.GetCombinedDirectory(true);
 
         if (workspaceManager.IsBagItLayout)
             depositPath += "/data";
@@ -650,6 +547,6 @@ public class ProcessPipelineJobHandler(
             }
         }
 
-        await workspaceManager.AddItemsToMets(wbsToAdd, runUser);
+        await workspaceManager.AddItemsToMets(wbsToAdd, runUser!);
     }
 }

--- a/src/DigitalPreservation/Pipeline.API/appsettings.Example.json
+++ b/src/DigitalPreservation/Pipeline.API/appsettings.Example.json
@@ -33,9 +33,6 @@
     "DisableAuth": "true",
     "UseLocalHostedServiceForPipeline": "true"
   },
-  "PipelineJob": {
-    "PipelineJobTopicArn": "arn:aws:sns:eu-west-1:975050260954:dlip-pres-local-pipeline-job-runner-topic"
-  },
   "ApiKeyOptions": {
     "ApiKey": "API Key",
     "ApiHeaderName": "X-API-KEY"

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -464,27 +464,11 @@ public class MetsManager(
                         return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
                     }
 
-                    var amdSec = fullMets.Mets.AmdSec.SingleOrDefault(a => a.Id == file.Admid[0]);
-                    if (amdSec == null)
-                    {
-                        logger.LogError($"Could not find amdSec with Id {fileId}", file.Admid[0]);
-                        logger.LogInformation("div:");
-                        logger.LogInformation(div.ToString());
-                        logger.LogInformation("fileId: " + fileId);
-                        logger.LogInformation("file:");
-                        logger.LogInformation(file.ToString());
-                        logger.LogInformation("fileAdmId:");
-                        foreach (var admid in file.Admid)
-                        {
-                            logger.LogInformation(admid);
-                        }
-                        logger.LogInformation("Known AMD SECs:");
-                        foreach (var amdSecTemp in fullMets.Mets.AmdSec)
-                        {
-                            logger.LogInformation(amdSecTemp.Id);
-                        }
-                        throw new InvalidOperationException($"Could not find amdSec with Id {file.Admid[0]}");
-                    }
+                    // TODO: This is a quick fix to get round the problem of spaces in XML IDs.
+                    // We need to not have any spaces in XML IDs, which means we need to escape them 
+                    // in a reversible way (replacing with _ won't do)
+                    var fileAdmId = string.Join(' ', file.Admid);
+                    var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == fileAdmId);
                     var premisXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault();
                     FileFormatMetadata patchPremis;
                     try


### PR DESCRIPTION
Added a Deposit property to WorkspaceManager - returns the deposit it was created for.
This makes some of the code in ExecutePipelineJob a lot simpler.

Refactored ExecutePipelineJob to isolate the creation of a new WorkspaceManager and remove some code duplication, and unnecessary refreshes of the filesystem (we still need to address this though, we need batch operations for the things the pipeline does.

Changed the way DeleteBrunnhildeFoldersAndFiles works so that it builds its list for deletion from the WorkspaceManager files, rather than the pipeline local filesystem (there might not be any metadata there, an initial run might have happened in BitCurator)

Added a temporary fix to MetsManager (see comment).