### PR TITLE
changes for checking process running

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -74,7 +74,7 @@
                                 </button>
                             </li>
                             <li>
-                                <button disabled="@(!jobRunning)" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ForceCompletePipelineRun">
+                                <button disabled="@(!jobRunning)" class="dropdown-item @(!jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ForceCompletePipelineRun">
                                     <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Stop pipeline run</span>
                                 </button>
                             </li>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -69,12 +69,12 @@
                         @if (Model.ShowPipeline)
                         {
                             <li>
-                                <button disabled="@jobRunning" class="dropdown-item text-primary" type="submit" asp-page-handler="RunPipeline">
+                                <button disabled="@jobRunning" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="RunPipeline">
                                     <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Run pipeline</span>
                                 </button>
                             </li>
                             <li>
-                                <button disabled="@(!jobRunning)" class="dropdown-item text-primary" type="submit" asp-page-handler="ForceCompletePipelineRun">
+                                <button disabled="@(!jobRunning)" class="dropdown-item @(jobRunning ? "text-secondary" : "text-primary")" type="submit" asp-page-handler="ForceCompletePipelineRun">
                                     <svg class="bi"><use xlink:href="#gear"/></svg><span class="ms-2">Stop pipeline run</span>
                                 </button>
                             </li>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -555,14 +555,14 @@ public class DepositModel(
     public async Task<(List<ProcessPipelineResult> jobs, ProcessPipelineResult? runningJob)> GetCleanedPipelineJobsRunning()
     {
         var allJobs = GetPipelineJobResults().Result;
-        var oneDayAgo = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(pipelineOptions.Value.PipelineJobsCleanupMinutes));
+        var cutoffDate = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(pipelineOptions.Value.PipelineJobsCleanupMinutes));
         var longRunningUnfinishedJobs = allJobs
-            .Where(x => x.DateBegun.HasValue && x.DateBegun.Value < oneDayAgo && x.Deposit == Id)
+            .Where(x => x.DateBegun.HasValue && x.DateBegun.Value < cutoffDate && x.Deposit == Id)
             .Where(x => PipelineJobStates.IsNotComplete(x.Status))
             .ToList();
 
         var longRunningUnfinishedWaitingJobs = allJobs
-            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value < oneDayAgo && x.Deposit == Id)
+            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value < cutoffDate && x.Deposit == Id)
             .Where(x => PipelineJobStates.IsNotComplete(x.Status))
             .ToList();
 
@@ -596,12 +596,12 @@ public class DepositModel(
         }
 
         var latestJob = allJobs
-            .Where(x => x.DateBegun.HasValue && x.DateBegun.Value >= oneDayAgo && x.Deposit == Id)
+            .Where(x => x.DateBegun.HasValue && x.DateBegun.Value >= cutoffDate && x.Deposit == Id)
             .OrderByDescending(x => x.DateBegun)
             .FirstOrDefault();
 
         var latestWaitingJob = allJobs
-            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value >= oneDayAgo && x.Deposit == Id)
+            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value >= cutoffDate && x.Deposit == Id)
             .OrderByDescending(x => x.Created)
             .FirstOrDefault();
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -69,7 +69,7 @@ public class DepositModel(
                     ArchivalGroupTestWarning = testArchivalGroupResult.ErrorMessage;
                 }
             }
-            
+
             (PipelineJobResults, RunningPipelineJob) = await GetCleanedPipelineJobsRunning();
 
             if (Deposit.Status != DepositStates.Exporting)
@@ -562,7 +562,7 @@ public class DepositModel(
             .ToList();
 
         var longRunningUnfinishedWaitingJobs = allJobs
-            .Where(x => x.Created.HasValue && x.Created.Value < oneDayAgo && x.Deposit == Id)
+            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value < oneDayAgo && x.Deposit == Id)
             .Where(x => PipelineJobStates.IsNotComplete(x.Status))
             .ToList();
 
@@ -581,16 +581,27 @@ public class DepositModel(
             };
 
             var result = await mediator.Send(new ReleaseLock(Deposit!));
+            if (result.Success && Deposit != null)
+            {
+                Deposit.LockDate = null;
+                Deposit.LockedBy = null;
+            }
             await preservationApiClient.LogPipelineRunStatus(pipelineDeposit, CancellationToken.None);
         }
-        
+
+        if (longRunningUnfinishedJobs.Any())
+        {
+            //refresh as all jobs have been sent
+            allJobs = GetPipelineJobResults().Result;
+        }
+
         var latestJob = allJobs
             .Where(x => x.DateBegun.HasValue && x.DateBegun.Value >= oneDayAgo && x.Deposit == Id)
             .OrderByDescending(x => x.DateBegun)
             .FirstOrDefault();
 
         var latestWaitingJob = allJobs
-            .Where(x => x.Created.HasValue && x.Created.Value >= oneDayAgo && x.Deposit == Id)
+            .Where(x => x is { Created: not null, DateBegun: null } && x.Created.Value >= oneDayAgo && x.Deposit == Id)
             .OrderByDescending(x => x.Created)
             .FirstOrDefault();
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -48,6 +48,6 @@
     "ApiKeyHeader": "X-API-KEY"
   },
   "PipelineOptions": {
-    "PipelineJobsCleanupMinutes": 5
+    "PipelineJobsCleanupMinutes": 1440
   }
 }


### PR DESCRIPTION
This code has a timer to check whether there is a cleanup process job or force complete for the running job in which case especially for a large deposit that this would kill the brunnhilde process. This was implemented to allow Christine to test the cleanup of old pipeline run jobs in the database.

Associated ticket:
https://dev.azure.com/universityofleeds/Library/_workitems/edit/104522

For setting the cleanup process interval setting `PipelineJobsCleanupMinutes` to 5 minutes for Christine's large deposit to test.
https://preservation-dev.library.leeds.ac.uk/deposits/pcnr4d3btsuy