### PR TITLE
Get content/mime type from server side for less known file extensions like .msg

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -172,8 +172,8 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
 
 
-            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
-                cachedDepositFileFormatMetadata!.FormatName = "Blah";
+            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.ContentType))
+                cachedDepositFileFormatMetadata!.ContentType = !string.IsNullOrWhiteSpace(FileInDeposit!.ContentType) ? FileInDeposit.ContentType : "All empty";
             if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
                 cachedDepositFileFormatMetadata!.FormatName = "[Not Identified]";
             if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey))

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -176,7 +176,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                 cachedDepositFileFormatMetadata!.ContentType = !string.IsNullOrWhiteSpace(FileInDeposit!.ContentType) ? FileInDeposit.ContentType : "All empty";
             if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
                 cachedDepositFileFormatMetadata!.FormatName = "[Not Identified]";
-            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey))
+            if (cachedDepositFileFormatMetadata != null && (string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey) ||  cachedDepositFileFormatMetadata.PronomKey.ToLower().Trim() == "unknown"))
                     cachedDepositFileFormatMetadata!.PronomKey = "dlip/unknown";
 
             haveScannedDepositFileFormatMetadata = true;

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -66,6 +66,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
         {
             return misMatches;
         }
+
         // (temp) do this just for FileFormatMetadata initially
         if (DepositFileFormatMetadata != null && MetsFileFormatMetadata != null)
         {

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -171,9 +171,11 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             }
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
 
-            if (cachedDepositFileFormatMetadata is { FormatName: null }) cachedDepositFileFormatMetadata.FormatName = "[Not Identified]";
-            if (cachedDepositFileFormatMetadata is { PronomKey: null }) cachedDepositFileFormatMetadata.PronomKey = "dlip/unknown";
-           
+            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
+                cachedDepositFileFormatMetadata!.FormatName = "[Not Identified]";
+            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey))
+                    cachedDepositFileFormatMetadata!.PronomKey = "dlip/unknown";
+
             haveScannedDepositFileFormatMetadata = true;
             return cachedDepositFileFormatMetadata;
         }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -202,6 +202,10 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             }
 
             cachedMetsFileFormatMetadata = FileInMets?.GetFileFormatMetadata();
+
+            if (cachedMetsFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedMetsFileFormatMetadata?.Digest))
+                cachedMetsFileFormatMetadata!.Digest = FileInMets?.Digest ?? "All empty Digest";
+
             haveScannedMetsFileFormatMetadata = true;
             return cachedMetsFileFormatMetadata;
         }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -66,7 +66,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
         {
             return misMatches;
         }
-        
+
         // (temp) do this just for FileFormatMetadata initially
         if (DepositFileFormatMetadata != null && MetsFileFormatMetadata != null)
         {
@@ -83,7 +83,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                     DepositFileFormatMetadata.PronomKey, MetsFileFormatMetadata.PronomKey));
             }
 
-            if (DepositFileFormatMetadata!.ContentType != FileInMets.ContentType)
+            if ((DepositFileFormatMetadata!.ContentType ?? FileInDeposit.ContentType) != FileInMets.ContentType)
             {
                 misMatches.Add(new FileMisMatch(nameof(FileFormatMetadata), "ContentType",
                     DepositFileFormatMetadata.ContentType, FileInMets.ContentType));
@@ -170,6 +170,10 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                 return cachedDepositFileFormatMetadata;
             }
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
+
+            if (cachedDepositFileFormatMetadata is { FormatName: null }) cachedDepositFileFormatMetadata.FormatName = "[Not Identified]";
+            if (cachedDepositFileFormatMetadata is { PronomKey: null }) cachedDepositFileFormatMetadata.PronomKey = "dlip/unknown";
+           
             haveScannedDepositFileFormatMetadata = true;
             return cachedDepositFileFormatMetadata;
         }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -83,7 +83,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                     DepositFileFormatMetadata.PronomKey, MetsFileFormatMetadata.PronomKey));
             }
 
-            if ((DepositFileFormatMetadata!.ContentType ?? FileInDeposit.ContentType) != FileInMets.ContentType)
+            if (DepositFileFormatMetadata!.ContentType != FileInMets.ContentType)
             {
                 misMatches.Add(new FileMisMatch(nameof(FileFormatMetadata), "ContentType",
                     DepositFileFormatMetadata.ContentType, FileInMets.ContentType));
@@ -169,16 +169,8 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             {
                 return cachedDepositFileFormatMetadata;
             }
+
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
-
-
-            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.ContentType))
-                cachedDepositFileFormatMetadata!.ContentType = !string.IsNullOrWhiteSpace(FileInDeposit!.ContentType) ? FileInDeposit.ContentType : "All empty";
-            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
-                cachedDepositFileFormatMetadata!.FormatName = "[Not Identified]";
-            if (cachedDepositFileFormatMetadata != null && (string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey) ||  cachedDepositFileFormatMetadata.PronomKey.ToLower().Trim() == "unknown"))
-                    cachedDepositFileFormatMetadata!.PronomKey = "dlip/unknown";
-
             haveScannedDepositFileFormatMetadata = true;
             return cachedDepositFileFormatMetadata;
         }
@@ -202,10 +194,6 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             }
 
             cachedMetsFileFormatMetadata = FileInMets?.GetFileFormatMetadata();
-
-            if (cachedMetsFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedMetsFileFormatMetadata?.Digest))
-                cachedMetsFileFormatMetadata!.Digest = FileInMets?.Digest ?? "All empty Digest";
-
             haveScannedMetsFileFormatMetadata = true;
             return cachedMetsFileFormatMetadata;
         }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -171,6 +171,9 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             }
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
 
+
+            if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
+                cachedDepositFileFormatMetadata!.FormatName = "Blah";
             if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.FormatName))
                 cachedDepositFileFormatMetadata!.FormatName = "[Not Identified]";
             if (cachedDepositFileFormatMetadata != null && string.IsNullOrWhiteSpace(cachedDepositFileFormatMetadata?.PronomKey))

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -66,7 +66,6 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
         {
             return misMatches;
         }
-
         // (temp) do this just for FileFormatMetadata initially
         if (DepositFileFormatMetadata != null && MetsFileFormatMetadata != null)
         {
@@ -169,7 +168,6 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             {
                 return cachedDepositFileFormatMetadata;
             }
-
             cachedDepositFileFormatMetadata = FileInDeposit?.GetFileFormatMetadata();
             haveScannedDepositFileFormatMetadata = true;
             return cachedDepositFileFormatMetadata;

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -53,10 +53,9 @@ public class WorkingFile : WorkingBase
             .OfType<FileFormatMetadata>()
             .ToList();
 
-        var digestMetadata = GetDigestMetadata();
-
-        if (fileFormatMetadata.Count == 0 && FolderNames.IsMetadata(LocalPath))
+        if (fileFormatMetadata.Count == 0)
         {
+            var digestMetadata = GetDigestMetadata();
             // These have not been analysed by file format pipelines
             var syntheticMetadata = new FileFormatMetadata
             {
@@ -74,35 +73,15 @@ public class WorkingFile : WorkingBase
             return syntheticMetadata;
         }
 
-        if (fileFormatMetadata.Count == 0 && !FolderNames.IsMetadata(LocalPath))
-        {
-            var objectFileFormatMetadata = new FileFormatMetadata
-            {
-                Source = "Mets",
-                ContentType = ContentType,
-                Digest = digestMetadata?.Digest ?? Digest,
-                Size = Size,
-                OriginalName = LocalPath, // workingFile.LocalPath
-                StorageLocation = null // storageLocation
-            };
-
-            if (ContentType == "application/octet-stream" && MimeTypes.TryGetMimeType(LocalPath.GetSlug(), out var foundMimeType))
-            {
-                objectFileFormatMetadata.ContentType = foundMimeType;
-            }
-
-            return objectFileFormatMetadata;
-        }
-
-        if (fileFormatMetadata.Count == 1)
+        if (fileFormatMetadata.Count <= 1)
         {
             return fileFormatMetadata.SingleOrDefault();
         }
 
         var pronomKeys = fileFormatMetadata
-                .Where(m => m.PronomKey.HasText())
-                .Select(m => m.PronomKey!)
-                .ToList();
+            .Where(m => m.PronomKey.HasText())
+            .Select(m => m.PronomKey!)
+            .ToList();
         var contentTypes = fileFormatMetadata
             .Where(m => m.ContentType.HasText())
             .Select(m => m.ContentType!)
@@ -151,7 +130,7 @@ public class WorkingFile : WorkingBase
                 };
             }
         }
-        
+
         // There is only one, or none
         return fileFormatMetadata.SingleOrDefault();
     }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -76,7 +76,7 @@ public class WorkingFile : WorkingBase
 
         if (fileFormatMetadata.Count == 0 && !FolderNames.IsMetadata(LocalPath))
         {
-            return new FileFormatMetadata
+            var objectFileFormatMetadata = new FileFormatMetadata
             {
                 Source = "Mets",
                 ContentType = ContentType,
@@ -85,6 +85,13 @@ public class WorkingFile : WorkingBase
                 OriginalName = LocalPath, // workingFile.LocalPath
                 StorageLocation = null // storageLocation
             };
+
+            if (ContentType == "application/octet-stream" && MimeTypes.TryGetMimeType(LocalPath.GetSlug(), out var foundMimeType))
+            {
+                objectFileFormatMetadata.ContentType = foundMimeType;
+            }
+
+            return objectFileFormatMetadata;
         }
 
         if (fileFormatMetadata.Count == 1)

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -53,9 +53,10 @@ public class WorkingFile : WorkingBase
             .OfType<FileFormatMetadata>()
             .ToList();
 
+        var digestMetadata = GetDigestMetadata();
+
         if (fileFormatMetadata.Count == 0 && FolderNames.IsMetadata(LocalPath))
         {
-            var digestMetadata = GetDigestMetadata();
             // These have not been analysed by file format pipelines
             var syntheticMetadata = new FileFormatMetadata
             {
@@ -72,15 +73,29 @@ public class WorkingFile : WorkingBase
 
             return syntheticMetadata;
         }
-        if (fileFormatMetadata.Count <= 1)
+
+        if (fileFormatMetadata.Count == 0 && !FolderNames.IsMetadata(LocalPath))
+        {
+            return new FileFormatMetadata
+            {
+                Source = "Mets",
+                ContentType = ContentType,
+                Digest = digestMetadata?.Digest ?? Digest,
+                Size = Size,
+                OriginalName = LocalPath, // workingFile.LocalPath
+                StorageLocation = null // storageLocation
+            };
+        }
+
+        if (fileFormatMetadata.Count == 1)
         {
             return fileFormatMetadata.SingleOrDefault();
         }
 
         var pronomKeys = fileFormatMetadata
-            .Where(m => m.PronomKey.HasText())
-            .Select(m => m.PronomKey!)
-            .ToList();
+                .Where(m => m.PronomKey.HasText())
+                .Select(m => m.PronomKey!)
+                .ToList();
         var contentTypes = fileFormatMetadata
             .Where(m => m.ContentType.HasText())
             .Select(m => m.ContentType!)

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -53,7 +53,7 @@ public class WorkingFile : WorkingBase
             .OfType<FileFormatMetadata>()
             .ToList();
 
-        if (fileFormatMetadata.Count == 0)
+        if (fileFormatMetadata.Count == 0 && FolderNames.IsMetadata(LocalPath))
         {
             var digestMetadata = GetDigestMetadata();
             // These have not been analysed by file format pipelines
@@ -68,11 +68,6 @@ public class WorkingFile : WorkingBase
             if (ContentType == "application/octet-stream" && MimeTypes.TryGetMimeType(LocalPath.GetSlug(), out var foundMimeType))
             {
                 syntheticMetadata.ContentType = foundMimeType;
-            }
-
-            if (FolderNames.IsMetadata(LocalPath))
-            {
-                syntheticMetadata.PronomKey = "-";
             }
 
             return syntheticMetadata;

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -72,7 +72,6 @@ public class WorkingFile : WorkingBase
 
             return syntheticMetadata;
         }
-
         if (fileFormatMetadata.Count <= 1)
         {
             return fileFormatMetadata.SingleOrDefault();
@@ -130,7 +129,6 @@ public class WorkingFile : WorkingBase
                 };
             }
         }
-
         // There is only one, or none
         return fileFormatMetadata.SingleOrDefault();
     }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -129,6 +129,7 @@ public class WorkingFile : WorkingBase
                 };
             }
         }
+
         // There is only one, or none
         return fileFormatMetadata.SingleOrDefault();
     }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -70,6 +70,11 @@ public class WorkingFile : WorkingBase
                 syntheticMetadata.ContentType = foundMimeType;
             }
 
+            if (FolderNames.IsMetadata(LocalPath))
+            {
+                syntheticMetadata.PronomKey = "-";
+            }
+
             return syntheticMetadata;
         }
 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -178,9 +178,49 @@
     {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
             <p>@Html.Raw(TempData["MisMatchCount"]) files have metadata not present in METS.</p>
+            
+            @{
+                var lastFileName = string.Empty;
+                var differencesString = string.Empty;
+                }
+            <!--ADD IN EXTRA INFORMATION AND DISPLAY MORE INFO ON MISMATCHES-->
+            @foreach (var detailMismatch in Model.FileMisMatches)
+            {
+                foreach (var fileMismatch in detailMismatch.Item1)
+                {
+                    switch (fileMismatch.Field.ToLower())
+                    {
+                        case "contenttype":
+                            differencesString += " Content type;";
+                            @* <p>Content type is different</p> *@
+                            break;
+                        case "pronomkey":
+                            differencesString += " Pronom key;";
+                            @* <p>Pronom key is different</p> *@
+                            break;
+                        case "formatname":
+                            differencesString += " Format name;";
+                            @* <p>Format name is different</p> *@
+                            break;
+                        case "digest":
+                            differencesString += " Digest;";
+                            @* <p>Format name is different</p> *@
+                            break;
+                        default:
+                            <p>undocumented difference</p>
+                            break;
+                    }
+                }
+                <p>@detailMismatch.Item2 (Differences: @differencesString)</p>
+                differencesString = string.Empty;
+            }
+            
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
+
+
     }
+
     
     @if (jobRunning && TempData["Valid"] == null)
     {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -43,6 +43,8 @@ public class DepositModel(
 
     public bool ShowPipeline => configuration.GetValue<bool?>("FeatureFlags:ShowPipeline") ?? false;
 
+    public List<(List<CombinedFile.FileMisMatch>, string)> FileMisMatches { get; set; } = [];
+
     public async Task OnGet(
         [FromRoute] string id,
         [FromQuery] bool readFromStorage = false,
@@ -79,11 +81,15 @@ public class DepositModel(
                     RootCombinedDirectory = combinedResult.Value;
                     if (WorkspaceManager.Editable)
                     {
-                        var mismatches = RootCombinedDirectory.GetMisMatches();
+                        var (mismatches, detailedMismatches) = RootCombinedDirectory.GetMisMatches();
+
                         if (mismatches.Count != 0)
                         {
                             TempData["MisMatchCount"] = mismatches.Count;
                         }
+
+                        FileMisMatches = detailedMismatches;
+
                     }
                 }
             }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
 using Preservation.Client;
 using System.Text.Json;
-using DigitalPreservation.Common.Model.Identity;
 
 namespace DigitalPreservation.UI.Pages.Deposits;
 
@@ -232,6 +231,11 @@ public class DepositModel(
         {
             newFileContext = newFileContext.GetParent();
         }
+
+        var slug = PreservedResource.MakeValidSlug(depositFile[0].FileName);
+
+        if(string.IsNullOrWhiteSpace(depositFileContentType) && MimeTypes.TryGetMimeType(slug, out var foundMimeType))
+            depositFileContentType = foundMimeType;
 
         if (await BindDeposit(id))
         {

--- a/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
+++ b/src/DigitalPreservation/DigitalPreservation.UI/appsettings.json
@@ -48,6 +48,6 @@
     "ApiKeyHeader": "X-API-KEY"
   },
   "PipelineOptions": {
-    "PipelineJobsCleanupMinutes": 5
+    "PipelineJobsCleanupMinutes": 1440
   }
 }


### PR DESCRIPTION
Get content/mime type from server side for less known file extensions like .msg
Also, get some Metadata properties from the `FileInDeposit` object if the associated `DepositFileFormatMetadata` properties are null.

Added in changes to show more information in METS mismatch banner.

Ticket:
https://dev.azure.com/universityofleeds/Library/_workitems/edit/106850