### PR TITLE
Introduce ResourceBase base class

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/Constants.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/Constants.cs
@@ -1,0 +1,9 @@
+﻿namespace DigitalPreservation.Common.Model.Mets;
+
+public class Constants
+{
+    public const string MetsCreatorAgent = "University of Leeds Digital Library Infrastructure Project";
+    public const string RestrictionOnAccess = "restriction on access";
+    public const string UseAndReproduction = "use and reproduction";
+    public const string Mets = "METS";
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
@@ -1,16 +1,10 @@
-﻿using DigitalPreservation.Common.Model.PreservationApi;
-using DigitalPreservation.Common.Model.Results;
+﻿using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
 
 namespace DigitalPreservation.Common.Model.Mets;
 
 public interface IMetsManager
 {
-    public const string MetsCreatorAgent = "University of Leeds Digital Library Infrastructure Project";
-    
-    public const string RestrictionOnAccess = "restriction on access";
-    public const string UseAndReproduction = "use and reproduction";
-    
     // Create an empty METS file
     Task<Result<MetsFileWrapper>> CreateStandardMets(Uri metsLocation, string? agNameFromDeposit);
     // Reverse-engineer a METS file from an existing AG. This is OK for now but likely to be an error scenario

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/MetsExtensions.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/MetsExtensions.cs
@@ -9,24 +9,13 @@ public class MetsExtensions
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Href { get; set; }
     
-    [JsonPropertyName("physDivId")]
+    [JsonPropertyName("divId")]
     [JsonPropertyOrder(101)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? PhysDivId { get; set; }
+    public string? DivId { get; set; }
     
     [JsonPropertyName("admId")]
     [JsonPropertyOrder(102)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AdmId { get; set; }
-    
-    [JsonPropertyName("rightsStatement")]
-    [JsonPropertyOrder(103)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? RightsStatement { get; set; }
-    
-    [JsonPropertyName("accessCondition")]
-    [JsonPropertyOrder(104)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? AccessCondition { get; set; }
-    
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/ResourceBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/ResourceBase.cs
@@ -1,0 +1,37 @@
+﻿using System.Text.Json.Serialization;
+using DigitalPreservation.Common.Model.Transit.Extensions;
+
+namespace DigitalPreservation.Common.Model.Transit;
+
+public abstract class ResourceBase
+{
+    [JsonPropertyOrder(0)]
+    [JsonPropertyName("type")]
+    public abstract string Type { get; set; }
+
+    [JsonPropertyName("name")]
+    [JsonPropertyOrder(2)]
+    public string? Name { get; set; }
+
+    // METS-specific information
+    [JsonPropertyName("metsExtensions")]
+    [JsonPropertyOrder(100)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MetsExtensions? MetsExtensions { get; set; }
+
+    [JsonPropertyName("accessRestrictions")]
+    [JsonPropertyOrder(5)]
+    public List<string> AccessRestrictions { get; set; } = [];
+
+    [JsonPropertyName("effectiveAccessRestrictions")]
+    [JsonPropertyOrder(6)]
+    public List<string> EffectiveAccessRestrictions { get; set; } = [];
+
+    [JsonPropertyName("rightsStatement")]
+    [JsonPropertyOrder(10)]
+    public Uri? RightsStatement { get; set; }
+
+    [JsonPropertyName("effectiveRightsStatement")]
+    [JsonPropertyOrder(11)]
+    public Uri? EffectiveRightsStatement { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingBase.cs
@@ -1,16 +1,13 @@
 ﻿using System.Text.Json.Serialization;
-using DigitalPreservation.Common.Model.Transit.Extensions;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
-using DigitalPreservation.Utils;
 
 namespace DigitalPreservation.Common.Model.Transit;
 
-public abstract class WorkingBase
+/// <summary>
+/// Base class for physical resources in METS that have a local file path
+/// </summary>
+public abstract class WorkingBase : ResourceBase
 {
-    [JsonPropertyOrder(0)]
-    [JsonPropertyName("type")]
-    public abstract string Type { get; set; }
-    
     /// <summary>
     /// This is always a file system rather than a URI path, and may contain characters acceptable in a file name
     /// but not a URI.
@@ -19,31 +16,14 @@ public abstract class WorkingBase
     [JsonPropertyOrder(1)]
     public required string LocalPath { get; set; }
     
-    [JsonPropertyName("name")]
-    [JsonPropertyOrder(2)]
-    public string? Name { get; set; }
-    
     [JsonPropertyName("modified")]
     [JsonPropertyOrder(3)]
     public DateTime Modified { get; set; }
     
-    // METS-specific information
-    [JsonPropertyName("metsExtensions")]
-    [JsonPropertyOrder(100)]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public MetsExtensions? MetsExtensions { get; set; }
-    
+    [JsonPropertyName("metadata")]
+    [JsonPropertyOrder(200)]
     public List<Metadata> Metadata { get; set; } = [];
     
-    [JsonPropertyName("accessRestrictions")]
-    [JsonPropertyOrder(5)]
-    public List<string> AccessRestrictions { get; set; } = [];
-    
-    [JsonPropertyName("rightsStatement")]
-    [JsonPropertyOrder(6)]
-    public Uri? RightsStatement { get; set; }
-    
-
     public string GetSlug()
     {
         return LocalPath.Split('/')[^1];

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml
@@ -390,7 +390,7 @@
                                     var fileFormatMetadata = metsBinary?.GetFileFormatMetadata();
                                     var virusMetadata = metsBinary?.GetVirusScanMetadata();
                                     <td aria-label="td-format" title="@fileFormatMetadata?.FormatName">@fileFormatMetadata?.PronomKey</td>
-                                    <td aria-label="td-access">@metsBinary?.MetsExtensions?.AccessCondition</td>
+                                    <td aria-label="td-access">@string.Join(", ", metsBinary?.AccessRestrictions ?? [])</td>
 
                                     @if (virusMetadata is { HasVirus: true })
                                     {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -299,9 +299,9 @@ public class MetsManager(
             agentName = mets.MetsHdr.Agent[0].Name;
         }
 
-        if (agentName != IMetsManager.MetsCreatorAgent)
+        if (agentName != Constants.MetsCreatorAgent)
         {
-            return Result.FailNotNull<FullMets>(ErrorCodes.BadRequest, "METS file was not created by " + IMetsManager.MetsCreatorAgent);
+            return Result.FailNotNull<FullMets>(ErrorCodes.BadRequest, "METS file was not created by " + Constants.MetsCreatorAgent);
         }
 
         if (mets != null)
@@ -731,7 +731,7 @@ public class MetsManager(
                         Role = MetsTypeMetsHdrAgentRole.Creator, 
                         Type = MetsTypeMetsHdrAgentType.Other, 
                         Othertype = "SOFTWARE",
-                        Name = IMetsManager.MetsCreatorAgent
+                        Name = Constants.MetsCreatorAgent
                     }
                 }
             },
@@ -853,7 +853,7 @@ public class MetsManager(
     public List<string> GetRootAccessRestrictions(FullMets fullMets)
     {
         var mods = ModsManager.GetRootMods(fullMets.Mets);
-        return mods == null ? [] : mods.GetAccessConditions(IMetsManager.RestrictionOnAccess); // may add Goobi things to this
+        return mods == null ? [] : mods.GetAccessConditions(Constants.RestrictionOnAccess); // may add Goobi things to this
     }
 
     public void SetRootAccessRestrictions(FullMets fullMets, List<string> accessRestrictions)
@@ -861,10 +861,10 @@ public class MetsManager(
         var mods = ModsManager.GetRootMods(fullMets.Mets);
         if (mods is null) return;
         
-        mods.RemoveAccessConditions(IMetsManager.RestrictionOnAccess);
+        mods.RemoveAccessConditions(Constants.RestrictionOnAccess);
         foreach (var accessRestriction in accessRestrictions)
         {
-            mods.AddAccessCondition(accessRestriction, IMetsManager.RestrictionOnAccess);
+            mods.AddAccessCondition(accessRestriction, Constants.RestrictionOnAccess);
         }
         ModsManager.SetRootMods(fullMets.Mets, mods);
     }
@@ -874,10 +874,10 @@ public class MetsManager(
         var mods = ModsManager.GetRootMods(fullMets.Mets);
         if (mods is null) return;
         
-        mods.RemoveAccessConditions(IMetsManager.UseAndReproduction);
+        mods.RemoveAccessConditions(Constants.UseAndReproduction);
         if (uri is not null)
         {
-            mods.AddAccessCondition(uri.ToString(), IMetsManager.UseAndReproduction);
+            mods.AddAccessCondition(uri.ToString(), Constants.UseAndReproduction);
         }
         ModsManager.SetRootMods(fullMets.Mets, mods);
     }
@@ -885,7 +885,7 @@ public class MetsManager(
     public Uri? GetRootRightsStatement(FullMets fullMets)
     {
         var mods = ModsManager.GetRootMods(fullMets.Mets);
-        var rights = mods?.GetAccessConditions(IMetsManager.UseAndReproduction).SingleOrDefault();
+        var rights = mods?.GetAccessConditions(Constants.UseAndReproduction).SingleOrDefault();
         return rights is not null ? new Uri(rights) : null;
     }
 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -188,7 +188,7 @@ public class MetsParser(
                 // and in the flat list
                 mets.Files.Add(mets.Self);
             }
-            mets.Editable = mets.Agent == IMetsManager.MetsCreatorAgent;
+            mets.Editable = mets.Agent == Constants.MetsCreatorAgent;
         }
         return Result.OkNotNull(mets);
     }
@@ -202,7 +202,7 @@ public class MetsParser(
             PhysicalStructure = Storage.RootDirectory()
         };
         PopulateFromMets(mets, metsXDocument);
-        mets.Editable = mets.Agent == IMetsManager.MetsCreatorAgent;
+        mets.Editable = mets.Agent == Constants.MetsCreatorAgent;
         return Result.OkNotNull(mets);
     }
 
@@ -319,14 +319,14 @@ public class MetsParser(
             foreach (var accessCondition in rootAccessConditions)
             {
                 var acType = accessCondition.Attribute("type")?.Value;
-                if (acType is IMetsManager.RestrictionOnAccess or "status") // status is Goobi access cond
+                if (acType is Constants.RestrictionOnAccess or "status") // status is Goobi access cond
                 {
                     if (accessCondition.Value.HasText())
                     {
                         mets.RootAccessConditions.Add(accessCondition.Value);
                     }
                 }
-                else if (acType is IMetsManager.UseAndReproduction) // Goobi might have different
+                else if (acType is Constants.UseAndReproduction) // Goobi might have different
                 {
                     if (accessCondition.Value.HasText() && mets.RootRightsStatement is null)
                     {
@@ -468,8 +468,7 @@ public class MetsParser(
                                 workingDirectory.MetsExtensions = new MetsExtensions
                                 {
                                     AdmId = admId,
-                                    PhysDivId = div.Attribute("ID")?.Value,
-                                    AccessCondition = "Open"
+                                    DivId = div.Attribute("ID")?.Value
                                 };
                                 workingDirectory.Metadata =
                                 [
@@ -686,8 +685,7 @@ public class MetsParser(
                     MetsExtensions = new MetsExtensions
                     {
                         AdmId = admId,
-                        PhysDivId = div.Attribute("ID")?.Value,
-                        AccessCondition = "Open"
+                        DivId = div.Attribute("ID")?.Value
                     }
                 };
                 if (premisMetadata != null)

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/PremisManager.cs
@@ -2,7 +2,6 @@
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Premis.V3;
-using System.Collections.ObjectModel;
 using System.Xml;
 using System.Xml.Serialization;
 using DigitalPreservation.Common.Model.DepositHelpers;
@@ -13,8 +12,8 @@ namespace Storage.Repository.Common.Mets;
 public static class PremisManager
 {
     private static readonly XmlSerializerNamespaces Namespaces;
-    public const string Pronom = "PRONOM";
-    public const string Sha256 = "SHA256";
+    private const string Pronom = "PRONOM";
+    private const string Sha256 = "SHA256";
     
     static PremisManager()
     {
@@ -64,7 +63,7 @@ public static class PremisManager
         }
         
         var storage = file.Storage?.SingleOrDefault(
-            s => s.StorageMedium.FirstOrDefault(sm => sm.Value == IMetsManager.MetsCreatorAgent) != null);
+            s => s.StorageMedium.FirstOrDefault(sm => sm.Value == Constants.MetsCreatorAgent) != null);
         if (storage != null)
         {
             premisFile.StorageLocation = new Uri(storage.ContentLocation.ContentLocationValue);
@@ -170,7 +169,7 @@ public static class PremisManager
         if (premisFile.StorageLocation != null)
         {
             var storageComplexType = new StorageComplexType();
-            storageComplexType.StorageMedium.Add(new StorageMedium { Value = IMetsManager.MetsCreatorAgent });
+            storageComplexType.StorageMedium.Add(new StorageMedium { Value = Constants.MetsCreatorAgent });
             storageComplexType.ContentLocation = new ContentLocationComplexType
             {
                 ContentLocationType = new ContentLocationType { Value = "uri" },
@@ -333,11 +332,11 @@ public static class PremisManager
     private static ContentLocationComplexType EnsureContentLocation(File file)
     {
         var thisStorage = file.Storage.FirstOrDefault(
-            s => s.StorageMedium.FirstOrDefault(sm => sm.Value == IMetsManager.MetsCreatorAgent) != null);
+            s => s.StorageMedium.FirstOrDefault(sm => sm.Value == Constants.MetsCreatorAgent) != null);
         if (thisStorage == null)
         {
             thisStorage = new StorageComplexType();
-            thisStorage.StorageMedium.Add(new StorageMedium { Value = IMetsManager.MetsCreatorAgent });
+            thisStorage.StorageMedium.Add(new StorageMedium { Value = Constants.MetsCreatorAgent });
             file.Storage.Add(thisStorage);
         }
 

--- a/src/DigitalPreservation/Test.Helpers/TestData/TestStructure.cs
+++ b/src/DigitalPreservation/Test.Helpers/TestData/TestStructure.cs
@@ -187,7 +187,7 @@ public class TestStructure
                                   "files": [],
                                   "directories": [],
                                   "metsExtensions": {
-                                    "physDivId": "PHYS_metadata",
+                                    "divId": "PHYS_metadata",
                                     "admId": "ADM_metadata",
                                     "accessCondition": "Open",
                                     "originalPath": "metadata"
@@ -201,7 +201,7 @@ public class TestStructure
                                   "files": [],
                                   "directories": [],
                                   "metsExtensions": {
-                                    "physDivId": "PHYS_objects",
+                                    "divId": "PHYS_objects",
                                     "admId": "ADM_objects",
                                     "accessCondition": "Open",
                                     "originalPath": "objects"


### PR DESCRIPTION
To lay the ground for future resources in a Deposit that need access conditions, links to record identifiers etc, make a common base class `ResourceBase` from which WorkingBase inherits.

Also move some constants to a new `Constants` class to avoid MetsParser having a reference to `IMetsManager`.