### PR TITLE
First EditMets refactor attempt.

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/Constants.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace DigitalPreservation.Common.Model.Mets;
+﻿using DigitalPreservation.Common.Model.Transit;
+
+namespace DigitalPreservation.Common.Model.Mets;
 
 public static class Constants
 {
@@ -6,4 +8,14 @@ public static class Constants
     public const string RestrictionOnAccess = "restriction on access";
     public const string UseAndReproduction = "use and reproduction";
     public const string Mets = "METS";
+    public const string PhysIdPrefix = "PHYS_";
+    public const string FileIdPrefix = "FILE_";
+    public const string AdmIdPrefix = "ADM_";
+    public const string TechIdPrefix = "TECH_";
+    public const string DmdPhysRoot = "DMD_PHYS_ROOT";
+    public const string ObjectsDivId = PhysIdPrefix + FolderNames.Objects;
+    public const string MetadataDivId = PhysIdPrefix + FolderNames.Metadata;
+    public const string DirectoryType = "Directory";
+    public const string ItemType = "Item";
+    public const string VirusProvEventPrefix = "digiprovMD_ClamAV_";
 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -682,7 +682,7 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "Cannot delete a non-empty directory.");
         }
 
-        string admId;
+        string? admId;
         if (div is { Type: "Item" })
         {
             SetFileAndFileGroup(div, fullMets);
@@ -692,7 +692,7 @@ public class MetsManager(
                 return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
             }
 
-            admId = File != null && File.Admid.Count > 1 ? string.Join(" ", File.Admid) : File.Admid[0];
+            admId = File != null && File.Admid.Count > 1 ? string.Join(" ", File.Admid) : File?.Admid[0];
 
             FileGroup?.File.Remove(File);
         }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -1,5 +1,4 @@
-﻿using Amazon.Runtime.Internal.Util;
-using DigitalPreservation.Common.Model;
+﻿using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Mets;
 using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
@@ -8,6 +7,7 @@ using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Extensions;
 using DigitalPreservation.XmlGen.Mets;
 using DigitalPreservation.XmlGen.Premis.V3;
+using System.Xml;
 
 namespace Storage.Repository.Common.Mets;
 
@@ -15,17 +15,6 @@ public class MetsManager(
     IMetsParser metsParser,
     IMetsStorage metsStorage) : IMetsManager
 {
-    private const string PhysIdPrefix = "PHYS_";
-    private const string FileIdPrefix = "FILE_";
-    private const string AdmIdPrefix = "ADM_";
-    private const string TechIdPrefix = "TECH_";
-    public const string DmdPhysRoot = "DMD_PHYS_ROOT";
-    private const string ObjectsDivId = PhysIdPrefix + FolderNames.Objects;
-    private const string MetadataDivId = PhysIdPrefix + FolderNames.Metadata;
-    private const string DirectoryType = "Directory";
-    private const string ItemType = "Item";
-    private const string VirusProvEventPrefix = "digiprovMD_ClamAV_";
-    
     public async Task<Result<MetsFileWrapper>> CreateStandardMets(Uri metsLocation, string? agNameFromDeposit)
     {
         var (file, mets) = await GetStandardMets(metsLocation, agNameFromDeposit);
@@ -69,19 +58,19 @@ public class MetsManager(
             if (container is ArchivalGroup && childContainer.GetSlug() == FolderNames.Objects)
             {
                 // The objects div should already exist from our template
-                childDirectoryDiv = mets.StructMap[0].Div.Div.Single(d => d.Id == ObjectsDivId);
+                childDirectoryDiv = mets.StructMap[0].Div.Div.Single(d => d.Id == Constants.ObjectsDivId);
             }
 
             if (childDirectoryDiv == null)
             {
                 var localPath = childContainer.Id!.LocalPath.RemoveStart(agLocalPath).RemoveStart("/");
-                var admId = AdmIdPrefix + localPath;
-                var techId = TechIdPrefix + localPath;
+                var admId = Constants.AdmIdPrefix + localPath;
+                var techId = Constants.TechIdPrefix + localPath;
                 childDirectoryDiv = new DivType
                 {
-                    Type = DirectoryType,
+                    Type = Constants.DirectoryType,
                     Label = childContainer.Name,
-                    Id = $"{PhysIdPrefix}{localPath}",
+                    Id = $"{Constants.PhysIdPrefix}{localPath}",
                     Admid = { admId }
                 };
                 div.Div.Add(childDirectoryDiv);
@@ -103,14 +92,14 @@ public class MetsManager(
             {
                 continue;
             }
-            var fileId = FileIdPrefix + localPath;
-            var admId = AdmIdPrefix + localPath;
-            var techId = TechIdPrefix + localPath;
+            var fileId = Constants.FileIdPrefix + localPath;
+            var admId = Constants.AdmIdPrefix + localPath;
+            var techId = Constants.TechIdPrefix + localPath;
             var childItemDiv = new DivType
             {
-                Type = ItemType,
+                Type = Constants.ItemType,
                 Label = binary.Name,
-                Id = $"{PhysIdPrefix}{localPath}",
+                Id = $"{Constants.PhysIdPrefix}{localPath}",
                 Fptr = { new DivTypeFptr{ Fileid = fileId } }
             };
             div.Div.Add(childItemDiv);
@@ -157,8 +146,6 @@ public class MetsManager(
     }
     
 
-
-    
     public async Task<Result> WriteMets(FullMets fullMets)
     {
         return await metsStorage.WriteMets(fullMets);
@@ -220,312 +207,167 @@ public class MetsManager(
         // This may not be a good idea. But without it, we need a more complex way of
         // finding the METS parts, like the XDocument parsing in MetsParser.
 
-        var operationPath = FolderNames.RemovePathPrefix(workingBase?.LocalPath ?? deletePath);
-        var elements = operationPath!.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        var div = fullMets.Mets.StructMap.Single(sm => sm.Type=="PHYSICAL").Div!;
-        DivType? parent = null;
-        var testPath = string.Empty;
-        int counter = 0;
-        foreach (var element in elements)
-        {
-            if (testPath.HasText())
-            {
-                testPath += "/";
-            }
-            testPath += element;
-            // This is navigating using our ID convention for directories
-            // If we don't want to do this, we can use the premis:originalName for the directory
-            var childDiv = div.Div.SingleOrDefault(d => d.Id == $"{PhysIdPrefix}{testPath}");
-            if (childDiv is null)
-            {
-                break;
-            }
+        var (counter, parent, div, elements, operationPath, testPath) = GetMetsElements(workingBase, deletePath, fullMets);
 
-            counter++;
-            parent = div;
-            div = childDiv;
-        }
-            
         // div might be the file itself, or a parent or grandparent directory.
         // But for this atomic upload file handler we will not allow any Directory creation, that
         // must have already happened in HandleCreateFolder
         // i.e., we must already be at the last or penultimate member of elements
-        if (counter == elements.Length)
+        if (elements != null && counter == elements.Length)
         {
             if (deletePath is not null)
+                return workingBase is null ? DeleteFile(div, fullMets, parent, operationPath) : Result.Fail(ErrorCodes.BadRequest, "Cannot supply a WorkingBase and a deletePath.");
+
+            // we have arrived at an existing file or folder which is being OVERWRITTEN
+            if (workingBase is not WorkingDirectory || div?.Type == "Directory")
             {
-                if (workingBase is not null)
+                if (workingBase is not WorkingFile workingFile)
                 {
-                    return Result.Fail(ErrorCodes.BadRequest, "Cannot supply a WorkingBase and a deletePath.");
-                }
-                    
-                // we have arrived at an existing file or folder which is being DELETED
-                if (div.Div.Count > 0)
-                {
-                    return Result.Fail(ErrorCodes.BadRequest, "Cannot delete a non-empty directory.");
-                }
-
-                string admId;
-                if (div.Type == "Item")
-                {
-                    // for Files only
-                    var fileId = div.Fptr[0].Fileid;
-                    var fileGrp = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
-                    var file = fileGrp.File.Single(f => f.Id == fileId);
-                    if (file.FLocat[0].Href != operationPath)
+                    if (workingBase is WorkingDirectory workingDirectory)
                     {
-                        return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
+                        if (div?.Type != "Directory")
+                            return Result.Fail(ErrorCodes.BadRequest, "WorkingDirectory path does not end on a directory");
+
+
+                        // Is there anything else that could be done here?
+                        if (workingDirectory.Name.HasText())
+                            // and is it even done on hasText?
+                            div.Label = workingDirectory.Name;
                     }
-
-                    admId = file.Admid.Count > 1 ? string.Join(" ", file.Admid) : file.Admid[0];
-
-                    fileGrp.File.Remove(file);
+                    else
+                    {
+                        return Result.Fail(ErrorCodes.BadRequest, "WorkingBase is unsupported type");
+                    }
                 }
                 else
                 {
-                    admId = div.Admid.Count > 1 ? string.Join(" ", div.Admid) : div.Admid[0];
-                }
-                    
-                // for both Files and Directories
-                var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == admId);
-                fullMets.Mets.AmdSec.Remove(amdSec);
-                parent!.Div.Remove(div);
-            }
-            else
-            {
-                // we have arrived at an existing file or folder which is being OVERWRITTEN
-                if (workingBase is WorkingDirectory && div.Type != "Directory")
-                {
-                    return Result.Fail(ErrorCodes.BadRequest, "WorkingDirectory path does not end on a directory");
-                }
-
-                if (workingBase is WorkingFile workingFile)
-                {
-                    if (div.Type != "Item")
-                    {
+                    if (div != null && div.Type != "Item")
                         return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path does not end on a file");
-                    }
-                    var fileId = div.Fptr[0].Fileid;
-                    var fileGrp = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
-                    var file = fileGrp.File.Single(f => f.Id == fileId);
-                    if (file.FLocat[0].Href != operationPath)
-                    {
+
+                    SetFileAndFileGroup(div, fullMets);
+
+                    if (File?.FLocat[0].Href != operationPath)
                         return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
-                    }
 
                     // TODO: This is a quick fix to get round the problem of spaces in XML IDs.
                     // We need to not have any spaces in XML IDs, which means we need to escape them 
                     // in a reversible way (replacing with _ won't do)
-                    var fileAdmId = string.Join(' ', file.Admid);
-                    var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == fileAdmId);
-                    var premisXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault();
-                    var virusPremisXml = amdSec.DigiprovMd.FirstOrDefault(x => x.Id.Contains(VirusProvEventPrefix))?.MdWrap.XmlData.Any?.FirstOrDefault(); 
+                    FileAdmId = string.Join(' ', File.Admid);
+                    AmdSec = fullMets.Mets.AmdSec.Single(a => a.Id == FileAdmId);
 
-                    FileFormatMetadata patchPremis;
-                    try
-                    {
-                        patchPremis = GetFileFormatMetadata(workingFile, operationPath);
-                    }
-                    catch (MetadataException mex)
-                    {
-                        return Result.Fail(ErrorCodes.BadRequest, mex.Message);
-                    }
-                    
-                    var patchPremisVirus = workingFile.GetVirusScanMetadata();
-                    var patchPremisExif = workingFile.GetExifMetadata();
+                    var metadataResult = GetMetadataXml(fullMets, div, operationPath);
 
-                    PremisComplexType? premisType;
-                    if (premisXml is not null)
-                    {
-                        premisType = premisXml.GetPremisComplexType()!;
-                        PremisManager.Patch(premisType, patchPremis, patchPremisExif);
-                    }
-                    else
-                    {
-                        premisType = PremisManager.Create(patchPremis, patchPremisExif);
-                    }
-                    premisXml = PremisManager.GetXmlElement(premisType, true);
-                    amdSec.TechMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { premisXml } };
+                    if (!metadataResult.Success)
+                        return metadataResult;
 
-                    if (patchPremis.ContentType.HasText() && patchPremis.ContentType != ContentTypes.NotIdentified)
-                    {
-                        file.Mimetype = patchPremis.ContentType;
-                    }
-
-                    EventComplexType? virusEventComplexType = null;
-                    if (virusPremisXml is not null)
-                    {
-                        virusEventComplexType = virusPremisXml.GetEventComplexType()!;
-
-                        if (patchPremisVirus != null)
-                        {
-                            PremisEventManager.Patch(virusEventComplexType, patchPremisVirus);
-                        }
-                    }
-                    else
-                    {
-                        if (patchPremisVirus != null)
-                        {
-                            virusEventComplexType = PremisEventManager.Create(patchPremisVirus);
-                        }
-                    }
-
-                    if (virusEventComplexType is not null)
-                    {
-                        virusPremisXml = PremisEventManager.GetXmlElement(virusEventComplexType);
-
-                        if (amdSec.DigiprovMd.Any())
-                        {
-                            amdSec.DigiprovMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { virusPremisXml } };
-                        }
-                        else
-                        {
-                            amdSec.DigiprovMd.Add(new MdSecType
-                            {
-                                Id = $"{VirusProvEventPrefix}{fileAdmId}",
-                                MdWrap = new MdSecTypeMdWrap
-                                {
-                                    Mdtype = MdSecTypeMdWrapMdtype.PremisEvent,
-                                    XmlData = new MdSecTypeMdWrapXmlData { Any = { virusPremisXml } }
-                                }
-                            });
-                        }
-                    }
+                    ProcessFileFormatDataForFile(workingFile, operationPath, false);
+                    ProcessVirusDataForFile(workingFile);
                 }
-                else if (workingBase is WorkingDirectory workingDirectory)
-                {
-                    if(div.Type != "Directory")
-                    {
-                        return Result.Fail(ErrorCodes.BadRequest, "WorkingDirectory path does not end on a directory");
-                    }
+            }
+            else
+            {
+                return Result.Fail(ErrorCodes.BadRequest, "WorkingDirectory path does not end on a directory");
+            }
+        } 
+        else if (elements != null && counter == elements.Length - 1)
+        {
+            if (deletePath is not null)
+                return Result.Fail(ErrorCodes.NotFound, "Can't find a file or folder to delete.");
+            
+            // div is a directory
+            if (div != null && div.Type != "Directory")
+                return Result.Fail(ErrorCodes.BadRequest, "Parent path is not a Directory");
 
-                    // Is there anything else that could be done here?
-                    if (workingDirectory.Name.HasText())
+            if (workingBase is null)
+                return Result.Fail(ErrorCodes.BadRequest, "No working directory or working file supplied to add.");
+
+            var physId = Constants.PhysIdPrefix + operationPath;
+            var admId = Constants.AdmIdPrefix + operationPath;
+            var techId = Constants.TechIdPrefix + operationPath;
+            TechId = techId;
+
+            FileAdmId = admId;
+
+            if (workingBase is not WorkingFile workingFile)
+            {
+                if (workingBase is WorkingDirectory workingDirectory)
+                {
+                    var childDirectoryDiv = new DivType
                     {
-                        // and is it even done on hasText?
-                        div.Label = workingDirectory.Name;
-                    }
+                        Type = Constants.DirectoryType,
+                        Label = workingDirectory.Name ?? operationPath.GetSlug(),
+                        Id = physId,
+                        Admid = { admId }
+                    };
+                    div?.Div.Add(childDirectoryDiv);
+                    var premisFile = new FileFormatMetadata
+                    {
+                        Source = Constants.Mets,
+                        OriginalName = operationPath, // workingDirectory.LocalPath
+                        StorageLocation = null // storageLocation
+                    };
+                    fullMets.Mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId));
                 }
                 else
                 {
                     return Result.Fail(ErrorCodes.BadRequest, "WorkingBase is unsupported type");
-                }                    
-            }
-        } 
-        else if (counter == elements.Length - 1)
-        {
-            if (deletePath is not null)
-            {
-                return Result.Fail(ErrorCodes.NotFound, "Can't find a file or folder to delete.");
-            }
-            // div is a directory
-            if (div.Type != "Directory")
-            {
-                return Result.Fail(ErrorCodes.BadRequest, "Parent path is not a Directory");
-            }
-
-            if (workingBase is null)
-            {
-                return Result.Fail(ErrorCodes.BadRequest, "No working directory or working file supplied to add.");
-            }
-
-            var physId = PhysIdPrefix + operationPath;
-            var admId = AdmIdPrefix + operationPath;
-            var techId = TechIdPrefix + operationPath;
-                
-            if (workingBase is WorkingFile workingFile)
-            {
-                var fileId = FileIdPrefix + operationPath;
-                var childItemDiv = new DivType
-                {
-                    Type = ItemType,
-                    Label = workingFile.Name ?? operationPath.GetSlug(),
-                    Id = physId,
-                    Fptr = { new DivTypeFptr{ Fileid = fileId } }
-                };
-                div.Div.Add(childItemDiv);
-                FileFormatMetadata premisFile;
-                VirusScanMetadata? virusScanMetadata;
-                ExifMetadata? exifMetadata;
-                try
-                {
-                    premisFile = GetFileFormatMetadata(workingFile, operationPath);
                 }
-                catch (MetadataException mex)
-                {
-                    return Result.Fail(ErrorCodes.BadRequest, mex.Message);
-                }
-
-
-                try
-                {
-                    virusScanMetadata = workingFile.GetVirusScanMetadata();
-                }
-                catch (MetadataException mex)
-                {
-                    return Result.Fail(ErrorCodes.BadRequest, mex.Message);
-                }
-
-                try
-                {
-                    exifMetadata = workingFile.GetExifMetadata();
-                }
-                catch (MetadataException mex)
-                {
-                    return Result.Fail(ErrorCodes.BadRequest, mex.Message);
-                }
-
-
-                fullMets.Mets.FileSec.FileGrp[0].File.Add(
-                    new FileType
-                    {
-                        Id = fileId, 
-                        Admid = { admId },
-                        Mimetype = premisFile.ContentType ?? workingFile.ContentType,
-                        FLocat = { 
-                            new FileTypeFLocat
-                            {
-                                Href = operationPath, Loctype = FileTypeFLocatLoctype.Url
-                            } 
-                        }
-                    });
-                fullMets.Mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId, $"{VirusProvEventPrefix}{admId}", virusScanMetadata, exifMetadata));
-            }
-            else if (workingBase is WorkingDirectory workingDirectory)
-            {
-                var childDirectoryDiv = new DivType
-                {
-                    Type = DirectoryType,
-                    Label = workingDirectory.Name ?? operationPath.GetSlug(),
-                    Id = physId,
-                    Admid = { admId }
-                };
-                div.Div.Add(childDirectoryDiv);
-                var premisFile = new FileFormatMetadata
-                {
-                    Source = Constants.Mets,
-                    OriginalName = operationPath, // workingDirectory.LocalPath
-                    StorageLocation = null // storageLocation
-                };
-                fullMets.Mets.AmdSec.Add(GetAmdSecType(premisFile, admId, techId));
             }
             else
             {
-                return Result.Fail(ErrorCodes.BadRequest, "WorkingBase is unsupported type");
+                var fileId = Constants.FileIdPrefix + operationPath;
+                var childItemDiv = new DivType
+                {
+                    Type = Constants.ItemType,
+                    Label = workingFile.Name ?? operationPath.GetSlug(),
+                    Id = physId,
+                    Fptr = { new DivTypeFptr { Fileid = fileId } }
+                };
+                div?.Div.Add(childItemDiv);
+
+                ProcessFileFormatDataForFile(workingFile, operationPath, true);
+
+                File = new FileType
+                {
+                    Id = fileId,
+                    Admid = { admId },
+                    Mimetype = PremisFile?.ContentType ?? workingFile.ContentType,
+                    FLocat =
+                    {
+                        new FileTypeFLocat
+                        {
+                            Href = operationPath, Loctype = FileTypeFLocatLoctype.Url
+                        }
+                    }
+                };
+
+                fullMets.Mets.FileSec.FileGrp[0].File.Add(File);
+
+                if (PremisFile != null && PremisFile.ContentType.HasText() && PremisFile.ContentType != ContentTypes.NotIdentified)
+                {
+                    File.Mimetype = PremisFile.ContentType;
+                }
+
+                ProcessVirusDataForFile(workingFile);
+
+                fullMets.Mets.AmdSec.Add(AmdSec);
             }
-                
+
             // Now we need to ensure the child items are in alphanumeric order by name...
             // how do we do that? We can't sort a Collection<T> in place, and we can't 
             // create a new Collection and assign it to Div
-            var childList = new List<DivType>(div.Div);
-            div.Div.Clear();
-            // We will order case-insensitive; we want to match what a typical file explorer would do.
-            // What about the original ordering? For born digital, is there such a thing?
-            // How do we know what sort order the creator of the archive applied to their view?
-            // Later we can implement something that can set order.
-            foreach (var divType in childList.OrderBy(d => d.Label.ToLowerInvariant()))
+            if (div != null)
             {
-                div.Div.Add(divType);
+                var childList = new List<DivType>(div.Div);
+                div.Div.Clear();
+                // We will order case-insensitive; we want to match what a typical file explorer would do.
+                // What about the original ordering? For born digital, is there such a thing?
+                // How do we know what sort order the creator of the archive applied to their view?
+                // Later we can implement something that can set order.
+                foreach (var divType in childList.OrderBy(d => d.Label.ToLowerInvariant()))
+                {
+                    div.Div.Add(divType);
+                }
             }
         }
         else
@@ -550,10 +392,7 @@ public class MetsManager(
             {
                 fileFormatMetadata.OriginalName = originalName;
             }
-            // if (fileFormatMetadata.StorageLocation == null)
-            // {
-            //     fileFormatMetadata.StorageLocation = storageLocation;
-            // }
+
             return fileFormatMetadata;
         }
         
@@ -588,7 +427,7 @@ public class MetsManager(
             },
             DmdSec =
             {
-                new MdSecType { Id = DmdPhysRoot }
+                new MdSecType { Id = Constants.DmdPhysRoot }
             },
             FileSec = new MetsTypeFileSec
             {
@@ -606,21 +445,21 @@ public class MetsManager(
                     {
                         Id = "PHYS_ROOT",
                         Label = WorkingDirectory.DefaultRootName,
-                        Type = DirectoryType,  
-                        Dmdid = { DmdPhysRoot },
+                        Type = Constants.DirectoryType,  
+                        Dmdid = { Constants.DmdPhysRoot },
                         Div = { 
                             new DivType
                             {
-                                Id = MetadataDivId,  // do this with premis:originalName metadata for directories?
-                                Type = DirectoryType,
+                                Id = Constants.MetadataDivId,  // do this with premis:originalName metadata for directories?
+                                Type = Constants.DirectoryType,
                                 Label = FolderNames.Metadata,
                                 Dmdid = { $"DMD_{FolderNames.Metadata}" },
                                 Admid = { $"ADM_{FolderNames.Metadata}" }
                             }, 
                             new DivType
                             {
-                                Id = ObjectsDivId,  // do this with premis:originalName metadata for directories?
-                                Type = DirectoryType,
+                                Id = Constants.ObjectsDivId,  // do this with premis:originalName metadata for directories?
+                                Type = Constants.DirectoryType,
                                 Label = FolderNames.Objects,
                                 Dmdid = { $"DMD_{FolderNames.Objects}" },
                                 Admid = { $"ADM_{FolderNames.Objects}" }
@@ -635,12 +474,12 @@ public class MetsManager(
                     {
                         Source = Constants.Mets, OriginalName = FolderNames.Objects 
                     }, 
-                    $"{AdmIdPrefix}{FolderNames.Objects}", $"{TechIdPrefix}{FolderNames.Objects}"),
+                    $"{Constants.AdmIdPrefix}{FolderNames.Objects}", $"{Constants.TechIdPrefix}{FolderNames.Objects}"),
                 GetAmdSecType(new FileFormatMetadata
                     {
                         Source = Constants.Mets, OriginalName = FolderNames.Metadata 
                     }, 
-                    $"{AdmIdPrefix}{FolderNames.Metadata}", $"{TechIdPrefix}{FolderNames.Metadata}")
+                    $"{Constants.AdmIdPrefix}{FolderNames.Metadata}", $"{Constants.TechIdPrefix}{FolderNames.Metadata}")
             }
             // NB we don't have a structLink because we have no logical structMap (yet)
         };
@@ -648,14 +487,13 @@ public class MetsManager(
         return mets;
     }
     
-
-    
-    
     private static AmdSecType GetAmdSecType(FileFormatMetadata premisFile, string admId, string techId, string? digiprovId = null, VirusScanMetadata? virusScanMetadata = null, ExifMetadata? exifMetadata = null)
     {
+        //TODO: use ProcessFileFormatDataForFile()
         var premis = PremisManager.Create(premisFile, exifMetadata);
         var xElement = PremisManager.GetXmlElement(premis, true);
 
+        //TODO: this is a new amdsec
         var amdSec = new AmdSecType
         {
             Id = admId,
@@ -730,4 +568,249 @@ public class MetsManager(
         var rights = mods?.GetAccessConditions(Constants.UseAndReproduction).SingleOrDefault();
         return rights is not null ? new Uri(rights) : null;
     }
+
+    //==============================================================
+    //construct design with method stubs
+    private Result ProcessFileFormatDataForFile(WorkingFile workingFile, string operationPath, bool newUpload)
+    {
+        //TODO: this will process new/existing metadata structure for new or existing file
+        //Call IPremisManager to get XML
+        //FileFormatMetadata premisFile;
+
+        try
+        {
+            PremisFile = GetFileFormatMetadata(workingFile, operationPath);
+        }
+        catch (MetadataException mex)
+        {
+            //TODO: return a Result
+            //return;
+            return Result.Fail(ErrorCodes.BadRequest, mex.Message);
+        }
+
+        var patchPremisExif = workingFile.GetExifMetadata();
+
+        PremisComplexType? premisType;
+        if (PremisIncExifXml is not null)
+        {
+            premisType = PremisIncExifXml.GetPremisComplexType()!;
+            PremisManager.Patch(premisType, PremisFile, patchPremisExif);
+        }
+        else
+        {
+            premisType = PremisManager.Create(PremisFile, patchPremisExif);
+        }
+
+        var premisXml = PremisManager.GetXmlElement(premisType, true);
+        SetAmdSec(premisXml, newUpload);
+
+        if (PremisFile.ContentType.HasText() && PremisFile.ContentType != ContentTypes.NotIdentified && File != null)
+        {
+            File.Mimetype = PremisFile.ContentType;
+        }
+
+        return Result.Ok();
+    }
+
+    //TODO: make these properties as used in all the methods
+    //TODO: WorkingFile workingFile, string operationPath, AmdSecType amdSec, FileType file, string? fileAdmId
+    private void ProcessVirusDataForFile(WorkingFile workingFile)
+    {
+        var patchPremisVirus = workingFile.GetVirusScanMetadata();
+
+        EventComplexType? virusEventComplexType = null;
+        if (VirusXml is not null)
+        {
+            virusEventComplexType = VirusXml.GetEventComplexType()!;
+
+            if (patchPremisVirus != null)
+            {
+                PremisEventManager.Patch(virusEventComplexType, patchPremisVirus);
+            }
+        }
+        else
+        {
+            if (patchPremisVirus != null)
+            {
+                virusEventComplexType = PremisEventManager.Create(patchPremisVirus);
+            }
+        }
+
+        if (virusEventComplexType is null) return;
+        VirusXml = PremisEventManager.GetXmlElement(virusEventComplexType);
+
+        if (AmdSec == null) return;
+
+        AddVirusXml();
+    }
+
+
+    //TODO: return Tuple of all metadata Premis, Virus and Exif (these may be null if a new file)
+    private Result GetMetadataXml(FullMets fullMets, DivType? div, string operationPath)
+    {
+        if (div != null && div.Type != "Item")
+        {
+            return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path does not end on a file");
+        }
+
+        SetFileAndFileGroup(div, fullMets);
+
+        if (File?.FLocat[0].Href != operationPath)
+        {
+            return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
+        }
+
+        // TODO: This is a quick fix to get round the problem of spaces in XML IDs.
+        // We need to not have any spaces in XML IDs, which means we need to escape them 
+        // in a reversible way (replacing with _ won't do)
+        FileAdmId = string.Join(' ', File.Admid);
+        var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == FileAdmId);
+        var premisIncExifXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault(); //TODO: this includes exif - separate this out
+        var virusPremisXml = amdSec.DigiprovMd.FirstOrDefault(x => x.Id.Contains(Constants.VirusProvEventPrefix))?.MdWrap.XmlData.Any?.FirstOrDefault();
+
+        PremisIncExifXml = premisIncExifXml;
+        VirusXml = virusPremisXml;
+
+        return Result.Ok();
+    }
+
+    private Result DeleteFile(DivType? div, FullMets fullMets, DivType? parent, string? operationPath)
+    {
+        // we have arrived at an existing file or folder which is being DELETED
+        if (div != null && div.Div.Count > 0)
+        {
+            return Result.Fail(ErrorCodes.BadRequest, "Cannot delete a non-empty directory.");
+        }
+
+        string admId;
+        if (div is { Type: "Item" })
+        {
+            SetFileAndFileGroup(div, fullMets);
+
+            if (File != null && File.FLocat[0].Href != operationPath)
+            {
+                return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
+            }
+
+            admId = File != null && File.Admid.Count > 1 ? string.Join(" ", File.Admid) : File.Admid[0];
+
+            FileGroup?.File.Remove(File);
+        }
+        else
+        {
+            admId = div != null && div.Admid.Count > 1 ? string.Join(" ", div.Admid) : div.Admid[0];
+        }
+
+        // for both Files and Directories
+        var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == admId);
+        fullMets.Mets.AmdSec.Remove(amdSec);
+        parent!.Div.Remove(div);
+
+        return Result.Ok();
+    }
+
+    private void SetAmdSec(XmlElement? premisXml, bool newUpload)
+    {
+        if (AmdSec is null || newUpload)
+        {
+            AmdSec = new AmdSecType
+            {
+                Id = FileAdmId, //admId
+                TechMd =
+                {
+                    new MdSecType
+                    {
+                        Id = TechId, //techId
+                        MdWrap = new MdSecTypeMdWrap
+                        {
+                            Mdtype = MdSecTypeMdWrapMdtype.PremisObject,
+                            XmlData = new MdSecTypeMdWrapXmlData { Any = { premisXml }}
+                        }
+                    }
+                },
+            };
+        }
+        else
+        {
+            AmdSec.TechMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { premisXml } };
+        }
+    }
+
+    private void AddVirusXml()
+    {
+        if (AmdSec is null)
+            return;
+
+        if (AmdSec.DigiprovMd.Any())
+        {
+            AmdSec.DigiprovMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { VirusXml } };
+        }
+        else
+        {
+            AmdSec.DigiprovMd.Add(new MdSecType
+            {
+                Id = $"{Constants.VirusProvEventPrefix}{FileAdmId}",
+                MdWrap = new MdSecTypeMdWrap
+                {
+                    Mdtype = MdSecTypeMdWrapMdtype.PremisEvent,
+                    XmlData = new MdSecTypeMdWrapXmlData { Any = { VirusXml } }
+                }
+            });
+        }
+    }
+
+    private void SetFileAndFileGroup(DivType? div, FullMets fullMets)
+    {
+        if (div == null) return;
+        var fileId = div.Fptr[0].Fileid;
+        FileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        File = FileGroup.File.Single(f => f.Id == fileId);
+    }
+
+        
+    private (int counter, DivType? parent, DivType? div, string[]? elements, string operationPath, string testPath) GetMetsElements(WorkingBase? workingBase, string? deletePath, FullMets fullMets)
+    {
+        //TODO: put in separate method this
+        var operationPath = FolderNames.RemovePathPrefix(workingBase?.LocalPath ?? deletePath);
+        var elements = operationPath!.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        //TODO: put this in a separate method
+        var div = fullMets.Mets.StructMap.Single(sm => sm.Type == "PHYSICAL").Div!;
+        DivType? parent = null;
+        var testPath = string.Empty;
+        var counter = 0;
+
+        foreach (var element in elements)
+        {
+            if (testPath.HasText())
+            {
+                testPath += "/";
+            }
+            testPath += element;
+            // This is navigating using our ID convention for directories
+            // If we don't want to do this, we can use the premis:originalName for the directory
+            var childDiv = div.Div.SingleOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}");
+            if (childDiv is null)
+            {
+                break;
+            }
+
+            counter++;
+            parent = div;
+            div = childDiv;
+        }
+
+        return (counter, parent, div, elements, operationPath, testPath);
+    }
+    //TODO: need to reset properties when on new file
+    private XmlElement? PremisIncExifXml { get; set; }
+    private XmlElement? VirusXml { get; set; }
+    private XmlElement? ExifXml { get; set; } //TODO: to follow when Exif has its own premis manager
+
+    private string? FileAdmId { get; set; }
+    private AmdSecType? AmdSec { get; set; } //TODO: may not be a good idea??
+    private FileType? File { get; set; }
+    private string? TechId { get; set; }
+    private FileFormatMetadata? PremisFile { get; set; }
+    private MetsTypeFileSecFileGrp? FileGroup { get; set; }
 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/ModsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/ModsManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml;
 using System.Xml.Serialization;
+using DigitalPreservation.Common.Model.Mets;
 using DigitalPreservation.XmlGen.Mets;
 using DigitalPreservation.XmlGen.Mods.V3;
 
@@ -73,7 +74,7 @@ public static class ModsManager
 
     public static ModsDefinition? GetRootMods(DigitalPreservation.XmlGen.Mets.Mets mets)
     {
-        var rootDmd = mets.DmdSec.Single(x => x.Id == MetsManager.DmdPhysRoot)!;
+        var rootDmd = mets.DmdSec.Single(x => x.Id == Constants.DmdPhysRoot)!;
         if (rootDmd.MdWrap is { Mdtype: MdSecTypeMdWrapMdtype.Mods })
         {
             var modsXml = rootDmd.MdWrap.XmlData.Any?.FirstOrDefault();
@@ -91,7 +92,7 @@ public static class ModsManager
 
     public static void SetRootMods(DigitalPreservation.XmlGen.Mets.Mets mets, ModsDefinition mods)
     {
-        var rootDmd = mets.DmdSec.Single(x => x.Id == MetsManager.DmdPhysRoot)!;
+        var rootDmd = mets.DmdSec.Single(x => x.Id == Constants.DmdPhysRoot)!;
         rootDmd.MdWrap = new MdSecTypeMdWrap
         {
             Mdtype = MdSecTypeMdWrapMdtype.Mods,


### PR DESCRIPTION
This EditMets method could be refactored further but thought to draw a line and get a review at this point.
I have broken the method down by extracting the code in EditMets into subroutines.

The requirement that needs a discussion is
"At the moment the code just goes through all the things that might need to be edited - premis file format data, virus metadata, exif metadata … and possibly more in future - and then edits them with the help of PremisManager and PremisEventManager. This is hard to follow and will just get bigger and bigger. How do we refactor this to make it easier to follow and maintain and extend in future?"

Ticket:
https://digirati.atlassian.net/browse/LPII-29

All BE Unit tests still passing for the branch:
<img width="2282" height="1073" alt="image" src="https://github.com/user-attachments/assets/8b61f7ca-1574-4d10-b78c-7cb9ab92eb8f" />
