### PR TITLE
Don't RefreshCombinedDirectory on load

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -65,7 +65,6 @@ public class DepositModel(
 
             if (Deposit.Status != DepositStates.Exporting)
             {
-                await WorkspaceManager.RefreshCombinedDirectory(); //refresh
                 var combinedResult = WorkspaceManager.GetRootCombinedDirectory();
                 if (combinedResult is { Success: true, Value: not null })
                 {


### PR DESCRIPTION
Removed the line that always rebuilds the file system model on every load of the Deposit page.