### PR TITLE
Pipeline identity

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Error.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Error.cs
@@ -5,14 +5,16 @@ namespace DigitalPreservation.Common.Model;
 public class Error
 {
     /// <summary>
-    /// Id directly to this version
+    /// Id directly to this version -optional
     /// </summary>
     [JsonPropertyName("id")]
     [JsonPropertyOrder(1)]
     public Uri? Id { get; set; }
     
     /// <summary>
-    /// 
+    /// The error text
     /// </summary>
+    [JsonPropertyName("message")]
+    [JsonPropertyOrder(2)]
     public required string Message { get; set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Import/ImportJob.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Import/ImportJob.cs
@@ -68,6 +68,7 @@ public class ImportJob : Resource
     /// permitted set. The name property of the container may be any UTF-8 characters, and can be used to preserve an
     /// original directory name.
     /// </summary>
+    [JsonPropertyName("containersToAdd")]
     [JsonPropertyOrder(610)]
     public List<Container> ContainersToAdd { get; set; } = [];
 
@@ -79,6 +80,7 @@ public class ImportJob : Resource
     /// cannot be obtained by the API from METS file information or from S3 metadata. All API-generated jobs will
     /// include this field. 
     /// </summary>
+    [JsonPropertyName("binariesToAdd")]
     [JsonPropertyOrder(620)]
     public List<Binary> BinariesToAdd { get; set; } = [];
 
@@ -86,12 +88,14 @@ public class ImportJob : Resource
     /// A list of containers to remove. id is the only required property. The Containers must either be already empty,
     /// or only contain Binaries mentioned in the binariesToDelete property of the same ImportJob.
     /// </summary>
+    [JsonPropertyName("containersToDelete")]
     [JsonPropertyOrder(630)]
     public List<Container> ContainersToDelete { get; set; } = [];
 
     /// <summary>
     /// A list of binaries to remove. id is the only required property.
     /// </summary>
+    [JsonPropertyName("binariesToDelete")]
     [JsonPropertyOrder(640)]
     public List<Binary> BinariesToDelete { get; set; } = [];
 
@@ -102,6 +106,7 @@ public class ImportJob : Resource
     /// supplied name. The location must be an S3 key within the Deposit. The digest is only required if the SHA256
     /// cannot be obtained by the API from METS file information or from S3 metadata.
     /// </summary>
+    [JsonPropertyName("binariesToPatch")]
     [JsonPropertyOrder(650)]
     public List<Binary> BinariesToPatch { get; set; } = [];
     

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Import/ImportJob.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Import/ImportJob.cs
@@ -58,6 +58,7 @@ public class ImportJob : Resource
     /// Always provided when you ask the API to generate an ImportJob as a diff and the ArchivalGroup already exists.
     /// May be null for a new object
     /// </summary>
+    [JsonPropertyName("sourceVersion")]
     [JsonPropertyOrder(540)]
     public ObjectVersion? SourceVersion { get; set; }  // TODO - name of this thing
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/PipelineOptions.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/PipelineOptions.cs
@@ -3,4 +3,5 @@ public class PipelineOptions
 {
     public required string PipelineJobTopicArn { get; set; }
     public required string PipelineJobQueue { get; set; }
+    public double PipelineJobsCleanupMinutes { get; set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
@@ -61,4 +61,8 @@ public class ProcessPipelineResult : Resource
     [JsonPropertyName("runUser")]
     public string? RunUser { get; set; }
 
+    [JsonPropertyOrder(512)]
+    [JsonPropertyName("cleanupProcessJob")]
+    public bool CleanupProcessJob { get; set; } = false;
+
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
@@ -72,7 +72,7 @@ public class ProcessPipelineResult : Resource
     public string? ArchivalGroup { get; set; }
 
     [JsonPropertyOrder(511)]
-    [JsonPropertyName("runUSer")]
+    [JsonPropertyName("runUser")]
     public string? RunUser { get; set; }
 
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
@@ -30,13 +30,6 @@ public class ProcessPipelineResult : Resource
     /// <summary>
     /// Timestamp indicating when the API finished processing the job. Will be null/missing until then.
     /// </summary>
-    [JsonPropertyName("dateSubmitted")]
-    [JsonPropertyOrder(610)]
-    public DateTime? DateSubmitted { get; set; }
-
-    /// <summary>
-    /// Timestamp indicating when the API finished processing the job. Will be null/missing until then.
-    /// </summary>
     [JsonPropertyName("dateBegun")]
     [JsonPropertyOrder(611)]
     public DateTime? DateBegun { get; set; }
@@ -47,13 +40,6 @@ public class ProcessPipelineResult : Resource
     [JsonPropertyName("dateFinished")]
     [JsonPropertyOrder(610)]
     public DateTime? DateFinished { get; set; }
-
-    /// <summary>
-    /// Timestamp indicating when the API finished processing the job. Will be null/missing until then.
-    /// </summary>
-    [JsonPropertyName("lastUpdated")]
-    [JsonPropertyOrder(610)]
-    public DateTime? LastUpdated { get; set; }
 
 
     /// <summary>
@@ -67,9 +53,9 @@ public class ProcessPipelineResult : Resource
     /// <summary>
     /// Also included for convenience, the repository object the changes specified in the job are being applied to
     /// </summary>
-    [JsonPropertyName("archivalGroup")]
+    [JsonPropertyName("archivalGroupName")]
     [JsonPropertyOrder(510)]
-    public string? ArchivalGroup { get; set; }
+    public string? ArchivalGroupName { get; set; }
 
     [JsonPropertyOrder(511)]
     [JsonPropertyName("runUser")]

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/PipelineApi/ProcessPipelineResult.cs
@@ -69,7 +69,7 @@ public class ProcessPipelineResult : Resource
     /// </summary>
     [JsonPropertyName("archivalGroup")]
     [JsonPropertyOrder(510)]
-    public required string? ArchivalGroup { get; set; }
+    public string? ArchivalGroup { get; set; }
 
     [JsonPropertyOrder(511)]
     [JsonPropertyName("runUSer")]

--- a/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/Requests/RunPipeline.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Features/Preservation/Requests/RunPipeline.cs
@@ -1,38 +1,19 @@
-﻿using DigitalPreservation.Common.Model.PipelineApi;
-using DigitalPreservation.Common.Model.PreservationApi;
+﻿using DigitalPreservation.Common.Model.PreservationApi;
 using DigitalPreservation.Common.Model.Results;
-using DigitalPreservation.Common.Model.Storage.Ocfl;
 using MediatR;
 using Preservation.Client;
 
 namespace DigitalPreservation.UI.Features.Preservation.Requests;
 
-public class RunPipeline(Deposit deposit, string runUser, string jobId, string depositId) : IRequest<Result>
+public class RunPipeline(Deposit deposit) : IRequest<Result>
 {
     public Deposit Deposit { get; } = deposit;
-    public string? RunUser { get; set; } = runUser;
-    public string JobId { get; set; } = jobId;
-    public string? DepositId { get; set; } = depositId;
-
 }
 
-public class RunPipelineHandler(IPreservationApiClient preservationApiClient, ILogger<RunPipelineHandler> logger) : IRequestHandler<RunPipeline, Result>
+public class RunPipelineHandler(IPreservationApiClient preservationApiClient) : IRequestHandler<RunPipeline, Result>
 {
     public async Task<Result> Handle(RunPipeline request, CancellationToken cancellationToken)
     {
-        var pipelineDeposit = new PipelineDeposit
-        {
-            Id = request.JobId,
-            Status = PipelineJobStates.Waiting,
-            DepositId = request.DepositId,
-            RunUser = request.RunUser
-        };
-        
-        var logResult = await preservationApiClient.LogPipelineRunStatus(pipelineDeposit, cancellationToken);
-
-        if(logResult.Failure)
-            logger.LogError("Failed to log the waiting status for jobId {jobId} for deposit {depositId}", request.JobId, request.DepositId);
-        return await preservationApiClient.RunPipeline(request.Deposit, request.RunUser, request.JobId, cancellationToken);
+        return await preservationApiClient.RunPipeline(request.Deposit, cancellationToken);
     }
-
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -24,10 +24,11 @@
     ViewData["Title"] = Model.GetDisplayTitle();
     ViewData["section"] = "deposits";
 
-    var (jobs, jobRunning, _) = await Model.GetCleanedPipelineJobsRunning();
-    if (jobRunning)
+    var jobRunning = false;
+    if (Model.RunningPipelineJob != null)
     {
         TempData.Remove("MisMatchCount");
+        jobRunning = true;
     }
 }
 
@@ -51,7 +52,7 @@
                         @if (Model.Deposit?.LockedBy != null)
                         {
                             <li>
-                                <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="ReleaseLock">
+                                <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ReleaseLock">
                                     <svg class="bi"><use xlink:href="#unlock"/></svg><span class="ms-2">Release lock</span>
                                 </button>
                             </li>
@@ -59,29 +60,29 @@
                         else
                         {
                             <li>
-                                <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="Lock">
+                                <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="Lock">
                                     <svg class="bi"><use xlink:href="#lock"/></svg><span class="ms-2">Lock deposit</span>
                                 </button>
                             </li>
                         }
                         
                         <li>
-                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="RunPipeline">
+                            <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="RunPipeline">
                                 <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Run pipeline</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@(!jobRunning)" class="dropdown-item text-primary" type="submit" asp-page-handler="ForceCompletePipelineRun">
+                            <button disabled="@(!jobRunning)" class="dropdown-item @(!jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ForceCompletePipelineRun">
                                 <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Stop pipeline run</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="ValidateStorage">
+                            <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ValidateStorage">
                                 <svg class="bi"><use xlink:href="#database-check"/></svg><span class="ms-2">Validate storage</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="RebuildDepositFileSystem" id="rebuildMets">
+                            <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="RebuildDepositFileSystem" id="rebuildMets">
                                 <svg class="bi"><use xlink:href="#arrow-clockwise"/></svg><span class="ms-2">Refresh storage</span>
                             </button>
                         </li>
@@ -93,17 +94,17 @@
                         </li>
                         <li><hr class="dropdown-divider"></li>
                         <li>
-                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="selectNonMets">
+                            <button @(jobRunning ? " disabled=disabled" : "") class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="button" id="selectNonMets">
                                 <svg class="bi"><use xlink:href="#check-square"/></svg><span class="ms-2">Select all non-METS</span>
                             </button>
                         </li>
                         <li>
-                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="addSelectionToMets" data-bs-toggle="modal" data-bs-target="#addSelectionToMetsModal">
+                            <button @(jobRunning ? " disabled=disabled" : "") class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="button" id="addSelectionToMets" data-bs-toggle="modal" data-bs-target="#addSelectionToMetsModal">
                                 <svg class="bi"><use xlink:href="#bookmark-plus"/></svg><span class="ms-2">Add selected to METS</span>
                             </button>
                         </li>
                         <li>
-                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" id="deleteSelection" data-bs-toggle="modal" data-bs-target="#deleteSelectionModal">
+                            <button @(jobRunning ? " disabled=disabled" : "") class="dropdown-item @(jobRunning ? "text-secondary" : "text-danger")" type="button" id="deleteSelection" data-bs-toggle="modal" data-bs-target="#deleteSelectionModal">
                                 <svg class="bi"><use xlink:href="#check-square"/></svg><span class="ms-2">Delete selected...</span>
                             </button>
                         </li>
@@ -115,7 +116,7 @@
                         </li>
                         <li><hr class="dropdown-divider"></li>
                         <li>
-                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" data-bs-toggle="modal" data-bs-target="#deleteDepositModal">
+                            <button @(jobRunning ? " disabled=disabled" : "") class="dropdown-item @(jobRunning ? "text-secondary" : "text-danger")" type="button" data-bs-toggle="modal" data-bs-target="#deleteDepositModal">
                                 <svg class="bi"><use xlink:href="#trash"/></svg><span class="ms-2">Delete Deposit</span>
                             </button>
                         </li>
@@ -415,7 +416,7 @@
                 <h3>Pipeline Jobs</h3>
 
                 @{
-                    if (jobs is { Count: 0 })
+                    if (Model.PipelineJobResults is { Count: 0 })
                     {
                         <p>There are no submitted pipeline jobs for this Deposit.</p>
                     }
@@ -434,31 +435,30 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                @if (jobs != null)
-                        {
-                            foreach (var result in jobs)
-                            {
-                                <tr>
-                                    <td aria-label="td-job-id">@result.JobId</td>
-                                    <td aria-label="td-status">@result.Status</td>
-                                    <td aria-label="td-date-begun">@result.DateBegun.GetDateDisplay()</td>
-                                    <td aria-label="td-date-finished">@result.DateFinished.GetDateDisplay()</td>
-                                    <td aria-label="td-run-user">@result.RunUser</td>
-                                    <td aria-label="td-errors" class="text-danger">
+                                @{
+                                    foreach (var result in Model.PipelineJobResults)
+                                    {
+                                        <tr>
+                                            <td aria-label="td-job-id">@result.JobId</td>
+                                            <td aria-label="td-status">@result.Status</td>
+                                            <td aria-label="td-date-begun">@result.DateBegun.GetDateDisplay()</td>
+                                            <td aria-label="td-date-finished">@result.DateFinished.GetDateDisplay()</td>
+                                            <td aria-label="td-run-user">@result.RunUser</td>
+                                            <td aria-label="td-errors" class="text-danger">
 
-                                        @if (result.Errors != null && result.Errors.Any())
-                                        {
-                                            foreach (var line in result.Errors.Select(e => e.Message))
-                                            {
-                                                <p>@line</p>
-                                            }
-                                        }
+                                                @if (result.Errors != null && result.Errors.Any())
+                                                {
+                                                    foreach (var line in result.Errors.Select(e => e.Message))
+                                                    {
+                                                        <p>@line</p>
+                                                    }
+                                                }
 
-                                    </td>
-                                </tr>
-                            }
-                        }
-                        </tbody>
+                                            </td>
+                                        </tr>
+                                    }
+                                }
+                                </tbody>
                             </table>
                         </div>
                     }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -4,9 +4,7 @@
 @using DigitalPreservation.Common.Model.Transit
 @using DigitalPreservation.Core.Auth
 @using DigitalPreservation.UI.Features
-@using DigitalPreservation.UI.TagHelpers
 @using DigitalPreservation.Utils
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model DepositModel
 
 @functions {
@@ -26,15 +24,11 @@
     ViewData["Title"] = Model.GetDisplayTitle();
     ViewData["section"] = "deposits";
 
-    var (jobs, jobRunning, _) = Model.PipelineJobsRunning();
-    await Model.CleanupPipelineRunsForDeposit(jobs);
-
+    var (jobs, jobRunning, _) = await Model.GetCleanedPipelineJobsRunning();
     if (jobRunning)
     {
         TempData.Remove("MisMatchCount");
     }
-
-    var pipelineRunStarted = jobRunning || (TempData["Valid"] != null && TempData["Valid"]!.ToString()!.ToLower().Contains("deposit locked and pipeline running"));
 }
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
@@ -57,7 +51,7 @@
                         @if (Model.Deposit?.LockedBy != null)
                         {
                             <li>
-                                <button disabled="@pipelineRunStarted" class="dropdown-item text-primary" type="submit" asp-page-handler="ReleaseLock">
+                                <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="ReleaseLock">
                                     <svg class="bi"><use xlink:href="#unlock"/></svg><span class="ms-2">Release lock</span>
                                 </button>
                             </li>
@@ -65,29 +59,29 @@
                         else
                         {
                             <li>
-                                <button disabled="@pipelineRunStarted" class="dropdown-item text-primary" type="submit" asp-page-handler="Lock">
+                                <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="Lock">
                                     <svg class="bi"><use xlink:href="#lock"/></svg><span class="ms-2">Lock deposit</span>
                                 </button>
                             </li>
                         }
                         
                         <li>
-                            <button disabled="@pipelineRunStarted" class="dropdown-item text-primary" type="submit" asp-page-handler="RunPipeline">
+                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="RunPipeline">
                                 <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Run pipeline</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@(!pipelineRunStarted)" class="dropdown-item text-primary" type="submit" asp-page-handler="ForceCompletePipelineRun">
+                            <button disabled="@(!jobRunning)" class="dropdown-item text-primary" type="submit" asp-page-handler="ForceCompletePipelineRun">
                                 <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Stop pipeline run</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@pipelineRunStarted" class="dropdown-item text-primary" type="submit" asp-page-handler="ValidateStorage">
+                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="ValidateStorage">
                                 <svg class="bi"><use xlink:href="#database-check"/></svg><span class="ms-2">Validate storage</span>
                             </button>
                         </li>
                         <li>
-                            <button disabled="@pipelineRunStarted" class="dropdown-item text-primary" type="submit" asp-page-handler="RebuildDepositFileSystem" id="rebuildMets">
+                            <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="RebuildDepositFileSystem" id="rebuildMets">
                                 <svg class="bi"><use xlink:href="#arrow-clockwise"/></svg><span class="ms-2">Refresh storage</span>
                             </button>
                         </li>
@@ -99,17 +93,17 @@
                         </li>
                         <li><hr class="dropdown-divider"></li>
                         <li>
-                            <button @(!pipelineRunStarted ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="selectNonMets">
+                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="selectNonMets">
                                 <svg class="bi"><use xlink:href="#check-square"/></svg><span class="ms-2">Select all non-METS</span>
                             </button>
                         </li>
                         <li>
-                            <button @(!pipelineRunStarted ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="addSelectionToMets" data-bs-toggle="modal" data-bs-target="#addSelectionToMetsModal">
+                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-primary" type="button" id="addSelectionToMets" data-bs-toggle="modal" data-bs-target="#addSelectionToMetsModal">
                                 <svg class="bi"><use xlink:href="#bookmark-plus"/></svg><span class="ms-2">Add selected to METS</span>
                             </button>
                         </li>
                         <li>
-                            <button @(!pipelineRunStarted ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" id="deleteSelection" data-bs-toggle="modal" data-bs-target="#deleteSelectionModal">
+                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" id="deleteSelection" data-bs-toggle="modal" data-bs-target="#deleteSelectionModal">
                                 <svg class="bi"><use xlink:href="#check-square"/></svg><span class="ms-2">Delete selected...</span>
                             </button>
                         </li>
@@ -121,7 +115,7 @@
                         </li>
                         <li><hr class="dropdown-divider"></li>
                         <li>
-                            <button @(!pipelineRunStarted ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" data-bs-toggle="modal" data-bs-target="#deleteDepositModal">
+                            <button @(!jobRunning ? "" : " disabled=disabled") class="dropdown-item text-danger" type="button" data-bs-toggle="modal" data-bs-target="#deleteDepositModal">
                                 <svg class="bi"><use xlink:href="#trash"/></svg><span class="ms-2">Delete Deposit</span>
                             </button>
                         </li>
@@ -175,7 +169,7 @@
         </div>
     }
 
-    @if (!pipelineRunStarted && TempData["MisMatchCount"] != null)
+    @if (!jobRunning && TempData["MisMatchCount"] != null)
     {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
             <p>@Html.Raw(TempData["MisMatchCount"]) files have metadata not present in METS.</p>
@@ -397,8 +391,7 @@
                 <h3>Pipeline Jobs</h3>
 
                 @{
-                    var pipelineJobResults = jobs;
-                    if (pipelineJobResults is { Count: 0 })
+                    if (jobs is { Count: 0 })
                     {
                         <p>There are no submitted pipeline jobs for this Deposit.</p>
                     }
@@ -417,9 +410,9 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                @if (pipelineJobResults != null)
+                                @if (jobs != null)
                         {
-                            foreach (var result in pipelineJobResults)
+                            foreach (var result in jobs)
                             {
                                 <tr>
                                     <td aria-label="td-job-id">@result.JobId</td>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -67,10 +67,8 @@ public class DepositModel(
                     ArchivalGroupTestWarning = testArchivalGroupResult.ErrorMessage;
                 }
             }
-
-            var (jobs, runningJob) = await GetCleanedPipelineJobsRunning();
-            PipelineJobResults = jobs;
-            RunningPipelineJob = runningJob;
+            
+            (PipelineJobResults, RunningPipelineJob) = await GetCleanedPipelineJobsRunning();
 
             if (Deposit.Status != DepositStates.Exporting)
             {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -330,9 +330,6 @@ public class DepositModel(
     {
         if (await BindDeposit(id))
         {
-            //SET job id here
-            var jobId = identityMinter.MintIdentity("PipelineJob");
-            var runUser = User.GetCallerIdentity();
             var result = await mediator.Send(new LockDeposit(Deposit!));
             var result1 = await mediator.Send(new RunPipeline(Deposit!));
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -1,7 +1,6 @@
 ﻿using Amazon.S3.Util;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.DepositHelpers;
-using DigitalPreservation.Common.Model.Identity;
 using DigitalPreservation.Common.Model.Import;
 using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.Common.Model.PreservationApi;
@@ -24,9 +23,7 @@ public class DepositModel(
     IMediator mediator, 
     IOptions<PreservationOptions> options,
     WorkspaceManagerFactory workspaceManagerFactory,
-    IPreservationApiClient preservationApiClient,
-    ILogger<DepositModel> logger,
-    IIdentityMinter identityMinter) : PageModel
+    IPreservationApiClient preservationApiClient) : PageModel
 {
     public required string Id { get; set; }
     public required WorkspaceManager WorkspaceManager { get; set; }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -576,6 +576,7 @@ public class DepositModel(
                 Errors = "Cleaned up as previous processing did not complete"
             };
 
+            var result = await mediator.Send(new ReleaseLock(Deposit!));
             await preservationApiClient.LogPipelineRunStatus(pipelineDeposit, CancellationToken.None);
         }
         

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -326,7 +326,7 @@ public class DepositModel(
             var jobId = identityMinter.MintIdentity("PipelineJob");
             var runUser = User.GetCallerIdentity();
             var result = await mediator.Send(new LockDeposit(Deposit!));
-            var result1 = await mediator.Send(new RunPipeline(Deposit!, runUser, jobId, id));
+            var result1 = await mediator.Send(new RunPipeline(Deposit!));
 
             if (result.Success && result1.Success)
             {
@@ -351,10 +351,9 @@ public class DepositModel(
     {
         if (await BindDeposit(id))
         {
-            var runUser = User.GetCallerIdentity();
             var (_, _, jobId) = PipelineJobsRunning();
             var result = await mediator.Send(new ReleaseLock(Deposit!));
-            var result1 = await mediator.Send(new ForceCompletePipeline(Deposit!, runUser, jobId, id));
+            var result1 = await mediator.Send(new ForceCompletePipeline(jobId, id, User));
             if (result.Success && result1.Success)
             {
                 TempData["Valid"] = "Force complete of pipeline succeeded and lock released.";
@@ -595,7 +594,7 @@ public class DepositModel(
                     Errors = "Cleaned up as previous processing did not complete"
                 };
 
-                var logResult = await preservationApiClient.LogPipelineRunStatus(pipelineDeposit, new CancellationToken());
+                var logResult = await preservationApiClient.LogPipelineRunStatus(pipelineDeposit, CancellationToken.None);
 
                 if (logResult.Failure)
                     logger.LogError(

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -1,5 +1,6 @@
 ﻿using DigitalPreservation.Common.Model.Identity;
 using DigitalPreservation.Common.Model.Mets;
+using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.CommonApiClient;
 using DigitalPreservation.Core.Configuration;
 using DigitalPreservation.Core.Web.Headers;
@@ -55,7 +56,7 @@ try
 
 
     builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, options => options.Events = new RejectSessionCookieWhenAccountNotInCacheEvents());
-    
+    builder.Services.Configure<PipelineOptions>(builder.Configuration.GetSection("PipelineOptions"));
     // <ms_docref_add_default_controller_for_sign-in-out>
     builder.Services.AddRazorPages().AddMvcOptions(options =>
     {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -96,7 +96,6 @@ try
         .AddUIHealthChecks();
 
     builder.Services.AddControllers();
-    builder.Services.AddSingleton<IIdentityMinter, IdentityMinter>();
 
     var app = builder.Build();
     app

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -46,5 +46,8 @@
     "QueryTemplate": "/imu/utilities/getIIIFData.php?pid=",
     "TimeoutMs": 5000,
     "ApiKeyHeader": "X-API-KEY"
+  },
+  "PipelineOptions": {
+    "PipelineJobsCleanupMinutes": 5
   }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -48,6 +48,6 @@
     "ApiKeyHeader": "X-API-KEY"
   },
   "PipelineOptions": {
-    "PipelineJobsCleanupMinutes": 1440
+    "PipelineJobsCleanupMinutes": 5
   }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -48,6 +48,6 @@
     "ApiKeyHeader": "X-API-KEY"
   },
   "PipelineOptions": {
-    "PipelineJobsCleanupMinutes": 10
+    "PipelineJobsCleanupMinutes": 1440
   }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -48,6 +48,6 @@
     "ApiKeyHeader": "X-API-KEY"
   },
   "PipelineOptions": {
-    "PipelineJobsCleanupMinutes": 5
+    "PipelineJobsCleanupMinutes": 10
   }
 }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/PipelineController.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/PipelineController.cs
@@ -3,14 +3,11 @@ using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.Core.Web;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using Pipeline.API.Config;
 using Pipeline.API.Features.Pipeline.Models;
 using Pipeline.API.Features.Pipeline.Requests;
 using Pipeline.API.Middleware;
 using System.Diagnostics;
 using DigitalPreservation.Common.Model.Results;
-using Preservation.Client;
 
 namespace Pipeline.API.Features.Pipeline;
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/PipelineJobExecutorService.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/PipelineJobExecutorService.cs
@@ -17,6 +17,8 @@ public class PipelineJobExecutorService(
             if (transaction == null || !transaction.DepositName.HasText()) continue; 
             using var scope = serviceScopeFactory.CreateScope();
             var processor = scope.ServiceProvider.GetRequiredService<PipelineJobRunner>();
+
+            logger.LogInformation("About to execute the pipeline run for deposit {deposit}", transaction.DepositName);
             await processor.Execute(transaction, cancellationToken);
         }
     }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -40,9 +40,6 @@ public class ProcessPipelineJobHandler(
     private const string BrunnhildeFolderName = "brunnhilde";
     private readonly string[] filesToIgnore = ["tree.txt"];
     private StreamReader? _streamReader;
-    private Guid BrunnhildeProcessId = Guid.Parse("6BFB4FE2-E17E-423C-A889-426A0ADF4DF1");
-    private Guid MonitorForceCompleteId = Guid.Parse("97BD55BA-B039-460F-BDC9-34DAD57920C5");
-    private Dictionary<Guid, CancellationTokenSource> m_TokensCatalog = new();
 
     private int _processId;
     private readonly System.Timers.Timer ProcessTimer = new(10000);
@@ -270,15 +267,6 @@ public class ProcessPipelineJobHandler(
             }; 
         }
 
-        //var timer = new Timer()
-        //var tokenSourceBrunnhilde = new CancellationTokenSource();
-        //m_TokensCatalog.Add(BrunnhildeProcessId, tokenSourceBrunnhilde);
-        //var cancellationTokenBrunnhilde = tokenSourceBrunnhilde.Token;
-
-        //var tokenSourceForceComplete = new CancellationTokenSource();
-        //m_TokensCatalog.Add(MonitorForceCompleteId, tokenSourceForceComplete);
-        //var cancellationTokenMonitorForceComplete = tokenSourceForceComplete.Token;
-
         try
         {
             //var runProcessResult = await RunProcessAsync(objectPath, metadataProcessPath, cancellationToken);
@@ -288,10 +276,14 @@ public class ProcessPipelineJobHandler(
             process.StartInfo.Arguments = $"  {brunnhildeOptions.Value.PathToBrunnhilde} --hash sha256 {objectPath} {metadataProcessPath}  --overwrite ";
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
+
+            logger.LogInformation("Brunnhilde process about to be started {date}", DateTime.Now);
             var started = process.Start();
+
 
             if (started)
             {
+                logger.LogInformation("Brunnhilde process started {date}", DateTime.Now);
                 _processId = process.Id;
             }
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -138,7 +138,7 @@ public class ProcessPipelineJobHandler(
     
     public async Task<Result> Handle(ExecutePipelineJob request, CancellationToken cancellationToken)
     {
-        await CleanupPipelineRunsForDeposit(request);
+        //await CleanupPipelineRunsForDeposit(request);
 
         var workspaceResult = await GetWorkspaceManager(request, true, cancellationToken);
         if (workspaceResult.Failure || workspaceResult.Value?.Deposit == null)

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -236,6 +236,7 @@ public class ProcessPipelineJobHandler(
 
         if (forceComplete)
         {
+            await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
             if (!cleanupProcessJob)
             {
                 return new ProcessPipelineResult
@@ -250,7 +251,7 @@ public class ProcessPipelineJobHandler(
                 Status = PipelineJobStates.CompletedWithErrors,
                 Errors = [new Error { Message = "Cleaned up as previous processing did not complete" }],
                 CleanupProcessJob = true
-            }; ;
+            }; 
         }
 
         var start = new ProcessStartInfo
@@ -294,6 +295,7 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteOnSuccess)
             {
+                await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobOnSuccess)
                 {
                     return new ProcessPipelineResult
@@ -341,6 +343,7 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteAfterDelete)
             {
+                await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobAfterDelete)
                 {
                     return new ProcessPipelineResult
@@ -379,6 +382,7 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteAfterUploads)
             {
+                await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobAfterUploads)
                 {
                     return new ProcessPipelineResult
@@ -522,6 +526,7 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteBeforeUpload)
             {
+                await TryReleaseLock(request, deposit, cancellationToken);
                 return (createSubFolderResult: [], uploadFileResult: []);
             }
 
@@ -544,6 +549,7 @@ public class ProcessPipelineJobHandler(
                 // At this point we have not modified the METS file, the ETag for this workspace is still valid
                 if (forceCompleteDirectoryUpload)
                 {
+                    await TryReleaseLock(request, deposit, cancellationToken);
                     return (createSubFolderResult: [], uploadFileResult: []);
                 }
 
@@ -562,6 +568,7 @@ public class ProcessPipelineJobHandler(
                 // At this point we have not modified the METS file, the ETag for this workspace is still valid
                 if (forceCompleteFileUpload)
                 {
+                    await TryReleaseLock(request, deposit, cancellationToken);
                     return (createSubFolderResult: [], uploadFileResult: []);
                 }
 
@@ -633,6 +640,7 @@ public class ProcessPipelineJobHandler(
 
         if (forceCompleteUploadS3)
         {
+            await TryReleaseLock(request, deposit, cancellationToken);
             return null;
         }
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -820,7 +820,6 @@ public class ProcessPipelineJobHandler(
             x => x.JobId == request.JobIdentifier && x.Status == PipelineJobStates.CompletedWithErrors);
         var forceComplete = job != null;
 
-        //TODO: check if job is cleanup process job
         var cleanupProcessJob = job is { Errors: not null } &&
                                 job.Errors.Any(x => x.Message.Contains("Cleaned up as previous processing did not complete"));
         

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -143,11 +143,15 @@ public class ProcessPipelineJobHandler(
             var (forceComplete, _) = await CheckIfForceComplete(request, workspace.Deposit, cancellationToken);
             if (forceComplete)
             {
+                logger.LogInformation("Pipeline job run {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
+                
                 return Result.FailNotNull<Result>(ErrorCodes.UnknownError,
                     $"Pipeline job run {request.JobIdentifier} for deposit {request.DepositId} has been force completed.");
             }
 
             await UpdateJobStatus(request, PipelineJobStates.Running, cancellationToken);
+
+            logger.LogInformation("About to execute Brunnhilde for pipeline job run {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
             var result = await ExecuteBrunnhilde(request, workspace, cancellationToken);
 
             if(!result.CleanupProcessJob)
@@ -239,6 +243,7 @@ public class ProcessPipelineJobHandler(
             await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
             if (!cleanupProcessJob)
             {
+                logger.LogInformation("Exited as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
                 return new ProcessPipelineResult
                 {
                     Status = PipelineJobStates.CompletedWithErrors,
@@ -246,6 +251,7 @@ public class ProcessPipelineJobHandler(
                 };
             }
 
+            logger.LogInformation("Exited as the pipeline job run has been cleaned up as previous processing did not complete {JobIdentifier} for deposit {DepositId}.", request.JobIdentifier, request.DepositId);
             return new ProcessPipelineResult
             {
                 Status = PipelineJobStates.CompletedWithErrors,
@@ -298,6 +304,7 @@ public class ProcessPipelineJobHandler(
                 await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobOnSuccess)
                 {
+                    logger.LogInformation("Exited as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
                     return new ProcessPipelineResult
                     {
                         Status = PipelineJobStates.CompletedWithErrors,
@@ -305,6 +312,7 @@ public class ProcessPipelineJobHandler(
                     };
                 }
 
+                logger.LogInformation("Exited as the pipeline job run has been cleaned up as previous processing did not complete {JobIdentifier} for deposit {DepositId}.", request.JobIdentifier, request.DepositId);
                 return new ProcessPipelineResult
                 {
                     Status = PipelineJobStates.CompletedWithErrors,
@@ -346,6 +354,7 @@ public class ProcessPipelineJobHandler(
                 await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobAfterDelete)
                 {
+                    logger.LogInformation("Exited as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
                     return new ProcessPipelineResult
                     {
                         Status = PipelineJobStates.CompletedWithErrors,
@@ -353,6 +362,7 @@ public class ProcessPipelineJobHandler(
                     };
                 }
 
+                logger.LogInformation("Exited as the pipeline job run has been cleaned up as previous processing did not complete {JobIdentifier} for deposit {DepositId}.", request.JobIdentifier, request.DepositId);
                 return new ProcessPipelineResult
                 {
                     Status = PipelineJobStates.CompletedWithErrors,
@@ -385,6 +395,7 @@ public class ProcessPipelineJobHandler(
                 await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobAfterUploads)
                 {
+                    logger.LogInformation("Exited as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
                     return new ProcessPipelineResult
                     {
                         Status = PipelineJobStates.CompletedWithErrors,
@@ -392,6 +403,7 @@ public class ProcessPipelineJobHandler(
                     };
                 }
 
+                logger.LogInformation("Exited as the pipeline job run has been cleaned up as previous processing did not complete {JobIdentifier} for deposit {DepositId}.", request.JobIdentifier, request.DepositId);
                 return new ProcessPipelineResult
                 {
                     Status = PipelineJobStates.CompletedWithErrors,
@@ -527,6 +539,7 @@ public class ProcessPipelineJobHandler(
             if (forceCompleteBeforeUpload)
             {
                 await TryReleaseLock(request, deposit, cancellationToken);
+                logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
                 return (createSubFolderResult: [], uploadFileResult: []);
             }
 
@@ -550,6 +563,7 @@ public class ProcessPipelineJobHandler(
                 if (forceCompleteDirectoryUpload)
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
+                    logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
                     return (createSubFolderResult: [], uploadFileResult: []);
                 }
 
@@ -569,6 +583,7 @@ public class ProcessPipelineJobHandler(
                 if (forceCompleteFileUpload)
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
+                    logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
                     return (createSubFolderResult: [], uploadFileResult: []);
                 }
 
@@ -640,6 +655,7 @@ public class ProcessPipelineJobHandler(
 
         if (forceCompleteUploadS3)
         {
+            logger.LogInformation("Exited UploadFileToDepositOnS3() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
             await TryReleaseLock(request, deposit, cancellationToken);
             return null;
         }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -45,7 +45,7 @@ public class ProcessPipelineJobHandler(
     private Dictionary<Guid, CancellationTokenSource> m_TokensCatalog = new();
 
     private int _processId;
-    private System.Timers.Timer ProcessTimer = new System.Timers.Timer(3000);
+    private readonly System.Timers.Timer ProcessTimer = new(3000);
 
     /// <summary>
     /// Reacquiring a new WorkspaceManager is not expensive, but refreshing the file system is
@@ -271,13 +271,13 @@ public class ProcessPipelineJobHandler(
         }
 
         //var timer = new Timer()
-        var tokenSourceBrunnhilde = new CancellationTokenSource();
-        m_TokensCatalog.Add(BrunnhildeProcessId, tokenSourceBrunnhilde);
-        var cancellationTokenBrunnhilde = tokenSourceBrunnhilde.Token;
+        //var tokenSourceBrunnhilde = new CancellationTokenSource();
+        //m_TokensCatalog.Add(BrunnhildeProcessId, tokenSourceBrunnhilde);
+        //var cancellationTokenBrunnhilde = tokenSourceBrunnhilde.Token;
 
-        var tokenSourceForceComplete = new CancellationTokenSource();
-        m_TokensCatalog.Add(MonitorForceCompleteId, tokenSourceForceComplete);
-        var cancellationTokenMonitorForceComplete = tokenSourceForceComplete.Token;
+        //var tokenSourceForceComplete = new CancellationTokenSource();
+        //m_TokensCatalog.Add(MonitorForceCompleteId, tokenSourceForceComplete);
+        //var cancellationTokenMonitorForceComplete = tokenSourceForceComplete.Token;
 
         try
         {
@@ -317,7 +317,7 @@ public class ProcessPipelineJobHandler(
 
         if (_streamReader == null)
         {
-            logger.LogError("Issue executing Brunnhilde process: process?.StandardOutput is null");
+            logger.LogError("Steam reader is null Issue executing Brunnhilde process: process?.StandardOutput is null");
 
             logger.LogError("Caught error in PipelineJob handler for job id {jobIdentifier} and deposit {depositId}",
                 request.JobIdentifier, request.DepositId);
@@ -942,7 +942,7 @@ public class ProcessPipelineJobHandler(
     }
 
     // This method is used only for internal function call.
-    private async Task<int> RunProcessAsync(Process process, CancellationToken cancelToken)
+    private Task<int> RunProcessAsync(Process process, CancellationToken cancelToken)
     {
         var tcs = new TaskCompletionSource<int>();
         
@@ -982,7 +982,7 @@ public class ProcessPipelineJobHandler(
             //await m_TokensCatalog[MonitorForceCompleteId].CancelAsync();
         }
 
-        return tcs.Task.Id;
+        return tcs.Task;
     }
 
     private async Task MonitorForceComplete(ExecutePipelineJob request, Deposit deposit, CancellationToken cancellationToken)
@@ -1020,7 +1020,7 @@ public class ProcessPipelineJobHandler(
             var (forceComplete, _) = await CheckIfForceComplete(request, deposit, cancellationToken);
             if (forceComplete)
             {
-                //_streamReader = null;
+                _streamReader = null;
 
                 try
                 {

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -295,6 +295,8 @@ public class ProcessPipelineJobHandler(
                 _processId = process.Id;
             }
 
+            _streamReader = process?.StandardOutput;
+
             //var processTimer = new System.Timers.Timer(3000);
             ProcessTimer.Elapsed += (sender, e) => CheckIfProcessRunning(sender, e, request, workspaceManager.Deposit, cancellationToken);
             //processTimer.Elapsed += CheckIfProcessRunning;
@@ -351,7 +353,6 @@ public class ProcessPipelineJobHandler(
                 Errors = [new Error { Message = $"Pipeline job run {request.JobIdentifier} for {request.DepositId} has issue with Brunnhilde output stream reader being null" }]
             };
         }
-
 
         logger.LogInformation("_streamReader {streamReader}",_streamReader);
         var result = await _streamReader.ReadToEndAsync(CancellationToken.None);
@@ -1019,7 +1020,7 @@ public class ProcessPipelineJobHandler(
             var (forceComplete, _) = await CheckIfForceComplete(request, deposit, cancellationToken);
             if (forceComplete)
             {
-                _streamReader = null;
+                //_streamReader = null;
 
                 try
                 {

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -296,7 +296,7 @@ public class ProcessPipelineJobHandler(
             var (forceCompleteStreamReader, cleanupProcessJobStreamReader) = await CheckIfForceComplete(request, workspaceManager.Deposit, cancellationToken);
             if (forceCompleteStreamReader)
             {
-                await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
+                //await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
                 if (!cleanupProcessJobStreamReader)
                 {
                     logger.LogInformation("Exited as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId} has been force completed.", request.JobIdentifier, request.DepositId);
@@ -323,7 +323,9 @@ public class ProcessPipelineJobHandler(
             };
         }
 
-        var result = await _streamReader!.ReadToEndAsync(cancellationToken);
+
+        logger.LogInformation("_streamReader {streamReader}",_streamReader);
+        var result = await _streamReader.ReadToEndAsync(CancellationToken.None);
         _streamReader = null;
         var brunnhildeExecutionSuccess = result.Contains("Brunnhilde characterization complete.");
         logger.LogInformation("Brunnhilde result success: {brunnhildeExecutionSuccess}", brunnhildeExecutionSuccess);

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -281,8 +281,20 @@ public class ProcessPipelineJobHandler(
 
         try
         {
-            var runProcessResult = await RunProcessAsync(objectPath, metadataProcessPath, cancellationToken);
-            
+            //var runProcessResult = await RunProcessAsync(objectPath, metadataProcessPath, cancellationToken);
+
+            using var process = new Process();
+            process.StartInfo.FileName = brunnhildeOptions.Value.PathToPython;
+            process.StartInfo.Arguments = $"  {brunnhildeOptions.Value.PathToBrunnhilde} --hash sha256 {objectPath} {metadataProcessPath}  --overwrite ";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            var started = process.Start();
+
+            if (started)
+            {
+                _processId = process.Id;
+            }
+
             //var processTimer = new System.Timers.Timer(3000);
             ProcessTimer.Elapsed += (sender, e) => CheckIfProcessRunning(sender, e, request, workspaceManager.Deposit, cancellationToken);
             //processTimer.Elapsed += CheckIfProcessRunning;
@@ -297,6 +309,7 @@ public class ProcessPipelineJobHandler(
         }
         catch (Exception e)
         {
+            logger.LogError(e, "Error thrown running the process and timer");
             var s = e.Message;
         }
 
@@ -955,7 +968,7 @@ public class ProcessPipelineJobHandler(
         {
             //you may allow for the process to be re-used (started = false) 
             //but I'm not sure about the guarantees of the Exited event in such a case
-            await m_TokensCatalog[BrunnhildeProcessId].CancelAsync();
+            //await m_TokensCatalog[BrunnhildeProcessId].CancelAsync();
             //await m_TokensCatalog[MonitorForceCompleteId].CancelAsync();
             throw new InvalidOperationException("Could not start process: " + process);
         }
@@ -964,7 +977,7 @@ public class ProcessPipelineJobHandler(
 
         if (_streamReader != null)
         {
-            await m_TokensCatalog[BrunnhildeProcessId].CancelAsync();
+            //await m_TokensCatalog[BrunnhildeProcessId].CancelAsync();
             //await m_TokensCatalog[MonitorForceCompleteId].CancelAsync();
         }
 

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
@@ -310,9 +310,9 @@ public class DepositsController(
     [ProducesResponseType<ProblemDetails>(404, "application/json")]
     [ProducesResponseType<ProblemDetails>(401, "application/json")]
     [ProducesResponseType<ProblemDetails>(409, "application/json")]
-    public async Task<IActionResult> RunPipeline([FromRoute] string id, [FromQuery] string? runUser, [FromQuery] string? jobId)
+    public async Task<IActionResult> RunPipeline([FromRoute] string id)
     {
-        var runPipelineResult = await mediator.Send(new RunPipeline(id, User, runUser, jobId));
+        var runPipelineResult = await mediator.Send(new RunPipeline(id, User));
         return this.StatusResponseFromResult(runPipelineResult, successStatusCode: 204);
     }
 
@@ -321,7 +321,7 @@ public class DepositsController(
     [ApiExplorerSettings(IgnoreApi = true)] // for internal use
     public async Task<IActionResult> LogPipelineRunStatus([FromBody] PipelineDeposit pipelineDeposit)
     {
-        var runPipelineStatusResult = await mediator.Send(new RunPipelineStatus(pipelineDeposit.Id, pipelineDeposit.DepositId , pipelineDeposit.Status ?? string.Empty, User, pipelineDeposit.RunUser, pipelineDeposit.Errors)); 
+        var runPipelineStatusResult = await mediator.Send(new RunPipelineStatus(pipelineDeposit, User)); 
 
         return this.StatusResponseFromResult(runPipelineStatusResult, successStatusCode: 204);
     }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
@@ -1,8 +1,6 @@
-﻿using System.Text.Json;
-using DigitalPreservation.Common.Model.DepositHelpers;
+﻿using DigitalPreservation.Common.Model.DepositHelpers;
 using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.Common.Model.PreservationApi;
-using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Core.Auth;
 using DigitalPreservation.Core.Web;

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/RunPipeline.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/RunPipeline.cs
@@ -11,15 +11,15 @@ using Preservation.API.Data;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DigitalPreservation.Core.Auth;
+using Preservation.API.Data.Entities;
 
 namespace Preservation.API.Features.Deposits.Requests;
 
-public class RunPipeline(string id, ClaimsPrincipal user, string? runUser, string? jobId) : IRequest<Result>
+public class RunPipeline(string depositId, ClaimsPrincipal user) : IRequest<Result>
 {
     public readonly ClaimsPrincipal User = user;
-    public string Id { get; } = id;
-    public string? JobId { get; set; } = jobId;
-    public string? RunUser { get; set; } = runUser;
+    public string DepositId { get; } = depositId;
 
 }
 
@@ -27,38 +27,63 @@ public class RunPipelineHandler(
     ILogger<RunPipelineHandler> logger,
     PreservationContext dbContext,
     IAmazonSimpleNotificationService snsClient,
-    IOptions<PipelineOptions> pipelineOptions) : IRequestHandler<RunPipeline, Result>
+    IOptions<PipelineOptions> pipelineOptions,
+    IIdentityMinter identityMinter) : IRequestHandler<RunPipeline, Result>
 {
     public async Task<Result> Handle(RunPipeline request, CancellationToken cancellationToken)
     {
-        var entity = await dbContext.Deposits.SingleOrDefaultAsync(d => d.MintedId == request.Id, cancellationToken);
-
+        var entity = await dbContext.Deposits.SingleOrDefaultAsync(d => d.MintedId == request.DepositId, cancellationToken);
         if (entity == null)
         {
-            return Result.Fail(ErrorCodes.NotFound, "Could not run pipeline because could not find no deposit for ID " + request.Id);
+            return Result.Fail(ErrorCodes.NotFound, 
+                "Could not run pipeline because could not find no deposit for ID " + request.DepositId);
         }
-
-        if (entity.LockedBy is not null && entity.LockedBy != request.RunUser)
+        
+        var callerIdentity = request.User.GetCallerIdentity();
+        if (entity.LockedBy is not null && entity.LockedBy != callerIdentity)
         {
-            return Result.Fail(ErrorCodes.Conflict, $"Could not run pipeline because the deposit {request.Id} is locked by " + entity.LockedBy);
+            return Result.Fail(ErrorCodes.Conflict, 
+                $"Could not run pipeline because the deposit {request.DepositId} is locked by " + entity.LockedBy);
         }
 
         var topicArn = pipelineOptions.Value.PipelineJobTopicArn;
-
-        var pipelineJobMessage = JsonSerializer.Serialize(new PipelineJobMessage { DepositName = request.Id, JobIdentifier = request.JobId, RunUser = request.RunUser});
+        var jobId = identityMinter.MintIdentity("PipelineJob");
+        
+        // Create a new job in the DB
+        var newJob = new PipelineRunJob
+        {
+            DateSubmitted = DateTime.UtcNow,
+            ArchivalGroup = entity.ArchivalGroupName,
+            PipelineJobJson = JsonSerializer.Serialize(request),
+            Id = jobId,
+            Status = PipelineJobStates.Waiting,
+            Deposit = entity.MintedId,
+            LastUpdated = DateTime.UtcNow,
+            RunUser = callerIdentity
+        };
+        dbContext.PipelineRunJobs.Add(newJob);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        
+        // publish the Pipeline job message for Pipeline.API to pick up
+        var pipelineJobMessage = JsonSerializer.Serialize(new PipelineJobMessage
+        {
+            DepositName = request.DepositId, 
+            JobIdentifier = jobId, 
+            RunUser = callerIdentity
+        });
         var pubRequest = new PublishRequest(topicArn, pipelineJobMessage);
-
         var response = await snsClient.PublishAsync(pubRequest, cancellationToken);
 
         logger.LogDebug(
             "Received statusCode {StatusCode} for sending to SNS for {Identifier} - {MessageId}",
-            response.HttpStatusCode, request.Id, response.MessageId);
+            response.HttpStatusCode, request.DepositId, response.MessageId);
 
         return Result.Ok();
     }
 }
 
 //TODO: put job id into the pipeline into the class
+// NB this is the same class as Pipeline.API.Features.Pipeline.PipelineJobMessage
 internal class PipelineJobMessage
 {
     [JsonPropertyName("depositname")]

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/RunPipelineStatus.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/RunPipelineStatus.cs
@@ -1,24 +1,19 @@
 ﻿using System.Security.Claims;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
-using DigitalPreservation.Core.Auth;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Preservation.API.Data;
-using System.Text.Json;
 using DigitalPreservation.Common.Model.PipelineApi;
-using Preservation.API.Data.Entities;
+using DigitalPreservation.Core.Auth;
+using DigitalPreservation.Utils;
 
 namespace Preservation.API.Features.Deposits.Requests;
 
-public class RunPipelineStatus(string id, string? depositId, string status, ClaimsPrincipal user, string? runUser, string? errors) : IRequest<Result>
+public class RunPipelineStatus(PipelineDeposit pipelineDeposit, ClaimsPrincipal user) : IRequest<Result>
 {
-    public readonly ClaimsPrincipal User = user;
-    public string Id { get; } = id;
-    public string? DepositId { get; } = depositId;
-    public string Status { get; set; } = status;
-    public string? RunUser { get; set; } = runUser;
-    public string? Errors { get; set; } = errors;
+    public PipelineDeposit PipelineDeposit { get; } = pipelineDeposit;
+    public ClaimsPrincipal User { get; } = user;
 }
 
 public class RunPipelineStatusHandler(
@@ -27,56 +22,39 @@ public class RunPipelineStatusHandler(
 {
     public async Task<Result> Handle(RunPipelineStatus request, CancellationToken cancellationToken)
     {
-        var deposit =
-            await dbContext.Deposits.SingleOrDefaultAsync(d => d.MintedId == request.DepositId, cancellationToken);
+        var deposit = await dbContext.Deposits.SingleOrDefaultAsync(
+            d => d.MintedId == request.PipelineDeposit.DepositId, cancellationToken);
 
         if (deposit == null)
         {
-            return Result.Fail(ErrorCodes.NotFound, "No deposit for deposit id " + request.DepositId);
+            return Result.Fail(ErrorCodes.NotFound, "No deposit for deposit id " + request.PipelineDeposit.DepositId);
         }
-        var callerIdentity = request.User.GetCallerIdentity();
+        var entity = await dbContext.PipelineRunJobs.SingleAsync(
+            d => d.Deposit == request.PipelineDeposit.DepositId && d.Id == request.PipelineDeposit.Id, cancellationToken);
 
-        var entity = await dbContext.PipelineRunJobs.SingleOrDefaultAsync(
-            d => d.Deposit == request.DepositId && d.Id == request.Id, cancellationToken) ?? new PipelineRunJob
-        {
-            ArchivalGroup = deposit.ArchivalGroupName,
-            PipelineJobJson = JsonSerializer.Serialize(request),
-            Id = request.Id,
-            Status = request.Status,
-            Deposit = deposit.MintedId,
-            LastUpdated = DateTime.UtcNow,
-            RunUser = request.RunUser,
-            Errors = request.Errors
-        };
-
-
-        switch (request.Status)
+        switch (request.PipelineDeposit.Status)
         {
             case PipelineJobStates.Waiting:
-                entity.DateSubmitted = DateTime.UtcNow;
-                dbContext.PipelineRunJobs.Add(entity);
+                // The PipelineRunJob must already exist
                 break;
             case PipelineJobStates.Running:
                 entity.DateBegun = DateTime.UtcNow;
-                entity.Status = request.Status;
-                dbContext.PipelineRunJobs.Update(entity);
                 break;
             case PipelineJobStates.MetadataCreated:
-                entity.Status = request.Status;
-                dbContext.PipelineRunJobs.Update(entity);
                 break;
             case PipelineJobStates.Completed:
                 entity.DateFinished = DateTime.UtcNow;
-                entity.Status = request.Status;
-                dbContext.PipelineRunJobs.Update(entity);
                 break;
             case PipelineJobStates.CompletedWithErrors:
                 entity.DateFinished = DateTime.UtcNow;
-                entity.Status = request.Status;
-                entity.Errors = request.Errors;
-                dbContext.PipelineRunJobs.Update(entity);
+                entity.Errors = request.PipelineDeposit.Errors;
                 break;
         }
+        if (request.PipelineDeposit.Status.HasText())
+        {
+            entity.Status = request.PipelineDeposit.Status;
+        }
+        dbContext.PipelineRunJobs.Update(entity);
 
         try
         {
@@ -89,7 +67,8 @@ public class RunPipelineStatusHandler(
             return Result.Fail(ErrorCodes.UnknownError, e.Message);
         }
 
-        logger.LogInformation("Pipeline job " + entity.Id + " was run by " + callerIdentity);
+        var callerIdentity = request.User.GetCallerIdentity();
+        logger.LogInformation("Pipeline job " + entity.Id + " was updated by " + callerIdentity);
         return Result.Ok();
     }
 }

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetImportJobResultsForDeposit.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetImportJobResultsForDeposit.cs
@@ -19,6 +19,7 @@ public class GetImportJobResultsForDepositHandler(
     {
         var importJobEntities = await dbContext.ImportJobs
             .Where(j => j.Deposit == request.DepositId)
+            .OrderBy(j => j.DateSubmitted)
             .ToListAsync(cancellationToken);
         var importJobs = importJobEntities
             .Select(j => JsonSerializer.Deserialize<ImportJobResult>(j.LatestPreservationApiResultJson))

--- a/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/PipelineRunJobsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/PipelineRunJobsController.cs
@@ -1,26 +1,33 @@
-﻿using DigitalPreservation.Common.Model.Import;
-using DigitalPreservation.Common.Model.PipelineApi;
+﻿using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.Core.Web;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Preservation.API.Features.ImportJobs;
-using Preservation.API.Features.ImportJobs.Requests;
 using Preservation.API.Features.PipelineRunJobs.Requests;
 
 namespace Preservation.API.Features.PipelineRunJobs;
 
-[Route("deposits/{depositId}/[controller]")]
+[Route("deposits/{depositId}/pipelinerunjobs")]
 [ApiController]
 public class PipelineRunJobsController(IMediator mediator) : Controller
 {
 
-    [HttpGet("results", Name = "GetPipelineJobResults")]
+    [HttpGet(Name = "GetPipelineJobResults")]
     [ProducesResponseType<List<ProcessPipelineResult>>(200, "application/json")]
     [ProducesResponseType<ProblemDetails>(404, "application/json")]
     [ProducesResponseType<ProblemDetails>(401, "application/json")]
     public async Task<IActionResult> GetPipelineJobResults([FromRoute] string depositId)
     {
         var result = await mediator.Send(new GetPipelineJobResultsForDeposit(depositId));
+        return this.StatusResponseFromResult(result);
+    }
+    
+    [HttpGet("{pipelineJobId}", Name = "GetPipelineJobResult")]
+    [ProducesResponseType<List<ProcessPipelineResult>>(200, "application/json")]
+    [ProducesResponseType<ProblemDetails>(404, "application/json")]
+    [ProducesResponseType<ProblemDetails>(401, "application/json")]
+    public async Task<IActionResult> GetPipelineJobResult([FromRoute] string depositId, [FromRoute] string pipelineJobId)
+    {
+        var result = await mediator.Send(new GetPipelineJobResult(depositId, pipelineJobId));
         return this.StatusResponseFromResult(result);
     }
 }

--- a/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/Requests/GetPipelineJobResult.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/Requests/GetPipelineJobResult.cs
@@ -1,0 +1,35 @@
+﻿using DigitalPreservation.Common.Model.Results;
+using MediatR;
+using Preservation.API.Data;
+using DigitalPreservation.Common.Model;
+using Microsoft.EntityFrameworkCore;
+using DigitalPreservation.Common.Model.PipelineApi;
+using Preservation.API.Mutation;
+
+namespace Preservation.API.Features.PipelineRunJobs.Requests;
+
+public class GetPipelineJobResult(string depositId, string jobId) : IRequest<Result<ProcessPipelineResult?>>
+{
+    public string DepositId { get; } = depositId;
+    public string JobId { get; } = jobId;
+}
+
+public class GetPipelineJobResultHandler(
+    PreservationContext dbContext,
+    ResourceMutator resourceMutator) : IRequestHandler<GetPipelineJobResult, Result<ProcessPipelineResult?>>
+{
+    public async Task<Result<ProcessPipelineResult?>> Handle(GetPipelineJobResult request, CancellationToken cancellationToken)
+    {
+        var pipelineJobEntity = await dbContext.PipelineRunJobs
+            .SingleOrDefaultAsync(j => j.Id == request.JobId && j.Deposit == request.DepositId, cancellationToken: cancellationToken);
+
+        if (pipelineJobEntity == null)
+        {
+            return Result.Fail<ProcessPipelineResult>(ErrorCodes.NotFound, 
+                $"Job {request.JobId} not found for deposit {request.DepositId}");
+        }
+        
+        var result = resourceMutator.MutatePipelineRunJob(pipelineJobEntity);
+        return Result.Ok(result);
+    }
+}

--- a/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/Requests/GetPipelineJobResultsForDeposit.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/PipelineRunJobs/Requests/GetPipelineJobResultsForDeposit.cs
@@ -19,6 +19,7 @@ public class GetPipelineJobResultsForDepositHandler(
     {
         var pipelineJobEntities = await dbContext.PipelineRunJobs
             .Where(j => j.Deposit == request.DepositId)
+            .OrderBy(j => j.DateSubmitted)
             .ToListAsync(cancellationToken);
 
         var results = new List<ProcessPipelineResult>();

--- a/src/DigitalPreservation/Preservation.API/Mutation/ResourceMutator.cs
+++ b/src/DigitalPreservation/Preservation.API/Mutation/ResourceMutator.cs
@@ -230,7 +230,8 @@ public class ResourceMutator(
             LastModified = entity.LastUpdated,
             LastModifiedBy = GetAgentUri(entity.RunUser),
             RunUser = entity.RunUser,
-            Errors = errors.Count != 0 ? errors.ToArray<Error>() : null
+            Errors = errors.Count != 0 ? errors.ToArray<Error>() : null,
+            Deposit = entity.Deposit
         };
         return processPipelineResult;
     }

--- a/src/DigitalPreservation/Preservation.API/Mutation/ResourceMutator.cs
+++ b/src/DigitalPreservation/Preservation.API/Mutation/ResourceMutator.cs
@@ -1,12 +1,14 @@
 ﻿using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Identity;
 using DigitalPreservation.Common.Model.Import;
-using DigitalPreservation.Common.Model.PreservationApi;
+using DigitalPreservation.Common.Model.PipelineApi;
 using DigitalPreservation.Utils;
 using LeedsDlipServices.Identity;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
-using DepositEntity = Preservation.API.Data.Entities.Deposit; 
+using Preservation.API.Data.Entities;
+using Deposit = DigitalPreservation.Common.Model.PreservationApi.Deposit;
+using DepositEntity = Preservation.API.Data.Entities.Deposit;
+using ImportJob = DigitalPreservation.Common.Model.Import.ImportJob;
 
 namespace Preservation.API.Mutation;
 
@@ -202,6 +204,45 @@ public class ResourceMutator(
     public List<Deposit> MutateDeposits(IEnumerable<DepositEntity> deposits)
     {
         return deposits.Select(MutateDeposit).ToList();
+    }
+    
+        
+    public ProcessPipelineResult MutatePipelineRunJob(PipelineRunJob entity)
+    {            
+        var errors = new List<Error>();
+        if (!string.IsNullOrEmpty(entity.Errors))
+        {
+            errors.Add(new Error
+            {
+                Message = entity.Errors
+            });
+        }
+        var processPipelineResult = new ProcessPipelineResult
+        {
+            Id = GetProcessPipelineResultUri(entity.Deposit, entity.Id),
+            JobId = entity.Id,
+            ArchivalGroupName = entity.ArchivalGroup,
+            Status = entity.Status,
+            Created = entity.DateSubmitted,
+            DateBegun = entity.DateBegun,
+            DateFinished = entity.DateFinished,
+            CreatedBy = GetAgentUri(entity.RunUser),
+            LastModified = entity.LastUpdated,
+            LastModifiedBy = GetAgentUri(entity.RunUser),
+            RunUser = entity.RunUser,
+            Errors = errors.Count != 0 ? errors.ToArray<Error>() : null
+        };
+        return processPipelineResult;
+    }
+    
+    private Uri GetProcessPipelineResultUri(string depositId, string jobId)
+    {
+        return new Uri($"{preservationHost}/{Deposit.BasePathElement}/{depositId}/pipelinerunjobs/{jobId}");
+    }
+    
+    public List<ProcessPipelineResult> MutatePipelineRunJobs(IEnumerable<PipelineRunJob> pipelineRunJobs)
+    {
+        return pipelineRunJobs.Select(MutatePipelineRunJob).ToList();
     }
     
     public void MutatePreservationImportJob(ImportJob preservationImportJob)

--- a/src/DigitalPreservation/Preservation.API/Program.cs
+++ b/src/DigitalPreservation/Preservation.API/Program.cs
@@ -19,6 +19,7 @@ using LeedsDlipServices;
 using LeedsDlipServices.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Amazon.SimpleNotificationService;
+using DigitalPreservation.Common.Model.Identity;
 using DigitalPreservation.Common.Model.PipelineApi;
 using Microsoft.OpenApi.Models;
 
@@ -68,6 +69,7 @@ try
         .AddStorageAwsAccess(builder.Configuration)
         .AddStorageClient(builder.Configuration, "Preservation-API")
         .AddIdentityServiceClient(builder.Configuration)
+        .AddSingleton<IIdentityMinter, IdentityMinter>()
         .AddMvpCatalogueClient(builder.Configuration)
         .AddResourceMutator(builder.Configuration)
         .AddSingleton<IMetsParser, MetsParser>()

--- a/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
@@ -62,7 +62,7 @@ public interface IPreservationApiClient
     Task<Result> LockDeposit(Deposit deposit, bool force, CancellationToken cancellationToken);
     Task<Result> ReleaseDepositLock(Deposit deposit, CancellationToken cancellationToken);
 
-    Task<Result> RunPipeline(Deposit deposit, string? runUser, string jobId, CancellationToken cancellationToken);
+    Task<Result> RunPipeline(Deposit deposit, CancellationToken cancellationToken);
     Task<OrderedCollection?> GetOrderedCollection(string stream);
     Task<OrderedCollectionPage?> GetOrderedCollectionPage(string stream, int index);
     

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -61,15 +61,9 @@ internal class PreservationApiClient(
         return await response.ToFailResult("Unable to remove lock");
     }
 
-    public async Task<Result> RunPipeline(Deposit deposit, string? runUser, string jobId, CancellationToken cancellationToken)
+    public async Task<Result> RunPipeline(Deposit deposit, CancellationToken cancellationToken)
     {
-        var queryString = $"?jobId={jobId}";
-
-        if (!string.IsNullOrEmpty(runUser))
-        {
-            queryString += $"&runUser={runUser}";
-        }
-        var uri = new Uri(deposit.Id!.AbsolutePath + "/pipeline" + queryString, UriKind.Relative);
+        var uri = new Uri(deposit.Id!.AbsolutePath + "/pipeline", UriKind.Relative);
         var response = await preservationHttpClient.PostAsync(uri, null, cancellationToken);
         if (response.IsSuccessStatusCode)
         {

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -520,7 +520,7 @@ internal class PreservationApiClient(
     {
         try
         {
-            var uri = new Uri($"/deposits/{depositId}/PipelineRunJobs/results", UriKind.Relative);
+            var uri = new Uri($"/deposits/{depositId}/pipelinerunjobs", UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await preservationHttpClient.SendAsync(req, cancellationToken);
             if (response.IsSuccessStatusCode)
@@ -532,7 +532,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<List<ProcessPipelineResult>>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<List<ProcessPipelineResult>>("Unable to get import job results");
+            return await response.ToFailNotNullResult<List<ProcessPipelineResult>>("Unable to get pipeline run job results");
         }
         catch (Exception e)
         {
@@ -545,7 +545,7 @@ internal class PreservationApiClient(
     {
         try
         {
-            var uri = new Uri($"/deposits/{depositId}/pipelineJobs/results/{pipelineJobId}", UriKind.Relative);
+            var uri = new Uri($"/deposits/{depositId}/pipelinerunjobs/{pipelineJobId}", UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await preservationHttpClient.SendAsync(req, cancellationToken);
             if (response.IsSuccessStatusCode)
@@ -557,7 +557,7 @@ internal class PreservationApiClient(
                 }
                 return Result.FailNotNull<ProcessPipelineResult>(ErrorCodes.NotFound, "No resource at " + uri);
             }
-            return await response.ToFailNotNullResult<ProcessPipelineResult>("Unable to get import job result");
+            return await response.ToFailNotNullResult<ProcessPipelineResult>("Unable to get pipeline run job result");
         }
         catch (Exception e)
         {

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -520,7 +520,6 @@ internal class PreservationApiClient(
     {
         try
         {
-            //var uri = new Uri($"/deposits/{depositId}/importJobs/results", UriKind.Relative);
             var uri = new Uri($"/deposits/{depositId}/PipelineRunJobs/results", UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await preservationHttpClient.SendAsync(req, cancellationToken);


### PR DESCRIPTION
This started from documenting the Pipeline features of the Preservation API and feeling uncomfortable about documenting the `runUser` parameter, so I started an experiment with removing that from the public API and relying on callerIdentity (the execution side still uses the concept).

I then did a bit of refactoring as I followed through the execute logic, which doesn't change behaviour but removes a lot of repetitive code blocks and makes the logic flow easier to follow (IMO). Some of the changes are really from the POV of an API consumer who is *not* the Preservation UI; what does it look like as a public API?

I also made some UI changes in Deposit.cshtml.

Summary of changes:

* Mediatr handlers take a `ClaimsPrincipal` rather than `string runUser`
* When starting a pipeline run, the API logs the first pipeline run status as well as sends the SNS message, rather than the caller logging the message. All messages are out of the API client's hands, and the `LogPipelineRunStatus` is a non-documented public API method (for internal use only). See `RunPipeline` and `RunPipelineStatus`. (might want to rename the latter but another time).
* The minting of the identity moves behind the Preservation API rather than in the UI. That is, callers can't supply their own jobId.
* In the Deposit view I have made the inactive action menu items grey - although they were `disabled` they still didn't look visually different
* In the Deposit Razor and model I have moved some code into the Model class (`RunningPipelineJob`) and removed the use of runUser. I renamed PipelineJobsRunning to GetCleanedPipelineJobsRunning and incorporated CleanupPipelineRunsForDeposit into it so that these definitely happen together.
* In ExecutePipelineJob I introduced some new methods: `TryReleaseLock` and various overloads of `UpdateJobStatus`. Although these add some new lines they save about 100 lines of code where the same actions are performed during the flow. This also isolated the point at which a chained Mediatr call happens, which I then refactored to call the preservation API directly so there is no Mediatr chain (see UpdateAnyJobStatus - this used to be many calls to await `mediator.Send(new LogPipelineJobStatus(..))`).
* Ordered pipeline jobs by dateSubmitted (there was no ordering) and did same for importJobs to match.
