### PR TITLE
Output Exif file to a metadata folder file during pipeline run

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.sln
+++ b/src/DigitalPreservation/DigitalPreservation.sln
@@ -159,9 +159,6 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E045329F-268B-4E69-8C2A-82B2CBEB9014} = {2FF7269F-F433-41F9-84BF-EAA8CFCFFCF5}
 		{476FB8C8-C5F6-4136-B448-8EF53FA55526} = {2FF7269F-F433-41F9-84BF-EAA8CFCFFCF5}

--- a/src/DigitalPreservation/Pipeline.API/Config/BrunnhildeOptions.cs
+++ b/src/DigitalPreservation/Pipeline.API/Config/BrunnhildeOptions.cs
@@ -7,4 +7,5 @@ public class BrunnhildeOptions
     public string? DirectorySeparator { get; set; }
     public string? ObjectsFolder { get; set; }
     public string? ProcessFolder { get; set; }
+    public string? ExifToolLocation { get; set; }
 }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -959,7 +959,7 @@ public class ProcessPipelineJobHandler(
                     FileName = exifToolLocation,
                     Arguments = $"exiftool -a {objectPath}",
                     RedirectStandardOutput = true,
-                    UseShellExecute = false, //true
+                    UseShellExecute = false,
                     CreateNoWindow = true
                 }
             };

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -973,7 +973,7 @@ public class ProcessPipelineJobHandler(
         }
         catch(Exception e)
         {
-            logger.LogError("Issue running exif tool for objects in the object path {ObjectPath}", objectPath);
+            logger.LogError("Issue running exif tool for objects in the object path {ObjectPath} error {Exception}", objectPath, e.Message);
         }
     }
 }


### PR DESCRIPTION
Ticket: https://digirati.atlassian.net/browse/LPII-1
The code uploads local process folder metadata folder exif output file to s3:
<img width="1899" height="718" alt="image" src="https://github.com/user-attachments/assets/f112bbd2-5b4b-4bb9-9a8b-30ba479b5292" />

Tested this using the local pipeline API swagger instance at `https://localhost:7005/swagger/index.html` to trgigger the pipeline run:
<img width="1854" height="1015" alt="image" src="https://github.com/user-attachments/assets/c4e747b3-3f1a-45db-98e2-ea9c3503329d" />

Add the following setting to the Pipeline API `appsettings.Development.json` `BrunnhildeOptions` section- will get Frank to add this to the config settings terraform (maybe) - might just put in `appsettings.json`:

` "ExifToolLocation": "C:\\Exif\\exiftool.exe"`

<img width="389" height="243" alt="image" src="https://github.com/user-attachments/assets/dfb14fc3-19fe-4422-9ca8-e4fab39e7e02" />


Do not deploy as need to get Exif tool installed to the pipeline Docker container - need to chat with Frank about this.





