### PR TITLE
Feature/lpii 5/parse exif metadata from mets

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DigitalPreservation.Common.Model.DepositHelpers;
+public class ExifTag
+{
+    public string TagName { get; set; }
+    public string TagValue { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
@@ -7,6 +7,6 @@ using System.Threading.Tasks;
 namespace DigitalPreservation.Common.Model.DepositHelpers;
 public class ExifTag
 {
-    public string? TagName { get; set; }
-    public string? TagValue { get; set; }
+    public string? TagName { get; set; } = string.Empty;
+    public string? TagValue { get; set; } = string.Empty;
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/ExifTag.cs
@@ -7,6 +7,6 @@ using System.Threading.Tasks;
 namespace DigitalPreservation.Common.Model.DepositHelpers;
 public class ExifTag
 {
-    public string TagName { get; set; }
-    public string TagValue { get; set; }
+    public string? TagName { get; set; }
+    public string? TagValue { get; set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -126,10 +126,10 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
         if (DepositExifMetadata != null && MetsExifMetadata != null)
         {
-            if (DepositExifMetadata.RawToolOutput != null && MetsExifMetadata.RawToolOutput != null)
+            if (DepositExifMetadata.Tags != null && MetsExifMetadata.Tags != null)
             {
-                var depositExifMetadata = DepositExifMetadata.RawToolOutput;
-                var metsExifMetadata = MetsExifMetadata.RawToolOutput;
+                var depositExifMetadata = DepositExifMetadata.Tags;
+                var metsExifMetadata = MetsExifMetadata.Tags;
 
                 var isEqual = depositExifMetadata.SequenceEqual(metsExifMetadata, new ExifTagComparer());
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -123,20 +123,16 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                     "(virus check)", null));
         }
 
-        //Compare each part of metadata in dictionary with the other
         if (DepositExifMetadata != null && MetsExifMetadata != null)
         {
             if (DepositExifMetadata.RawToolOutput != null && MetsExifMetadata.RawToolOutput != null)
             {
-                var t = DepositExifMetadata.RawToolOutput.OrderBy(kvp => kvp.Key)
-                    .SequenceEqual(MetsExifMetadata.RawToolOutput.OrderBy(kvp => kvp.Key));
-
                 var mismatches = MetsExifMetadata.RawToolOutput.Where(entry => DepositExifMetadata.RawToolOutput[entry.Key] != entry.Value)
                     .ToDictionary(entry => entry.Key, entry => entry.Value);
 
                 foreach (var mismatch in mismatches)
                 {
-                    var depositMismatchValue = DepositExifMetadata.RawToolOutput[mismatch.Key];
+                    var depositMismatchValue = DepositExifMetadata.RawToolOutput.FirstOrDefault(x => x.Key == mismatch.Key).Value;
                     misMatches.Add(new FileMisMatch(nameof(ExifMetadata), mismatch.Key,
                         depositMismatchValue, mismatch.Value));
                 }
@@ -410,4 +406,15 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
     {
         return FileInMets?.Name ?? FileInDeposit?.Name ?? FileInMets?.GetSlug() ?? FileInDeposit?.GetSlug();
     }
+}
+
+public class Person
+{
+    public Person(string firstName, string lastName)
+    {
+        FirstName = firstName;
+        LastName = lastName;
+    }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -439,14 +439,14 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
 public class ExifTagComparer : IEqualityComparer<ExifTag>
 {
-    public bool Equals(ExifTag x, ExifTag y)
+    public bool Equals(ExifTag? x, ExifTag? y)
     {
         //Check whether the compared objects reference the same data. 
-        if (object.ReferenceEquals(x, y))
+        if (ReferenceEquals(x, y))
             return true;
 
         //Check whether any of the compared objects is null. 
-        if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null))
+        if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
             return false;
 
         return string.Equals(x.TagName, y.TagName, StringComparison.OrdinalIgnoreCase) &&
@@ -456,12 +456,12 @@ public class ExifTagComparer : IEqualityComparer<ExifTag>
     public int GetHashCode(ExifTag exifTag)
     {
         //Check whether the object is null 
-        if (object.ReferenceEquals(exifTag, null))
+        if (ReferenceEquals(exifTag, null))
             return 0;
 
         //Get hash code for the name field if it is not null
-        int tagNameHashCode = !string.IsNullOrEmpty(exifTag.TagName) ? 0 : exifTag.TagName.GetHashCode();
-        int tagValueHashCode = !string.IsNullOrEmpty(exifTag.TagValue) ? 0 : exifTag.TagValue.GetHashCode();
+        var tagNameHashCode = !string.IsNullOrEmpty(exifTag.TagName) ? 0 : exifTag?.TagName?.GetHashCode() ?? 0;
+        var tagValueHashCode = exifTag != null && !string.IsNullOrEmpty(exifTag.TagValue) ? 0 : exifTag?.TagValue?.GetHashCode() ?? 0;
         // Get hash code for marks also if its not 0
 
         return tagNameHashCode ^ tagValueHashCode;

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/CombinedFile.cs
@@ -148,20 +148,22 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
                     var metsExifItem = arrayMets[depositItemArrayIndex];
 
-                    if (exifItemDepositTagName.ToLower() != metsExifItem.TagName.ToLower()) continue;
+                    if (exifItemDepositTagName != null && metsExifItem.TagName != null && !string.Equals(exifItemDepositTagName, metsExifItem.TagName, StringComparison.CurrentCultureIgnoreCase)) continue;
 
-                    if (!string.Equals(exifItemDepositTagValue, metsExifItem.TagValue, StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        misMatches.Add(new FileMisMatch(nameof(ExifMetadata), exifItemDepositTagName, exifItemDepositTagValue, metsExifItem.TagValue));
-                    }
+                    if (string.Equals(exifItemDepositTagValue, metsExifItem.TagValue,
+                            StringComparison.CurrentCultureIgnoreCase)) continue;
+
+                    if (exifItemDepositTagName != null)
+                        misMatches.Add(new FileMisMatch(nameof(ExifMetadata), exifItemDepositTagName,
+                            exifItemDepositTagValue, metsExifItem.TagValue));
 
                 }
 
                 var resultDeposit = depositExifMetadata.Where(p => metsExifMetadata.All(p2 => p2.TagName != p.TagName));
-                misMatches.AddRange(resultDeposit.Select(depositField => new FileMisMatch(nameof(ExifMetadata), depositField.TagName, depositField.TagValue, "field does not exist in METS")));
+                misMatches.AddRange(resultDeposit.Select(depositField => new FileMisMatch(nameof(ExifMetadata), depositField.TagName ?? string.Empty, depositField.TagValue, "field does not exist in METS")));
 
                 var resultMets = metsExifMetadata.Where(p => depositExifMetadata.All(p2 => p2.TagName != p.TagName));
-                misMatches.AddRange(resultMets.Select(metsField => new FileMisMatch(nameof(ExifMetadata), metsField.TagName, metsField.TagValue, "field does not exist in deposit")));
+                misMatches.AddRange(resultMets.Select(metsField => new FileMisMatch(nameof(ExifMetadata), metsField.TagName ?? string.Empty, metsField.TagValue, "field does not exist in deposit")));
 
             }
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExifMetadata.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExifMetadata.cs
@@ -1,10 +1,11 @@
 ﻿using System.Text.Json.Serialization;
+using DigitalPreservation.Common.Model.DepositHelpers;
 
 namespace DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 
 public class ExifMetadata : Metadata
 {
-    public Dictionary<string, string>? RawToolOutput { get; set; }
+    public List<ExifTag>? RawToolOutput { get; set; } = [];
     public int Width { get; set; }
     public int Height { get; set; }
     public double BitRate { get; set; }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExifMetadata.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExifMetadata.cs
@@ -5,9 +5,5 @@ namespace DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 
 public class ExifMetadata : Metadata
 {
-    public List<ExifTag>? RawToolOutput { get; set; } = [];
-    public int Width { get; set; }
-    public int Height { get; set; }
-    public double BitRate { get; set; }
-    public double Duration { get; set; }
+    public List<ExifTag>? Tags { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.Core.Tests/Lists/ListsComparer.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core.Tests/Lists/ListsComparer.cs
@@ -6,19 +6,7 @@ namespace DigitalPreservation.Core.Tests.Lists;
 public class ListsComparer
 {
     [Fact]
-    public void CompareTwoPersonLists()
-    {
-        var source = new List<Person>() { new("Ken", "Nakamura"), new("Nozomi", "Nakamura") };
-        var compare = new List<Person>() { new("Ken", "Nakamura"), new("Keiko", "Nakamura") };
-        //var result = source.Intersect(compare);
-
-        bool isEqual = source.SequenceEqual(compare, new PersonComparer());
-        var t = source.Except(compare, new PersonComparer());
-        var t1 = compare.Except(source, new PersonComparer());
-    }
-
-    [Fact]
-    public void CompareTwoTagValueLists()
+    public void CompareTwoTagValueListsWithMismatches()
     {
         var depositExifMetadata = new List<ExifTag>();
         depositExifMetadata.Add(new ExifTag {TagName = "ExifToolVersionNumber", TagValue = "13:42"});
@@ -64,79 +52,26 @@ public class ListsComparer
         
         var resultMets = metsExifMetadata.Where(p => depositExifMetadata.All(p2 => p2.TagName != p.TagName));
         misMatches.AddRange(resultMets.Select(metsField => new CombinedFile.FileMisMatch(nameof(ExifMetadata), metsField.TagName ?? string.Empty, metsField.TagValue, "field does not exist in deposit")));
+
+        misMatches.Count.Should().BeGreaterThan(0);
     }
 
-}
-
-public class Person
-{
-    public Person(string firstName, string lastName)
+    [Fact]
+    public void CompareTwoTagValueListsWithZeroMismatches()
     {
-        FirstName = firstName;
-        LastName = lastName;
-    }
-    public string? FirstName { get; set; }
-    public string? LastName { get; set; } 
-}
-public class PersonComparer : IEqualityComparer<Person>
-{
-    public bool Equals(Person x, Person y)
-    {
-        //Check whether the compared objects reference the same data. 
-        if (ReferenceEquals(x, y))
-            return true;
+        var depositExifMetadata = new List<ExifTag>();
+        depositExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:43" });
+        depositExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:45" });
+        depositExifMetadata.Add(new ExifTag { TagName = "Duration", TagValue = "1267" });
 
-        //Check whether any of the compared objects is null. 
-        if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
-            return false;
+        var metsExifMetadata = new List<ExifTag>();
+        metsExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:43" });
+        metsExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:45" });
+        metsExifMetadata.Add(new ExifTag { TagName = "Duration", TagValue = "1267" });
 
-        return string.Equals(x.FirstName, y.FirstName, StringComparison.OrdinalIgnoreCase) && x.LastName == y.LastName;
+        var isEqual = depositExifMetadata.SequenceEqual(metsExifMetadata, new ExifTagComparer());
+
+        isEqual.Should().Be(true);
     }
 
-    public int GetHashCode(Person person)
-    {
-        //Check whether the object is null 
-        if (ReferenceEquals(person, null))
-            return 0;
-
-        //Get hash code for the name field if it is not null
-        int firstNameHashCode = !string.IsNullOrEmpty(person.FirstName) ? 0 : person?.FirstName?.GetHashCode() ?? 0;
-        int lastNameHashCode = !string.IsNullOrEmpty(person?.LastName) ? 0 : person?.LastName?.GetHashCode() ?? 0;
-        // Get hash code for marks also if its not 0
-
-        return firstNameHashCode ^ lastNameHashCode;
-    }
-}
-
-public class ExifTagComparer : IEqualityComparer<ExifTag>
-{
-    public bool Equals(ExifTag? x, ExifTag? y)
-    {
-        //Check whether the compared objects reference the same data. 
-        if (ReferenceEquals(x, y))
-            return true;
-
-        //Check whether any of the compared objects is null. 
-        if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
-            return false;
-
-        return string.Equals(x.TagName, y.TagName, StringComparison.OrdinalIgnoreCase) &&
-               string.Equals(x.TagValue, y.TagValue, StringComparison.OrdinalIgnoreCase);
-    }
-
-    public int GetHashCode(ExifTag exifTag)
-    {
-        //Check whether the object is null 
-        if (ReferenceEquals(exifTag, null))
-            return 0;
-
-        //Get hash code for the name field if it is not null
-        var tagNameHashCode = !string.IsNullOrEmpty(exifTag.TagName) ? 0 : exifTag?.TagName?.GetHashCode() ?? 0;
-        var tagValueHashCode = exifTag != null && !string.IsNullOrEmpty(exifTag.TagValue)
-            ? 0
-            : exifTag?.TagValue?.GetHashCode() ?? 0;
-        // Get hash code for marks also if its not 0
-
-        return tagNameHashCode ^ tagValueHashCode;
-    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Core.Tests/Lists/ListsComparer.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Core.Tests/Lists/ListsComparer.cs
@@ -1,0 +1,145 @@
+﻿using DigitalPreservation.Common.Model.DepositHelpers;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+
+namespace DigitalPreservation.Core.Tests.Lists;
+public class ListsComparer
+{
+    [Fact]
+    public void CompareTwoPersonLists()
+    {
+        var source = new List<Person>() { new Person("Ken", "Nakamura"), new Person("Nozomi", "Nakamura") };
+        var compare = new List<Person>() { new Person("Ken", "Nakamura"), new Person("Keiko", "Nakamura") };
+        //var result = source.Intersect(compare);
+
+        bool isEqual = source.SequenceEqual(compare, new PersonComparer());
+        var t = source.Except(compare, new PersonComparer());
+        var t1 = compare.Except(source, new PersonComparer());
+    }
+
+    [Fact]
+    public void CompareTwoTagValueLists()
+    {
+        var depositExifMetadata = new List<ExifTag>();
+        depositExifMetadata.Add(new ExifTag {TagName = "ExifToolVersionNumber", TagValue = "13:42"});
+        depositExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:44" });
+        depositExifMetadata.Add(new ExifTag { TagName = "ColorVersion", TagValue = "Blah" });
+        depositExifMetadata.Add(new ExifTag { TagName = "Duration", TagValue = "Blah" });
+
+        var metsExifMetadata = new List<ExifTag>();
+        metsExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:43" });
+        metsExifMetadata.Add(new ExifTag { TagName = "ExifToolVersionNumber", TagValue = "13:45" });
+        metsExifMetadata.Add(new ExifTag { TagName = "ColorVersion", TagValue = "Blah" });
+        metsExifMetadata.Add(new ExifTag { TagName = "MatrixStructure", TagValue = "Blah2" });
+
+        //var result = source.Intersect(compare);
+
+        bool isEqual = depositExifMetadata.SequenceEqual(metsExifMetadata, new ExifTagComparer());
+        var t = depositExifMetadata.Except(metsExifMetadata, new ExifTagComparer());
+        var arrayDeposit = t.ToArray();
+        var t1 = metsExifMetadata.Except(depositExifMetadata, new ExifTagComparer());
+        var arrayMets = t1.ToArray();
+
+        var misMatches = new List<CombinedFile.FileMisMatch>();
+
+        foreach (var exifItemDeposit in arrayDeposit.Select((value, i) => (value, i)))
+        {
+            var exifItemDepositTagName = exifItemDeposit.value.TagName;
+            var exifItemDepositTagValue = exifItemDeposit.value.TagValue;
+            var depositItemArrayIndex = exifItemDeposit.i;
+
+            var metsExifItem = arrayMets[depositItemArrayIndex];
+
+            if (exifItemDepositTagName.ToLower() == metsExifItem.TagName.ToLower())
+            {
+                if (!string.Equals(exifItemDepositTagValue, metsExifItem.TagValue, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    misMatches.Add(new CombinedFile.FileMisMatch(nameof(ExifMetadata), exifItemDepositTagName, exifItemDepositTagValue, metsExifItem.TagValue));
+                }
+            }
+
+            var depositTagNameNotInMets =
+                metsExifMetadata.Where(x => x.TagName.ToLower() == exifItemDepositTagName.ToLower());
+        }
+
+        var resultDeposit = depositExifMetadata.Where(p => metsExifMetadata.All(p2 => p2.TagName != p.TagName));
+        misMatches.AddRange(resultDeposit.Select(depositField => new CombinedFile.FileMisMatch(nameof(ExifMetadata), depositField.TagName, depositField.TagValue, "field does not exist in METS")));
+        
+        var resultMets = metsExifMetadata.Where(p => depositExifMetadata.All(p2 => p2.TagName != p.TagName));
+        misMatches.AddRange(resultMets.Select(metsField => new CombinedFile.FileMisMatch(nameof(ExifMetadata), metsField.TagName, metsField.TagValue, "field does not exist in deposit")));
+    }
+
+}
+
+public class Person
+{
+    public Person(string firstName, string lastName)
+    {
+        FirstName = firstName;
+        LastName = lastName;
+    }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+}
+public class PersonComparer : IEqualityComparer<Person>
+{
+    public bool Equals(Person x, Person y)
+    {
+        //Check whether the compared objects reference the same data. 
+        if (object.ReferenceEquals(x, y))
+            return true;
+
+        //Check whether any of the compared objects is null. 
+        if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null))
+            return false;
+
+        return string.Equals(x.FirstName, y.FirstName, StringComparison.OrdinalIgnoreCase) && x.LastName == y.LastName;
+    }
+
+    public int GetHashCode(Person person)
+    {
+        //Check whether the object is null 
+        if (object.ReferenceEquals(person, null))
+            return 0;
+
+        //Get hash code for the name field if it is not null
+        int firstNameHashCode = !string.IsNullOrEmpty(person.FirstName) ? 0 : person.FirstName.GetHashCode();
+        int lastNameHashCode = !string.IsNullOrEmpty(person.LastName) ? 0 : person.LastName.GetHashCode();
+        // Get hash code for marks also if its not 0
+
+        return firstNameHashCode ^ lastNameHashCode;
+    }
+}
+
+public class ExifTagComparer : IEqualityComparer<ExifTag>
+{
+    public bool Equals(ExifTag x, ExifTag y)
+    {
+        //Check whether the compared objects reference the same data. 
+        if (object.ReferenceEquals(x, y))
+            return true;
+
+        //Check whether any of the compared objects is null. 
+        if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null))
+            return false;
+
+        return string.Equals(x.TagName, y.TagName, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(x.TagValue, y.TagValue, StringComparison.OrdinalIgnoreCase);
+        //x.TagValue == y.TagValue;
+
+    }
+
+    public int GetHashCode(ExifTag exifTag)
+    {
+        //Check whether the object is null 
+        if (object.ReferenceEquals(exifTag, null))
+            return 0;
+
+        //Get hash code for the name field if it is not null
+        int tagNameHashCode = !string.IsNullOrEmpty(exifTag.TagName) ? 0 : exifTag.TagName.GetHashCode();
+        int tagValueHashCode = !string.IsNullOrEmpty(exifTag.TagValue) ? 0 : exifTag.TagValue.GetHashCode();
+        // Get hash code for marks also if its not 0
+
+        return tagNameHashCode ^ tagValueHashCode;
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -195,48 +195,67 @@
             
             @{
                 List<string> mismatchMessages = [];
+                List<string> exifMismatchMessages = [];
             }
 
             @foreach (var detailMismatch in Model.FileMisMatches)
             {
                 foreach (var fileMismatch in detailMismatch.Item1)
                 {
-                    switch (fileMismatch.Field.ToLower())
+                    if (!(fileMismatch.MetadataType.ToLower() == "exifmetadata"))
                     {
-                        case "contenttype":
-                            mismatchMessages.Add("Content type");
-                            break;
-                        case "pronomkey":
-                            mismatchMessages.Add("Pronom key");
-                            break;
-                        case "formatname":
-                            mismatchMessages.Add("Format name");
-                            break;
-                        case "digest":
-                            mismatchMessages.Add("Digest");
-                            break;
-                        case "hasvirus":
-                            mismatchMessages.Add("Has virus");
-                            break;
-                        case "virusfound":
-                            mismatchMessages.Add("Virus found");
-                            break;
-                        case "virusdefinition":
-                            mismatchMessages.Add("Virus definition");
-                            break;
-                        case "(missing section)":
-                            mismatchMessages.Add("Missing metadata section: " + (fileMismatch.ValueInDeposit ?? fileMismatch.ValueInMets ?? "not specified"));
-                            break;
-                        default:
-                            mismatchMessages.Add("undocumented difference");
-                            break;
+                        switch (fileMismatch.Field.ToLower())
+                        {
+                            case "contenttype":
+                                mismatchMessages.Add("Content type");
+                                break;
+                            case "pronomkey":
+                                mismatchMessages.Add("Pronom key");
+                                break;
+                            case "formatname":
+                                mismatchMessages.Add("Format name");
+                                break;
+                            case "digest":
+                                mismatchMessages.Add("Digest");
+                                break;
+                            case "hasvirus":
+                                mismatchMessages.Add("Has virus");
+                                break;
+                            case "virusfound":
+                                mismatchMessages.Add("Virus found");
+                                break;
+                            case "virusdefinition":
+                                mismatchMessages.Add("Virus definition");
+                                break;
+                            case "(missing section)":
+                                mismatchMessages.Add("Missing metadata section: " + (fileMismatch.ValueInDeposit ?? fileMismatch.ValueInMets ?? "not specified"));
+                                break;
+                            default:
+                                mismatchMessages.Add("undocumented difference");
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        exifMismatchMessages.Add(fileMismatch.Field);
                     }
                 }
 
-                var differencesString = String.Join(", ", mismatchMessages.Select(x => x.ToString()).ToArray());
-                <p>@detailMismatch.Item2 (Differences: @differencesString)</p>
+                if (mismatchMessages.Any())
+                {
+                    var differencesString = String.Join(", ", mismatchMessages.Select(x => x.ToString()).ToArray());
+                    <p>@detailMismatch.Item2 (Differences: @differencesString)</p>
 
-                mismatchMessages.Clear();
+                    mismatchMessages.Clear();
+                }
+
+                if (exifMismatchMessages.Any())
+                {
+                    var differencesString = String.Join(", ", exifMismatchMessages.Select(x => x.ToString()).ToArray());
+                    <p>@detailMismatch.Item2 Exif Metadata: (Differences: @differencesString)</p>
+
+                    exifMismatchMessages.Clear();
+                }
             }
             
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -538,11 +538,12 @@ public class MetadataReader : IMetadataReader
                 else
                 {
                     var metadataPair = str.Split(":", 2);
+                    var key = metadataPair[0].Trim().Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty);
 
-                    if (exifMetadataForFile.ContainsKey(metadataPair[0].Trim()))
+                    if (exifMetadataForFile.ContainsKey(key))
                         continue;
 
-                    exifMetadataForFile.Add(metadataPair[0].Trim(), metadataPair[1].Trim());
+                    exifMetadataForFile.Add(key, metadataPair[1].Trim());
                 }
             }
 

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -540,10 +540,13 @@ public class MetadataReader : IMetadataReader
                     var metadataPair = str.Split(":", 2);
                     var key = metadataPair[0].Trim().Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty);
 
-                    if (exifMetadataForFile.ContainsKey(key))
-                        continue;
+                    var duplicates = exifMetadataForFile.Where(kvp => kvp.Key.StartsWith(key))
+                        .Select(kvp => kvp.Value)
+                        .ToList();
 
-                    exifMetadataForFile.Add(key, metadataPair[1].Trim());
+                    //index duplicates by appending sequential number at the end
+                    exifMetadataForFile.Add(exifMetadataForFile.ContainsKey(key) ? $"{key}{duplicates.Count}" : key,
+                        metadataPair[1].Trim());
                 }
             }
 
@@ -574,4 +577,5 @@ public class ExifModel
 {
     public required string Filepath { get; set; }
     public Dictionary<string, string> ExifMetadata { get; set; } = [];
+    //public List<KeyValuePair<string, string>> ExifMetadata { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -136,7 +136,7 @@ public class MetadataReader : IMetadataReader
             // => bc-example-1
             AddFileFormatMetadata(brunnhildeSiegfriedOutput, brunnhildeSiegfriedCommonParent, "Brunnhilde", timestamp);
         }
-        string brunnhildeAvCommonPrefix;
+
         var virusDefinitionRoot = workingRootUri.AppendEscapedSlug("metadata").AppendEscapedSlug("virus-definition").AppendEscapedSlug("virus-definition.txt");
 
         var virusDefinition = string.Empty;
@@ -160,20 +160,20 @@ public class MetadataReader : IMetadataReader
             }
         }
 
-        brunnhildeAvCommonPrefix = StringUtils.GetCommonParent(infectedFiles.Select(s => s.Filepath));
-        brunnhildeAvCommonPrefix = AllowForObjectsAndMetadata(brunnhildeAvCommonPrefix);
+        var brunnhildeCommonPrefix = StringUtils.GetCommonParent(infectedFiles.Select(s => s.Filepath));
+        brunnhildeCommonPrefix = AllowForObjectsAndMetadata(brunnhildeCommonPrefix);
 
         var brunnhildeFiles = brunnhildeSiegfriedOutput is { Files.Count: > 0 } ? brunnhildeSiegfriedOutput.Files : [];
-        AddVirusScanMetadata(brunnhildeFiles, brunnhildeAvCommonPrefix, brunnhildeSiegfriedCommonParent, "ClamAv", timestamp, virusDefinition);
+        AddVirusScanMetadata(brunnhildeFiles, brunnhildeCommonPrefix, brunnhildeSiegfriedCommonParent, "ClamAv", timestamp, virusDefinition);
 
         exifMetadataList = await GetExifOutputForAllFiles();
 
         if (!exifMetadataList.Any())
             return;
 
-        brunnhildeAvCommonPrefix = StringUtils.GetCommonParent(exifMetadataList.Select(s => s.Filepath));
-        brunnhildeAvCommonPrefix = AllowForObjectsAndMetadata(brunnhildeAvCommonPrefix);
-        AddExifMetadata(brunnhildeAvCommonPrefix, "Exif", timestamp);
+        brunnhildeCommonPrefix = StringUtils.GetCommonParent(exifMetadataList.Select(s => s.Filepath));
+        brunnhildeCommonPrefix = AllowForObjectsAndMetadata(brunnhildeCommonPrefix);
+        AddExifMetadata(brunnhildeCommonPrefix, "ExifTool", timestamp);
     }
 
     private void AddFileFormatMetadata(SiegfriedOutput siegfriedOutput, string commonParent, string source, DateTime timestamp)
@@ -258,7 +258,7 @@ public class MetadataReader : IMetadataReader
             {
                 Source = source,
                 Timestamp = timestamp,
-                RawToolOutput = exifMetadata.ExifMetadata
+                Tags = exifMetadata.ExifMetadata
             });
         }
     }
@@ -501,11 +501,11 @@ public class MetadataReader : IMetadataReader
 
         if (exifResult.Value == null) return [];
         var txt = await GetTextFromStream(exifResult.Value);
-        return ConvertExifResultStringToJson(txt);
+        return ParseExifToolOutput(txt);
 
     }
 
-    public static List<ExifModel> ConvertExifResultStringToJson(string exifResultStr)
+    public static List<ExifModel> ParseExifToolOutput(string exifResultStr)
     {
         try
         {

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -1,4 +1,5 @@
-﻿using DigitalPreservation.Common.Model.ToolOutput.Siegfried;
+﻿using DigitalPreservation.Common.Model.DepositHelpers;
+using DigitalPreservation.Common.Model.ToolOutput.Siegfried;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Utils;
@@ -513,7 +514,7 @@ public class MetadataReader : IMetadataReader
 
             var exifModel = new ExifModel { Filepath = string.Empty, ExifMetadata = [] };
             var i = 0;
-            var exifMetadataForFile = new Dictionary<string, string>();
+            var exifMetadataForFile = new List<ExifTag>();
 
             foreach (var str in exifResultList)
             {
@@ -521,7 +522,7 @@ public class MetadataReader : IMetadataReader
                 {
                     if (i > 0)
                     {
-                        exifModel.ExifMetadata = new Dictionary<string, string>(exifMetadataForFile);
+                        exifModel.ExifMetadata = new List<ExifTag>(exifMetadataForFile);
                         exifMetadataForFile.Clear();
                         result.Add(exifModel);
 
@@ -540,13 +541,11 @@ public class MetadataReader : IMetadataReader
                     var metadataPair = str.Split(":", 2);
                     var key = metadataPair[0].Trim().Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty);
 
-                    var duplicates = exifMetadataForFile.Where(kvp => kvp.Key.StartsWith(key))
-                        .Select(kvp => kvp.Value)
-                        .ToList();
-
-                    //index duplicates by appending sequential number at the end
-                    exifMetadataForFile.Add(exifMetadataForFile.ContainsKey(key) ? $"{key}{duplicates.Count}" : key,
-                        metadataPair[1].Trim());
+                    exifMetadataForFile.Add(new ExifTag
+                    {
+                        TagName = key,
+                        TagValue = metadataPair[1].Trim()
+                    });
                 }
             }
 
@@ -576,6 +575,7 @@ public class VirusModel
 public class ExifModel
 {
     public required string Filepath { get; set; }
-    public Dictionary<string, string> ExifMetadata { get; set; } = [];
+    //public Dictionary<string, string> ExifMetadata { get; set; } = [];
     //public List<KeyValuePair<string, string>> ExifMetadata { get; set; } = [];
+    public List<ExifTag> ExifMetadata { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -575,7 +575,5 @@ public class VirusModel
 public class ExifModel
 {
     public required string Filepath { get; set; }
-    //public Dictionary<string, string> ExifMetadata { get; set; } = [];
-    //public List<KeyValuePair<string, string>> ExifMetadata { get; set; } = [];
     public List<ExifTag> ExifMetadata { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.XmlGen/DigitalPreservation.XmlGen.Premis.V3.cs
+++ b/src/DigitalPreservation/DigitalPreservation.XmlGen/DigitalPreservation.XmlGen.Premis.V3.cs
@@ -525,7 +525,7 @@ namespace DigitalPreservation.XmlGen.Premis.V3
             {
                 return _any;
             }
-            set
+            private set
             {
                 _any = value;
             }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -632,14 +632,11 @@ public class MetsParser(
                     };
                 }
                 
-                var amd = xMets.Descendants(XNames.MetsAmdSec)
-                    .SingleOrDefault(t => t.Attribute("ID")!.Value == admId);
-                //TODO: EXIF Metadata 1. Similar for Exif - XNames.MetsDigiprovMD
-                var exifMetadataNode = amd.Descendants("ExifMetadata").SingleOrDefault(); //TODO:working file
-                ///
+                var amd = xMets.Descendants(XNames.MetsAmdSec).SingleOrDefault(t => t.Attribute("ID")!.Value == admId);
+                var exifMetadataNode = amd?.Descendants("ExifMetadata").SingleOrDefault(); //TODO:working file
+               
                 if (exifMetadataNode != null)
                 {
-                    //var lookup = exifMetadataNode.Descendants().ToLookup(x => x.Name.LocalName, x => x.Value);
                     var exifMetadataDictionary = exifMetadataNode.Descendants().ToDictionary(x => x.Name.LocalName, x => x.Value);
                     exifMetadata = new ExifMetadata
                     {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -634,7 +634,7 @@ public class MetsParser(
                 }
                 
                 var amd = xMets.Descendants(XNames.MetsAmdSec).SingleOrDefault(t => t.Attribute("ID")!.Value == admId);
-                var exifMetadataNode = amd?.Descendants("ExifMetadata").SingleOrDefault(); //TODO:working file
+                var exifMetadataNode = amd?.Descendants("ExifMetadata").SingleOrDefault();
                
                 if (exifMetadataNode != null)
                 {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -638,6 +638,7 @@ public class MetsParser(
                
                 if (exifMetadataNode != null)
                 {
+                    var timestamp = DateTime.UtcNow;
                     var exifMetadataList = new List<ExifTag>();
                     foreach (var element in exifMetadataNode.Descendants())
                     {
@@ -647,8 +648,8 @@ public class MetsParser(
                     exifMetadata = new ExifMetadata
                     {
                         Source = "METS",
-                        Timestamp = DateTime.UtcNow,
-                        RawToolOutput = exifMetadataList
+                        Timestamp = timestamp,
+                        Tags = exifMetadataList
                     };
 
                 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -3,6 +3,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
 using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.DepositHelpers;
 using DigitalPreservation.Common.Model.Mets;
 using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
@@ -637,12 +638,17 @@ public class MetsParser(
                
                 if (exifMetadataNode != null)
                 {
-                    var exifMetadataDictionary = exifMetadataNode.Descendants().ToDictionary(x => x.Name.LocalName, x => x.Value);
+                    var exifMetadataList = new List<ExifTag>();
+                    foreach (var element in exifMetadataNode.Descendants())
+                    {
+                        exifMetadataList.Add(new ExifTag{TagName = element.Name.LocalName , TagValue = element.Value });
+                    }
+
                     exifMetadata = new ExifMetadata
                     {
                         Source = "METS",
                         Timestamp = DateTime.UtcNow,
-                        RawToolOutput = exifMetadataDictionary
+                        RawToolOutput = exifMetadataList
                     };
 
                 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -106,25 +106,25 @@ public static class PremisManager
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
                         {
-                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
                         {
-                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
                         {
-                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
                         {
-                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue ?? string.Empty);
                         }
                     }
                 }
@@ -243,25 +243,25 @@ public static class PremisManager
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
                         {
-                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
                         {
-                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
                         {
-                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue ?? string.Empty);
                         }
 
-                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
+                        if (fileExifMetadata.TagName != null && fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
                         {
-                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue);
+                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue ?? string.Empty);
                         }
                     }
                 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -394,8 +394,8 @@ public static class PremisManager
     {
         try
         {
-            var element = document.CreateElement(exifMetdata.TagName.Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty));
-            element.InnerText = exifMetdata.TagValue;
+            var element = document.CreateElement(exifMetdata.TagName ?? string.Empty.Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty));
+            element.InnerText = exifMetdata.TagValue ?? string.Empty;
             return element;
         }
         catch (Exception)

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -4,8 +4,8 @@ using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Premis.V3;
 using System.Collections.ObjectModel;
 using System.Xml;
-using System.Xml.Linq;
 using System.Xml.Serialization;
+using DigitalPreservation.Common.Model.DepositHelpers;
 using File = DigitalPreservation.XmlGen.Premis.V3.File;
 
 namespace Storage.Repository.Common.Mets;
@@ -95,7 +95,7 @@ public static class PremisManager
         {
             var document = new XmlDocument();
             var parentCollection = new Collection<XmlElement>();
-            var parentElement = GetXmlElement(new KeyValuePair<string, string>("ExifMetadata", string.Empty), document);
+            var parentElement = GetXmlElement(new ExifTag{ TagName = "ExifMetadata" , TagValue = string.Empty}, document);
 
             if (parentElement != null)
             {
@@ -106,35 +106,32 @@ public static class PremisManager
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
                         {
-                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue);
                         }
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
                         {
-                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue);
                         }
 
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "duration")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
                         {
-                            AddSignificantProperty(file, "Duration", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue);
                         }
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
                         {
-                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue);
                         }
                     }
                 }
 
                 parentCollection.Add(parentElement);
-
-                var parentExtension = new ObjectCharacteristicsExtension
-                {
-                    Any = parentCollection
-                };
+                var parentExtension = new ObjectCharacteristicsExtension();
+                parentExtension.Any.Add(parentElement);
 
                 objectCharacteristics.ObjectCharacteristicsExtension.Add(parentExtension);
             }
@@ -225,20 +222,20 @@ public static class PremisManager
         {
             var document = new XmlDocument();
             var parentCollection = new Collection<XmlElement>();
-            var parentElement = GetXmlElement(new KeyValuePair<string, string>("ExifMetadata", string.Empty), document);
+            var parentElement = GetXmlElement(new ExifTag { TagName = "ExifMetadata", TagValue = string.Empty }, document);
+            
+            foreach (var extensionComplexType in objectCharacteristics.ObjectCharacteristicsExtension.ToList())
+            {
+                objectCharacteristics.ObjectCharacteristicsExtension.Remove(extensionComplexType);
+            }
+
+            foreach (var significantPropertiesComplexType in file.SignificantProperties.ToList())
+            {
+                file.SignificantProperties.Remove(significantPropertiesComplexType);
+            }
 
             if (parentElement != null)
             {
-                foreach (var extensionComplexType in objectCharacteristics.ObjectCharacteristicsExtension.ToList())
-                {
-                    objectCharacteristics.ObjectCharacteristicsExtension.Remove(extensionComplexType);
-                }
-
-                foreach (var significantPropertiesComplexType in file.SignificantProperties.ToList())
-                {
-                    file.SignificantProperties.Remove(significantPropertiesComplexType);
-                }
-
                 if (exifMetadata is { RawToolOutput: not null })
                 {
                     foreach (var fileExifMetadata in exifMetadata.RawToolOutput)
@@ -246,35 +243,32 @@ public static class PremisManager
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imageheight")
                         {
-                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "ImageHeight", fileExifMetadata.TagValue);
                         }
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "imagewidth")
                         {
-                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "ImageWidth", fileExifMetadata.TagValue);
                         }
 
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "duration")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "duration")
                         {
-                            AddSignificantProperty(file, "Duration", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "Duration", fileExifMetadata.TagValue);
                         }
 
-                        if (fileExifMetadata.Key.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
+                        if (fileExifMetadata.TagName.ToLower().Trim().Replace(" ", string.Empty) == "avgbitrate")
                         {
-                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.Value);
+                            AddSignificantProperty(file, "Bitrate", fileExifMetadata.TagValue);
                         }
                     }
                 }
 
                 parentCollection.Add(parentElement);
-
-                var parentExtension = new ObjectCharacteristicsExtension
-                {
-                    Any = parentCollection
-                };
+                var parentExtension = new ObjectCharacteristicsExtension();
+                parentExtension.Any.Add(parentElement);
 
                 objectCharacteristics.ObjectCharacteristicsExtension.Add(parentExtension);
             }
@@ -396,12 +390,12 @@ public static class PremisManager
         return doc.DocumentElement;
     }
 
-    public static XmlElement? GetXmlElement(KeyValuePair<string, string> exifMetdata, XmlDocument document)
+    public static XmlElement? GetXmlElement(ExifTag exifMetdata, XmlDocument document)
     {
         try
         {
-            var element = document.CreateElement(exifMetdata.Key.Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty));
-            element.InnerText = exifMetdata.Value;
+            var element = document.CreateElement(exifMetdata.TagName.Replace(" ", string.Empty).Replace("/", string.Empty).Replace(@"\", string.Empty));
+            element.InnerText = exifMetdata.TagValue;
             return element;
         }
         catch (Exception)

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -94,14 +94,13 @@ public static class PremisManager
         if (exifMetadata != null)
         {
             var document = new XmlDocument();
-            var parentCollection = new Collection<XmlElement>();
             var parentElement = GetXmlElement(new ExifTag{ TagName = "ExifMetadata" , TagValue = string.Empty}, document);
 
             if (parentElement != null)
             {
-                if (exifMetadata is { RawToolOutput: not null })
+                if (exifMetadata is { Tags: not null })
                 {
-                    foreach (var fileExifMetadata in exifMetadata.RawToolOutput)
+                    foreach (var fileExifMetadata in exifMetadata.Tags)
                     {
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
@@ -129,7 +128,6 @@ public static class PremisManager
                     }
                 }
 
-                parentCollection.Add(parentElement);
                 var parentExtension = new ObjectCharacteristicsExtension();
                 parentExtension.Any.Add(parentElement);
 
@@ -221,7 +219,6 @@ public static class PremisManager
         if (exifMetadata != null)
         {
             var document = new XmlDocument();
-            var parentCollection = new Collection<XmlElement>();
             var parentElement = GetXmlElement(new ExifTag { TagName = "ExifMetadata", TagValue = string.Empty }, document);
             
             foreach (var extensionComplexType in objectCharacteristics.ObjectCharacteristicsExtension.ToList())
@@ -236,9 +233,9 @@ public static class PremisManager
 
             if (parentElement != null)
             {
-                if (exifMetadata is { RawToolOutput: not null })
+                if (exifMetadata is { Tags: not null })
                 {
-                    foreach (var fileExifMetadata in exifMetadata.RawToolOutput)
+                    foreach (var fileExifMetadata in exifMetadata.Tags)
                     {
                         var element = GetXmlElement(fileExifMetadata, document);
                         if (element != null) parentElement.AppendChild(element);
@@ -266,7 +263,6 @@ public static class PremisManager
                     }
                 }
 
-                parentCollection.Add(parentElement);
                 var parentExtension = new ObjectCharacteristicsExtension();
                 parentExtension.Any.Add(parentElement);
 


### PR DESCRIPTION
Ticket:
https://digirati.atlassian.net/browse/LPII-5
https://digirati.atlassian.net/browse/LPII-12

Have added a list comparer for the Deposit and METS Exif Metadata lists.
Added a test to work on the technique.
Handling duplicates in the Exif output.

To reproduce mismatches - just edit/add items in the `MetsParser.cs` collection when running locally after running a pipeline job.

To add an item to `exifMetadataList` collection:
`exifMetadataList.Add(new ExifTag { TagName = "OnlyInMets", TagValue = "METS Only" });`

Here in screenshot `exifMetadataList` collection

<img width="984" height="673" alt="image" src="https://github.com/user-attachments/assets/3473f57e-486a-46d6-bba3-b6d99daab6d6" />
