### PR TITLE
Better Content Type determination

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ContentTypes.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ContentTypes.cs
@@ -1,9 +1,105 @@
-﻿namespace DigitalPreservation.Common.Model;
+﻿using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using DigitalPreservation.Utils;
 
-public class ContentTypes
+namespace DigitalPreservation.Common.Model;
+
+public static class ContentTypes
 {
     /// <summary>
     /// This is never served over the web, it's an internal marker
     /// </summary>
     public const string NotIdentified = "dlip/not-identified";
+
+    public static List<string> GetAllContentTypes(WorkingFile? fileInDeposit)
+    {
+        return fileInDeposit is null ? [] : GetDistinctTypes(fileInDeposit);
+    }
+
+    public static string? GetBestContentType(WorkingFile? fileInDeposit)
+    {
+        if (fileInDeposit is null)
+        {
+            return null;
+        }
+        var distinctTypes = GetDistinctTypes(fileInDeposit);
+        if (distinctTypes.Count == 1)
+        {
+            return distinctTypes[0];
+        }
+        RemoveExtraGenericContentTypes(distinctTypes);
+        if (distinctTypes.Count == 1)
+        {
+            return distinctTypes[0];
+        }
+        
+        // This is our jumping off point for more detailed investigation, using the tool outputs 
+        // of EXIF and maybe FFProbe in future to determine what the file is.
+        
+        var applicationCount = distinctTypes.Count(ct => ct.StartsWith("application/"));
+        var videoCount = distinctTypes.Count(ct => ct.StartsWith("video/"));
+        var audioCount = distinctTypes.Count(ct => ct.StartsWith("audio/"));
+        var imageCount = distinctTypes.Count(ct => ct.StartsWith("image/"));
+
+        if (applicationCount == 1)
+        {
+            if (videoCount == 1)
+            {
+                return distinctTypes.Single(ct => ct.StartsWith("video/"));
+            }
+            if (audioCount == 1)
+            {
+                return distinctTypes.Single(ct => ct.StartsWith("audio/"));
+            }
+            if (imageCount == 1)
+            {
+                return distinctTypes.Single(ct => ct.StartsWith("image/"));
+            }
+        }
+        
+        // We still have more than one distinct content type that isn't a generic one, even after our special rules.
+        return null;
+
+    }
+
+    private static List<string> GetDistinctTypes(WorkingFile fileInDeposit)
+    {
+        var contentTypesFromFileFormatMetadata = fileInDeposit
+            .Metadata
+            .OfType<FileFormatMetadata>()
+            .Where(m => m.ContentType.HasText())
+            .Select(m => m.ContentType!)
+            .Distinct()
+            .ToList();
+
+        var distinctTypes = contentTypesFromFileFormatMetadata;
+        if (fileInDeposit.ContentType.HasText())
+        {
+            distinctTypes = contentTypesFromFileFormatMetadata
+                .Union([fileInDeposit.ContentType])
+                .Distinct()
+                .ToList();
+        }
+
+        return distinctTypes;
+    }
+
+    /// <summary>
+    /// Will only remove these generic types if one or more other types are present
+    /// </summary>
+    /// <param name="distinctTypes"></param>
+    public static void RemoveExtraGenericContentTypes(List<string> distinctTypes)
+    {
+        if (distinctTypes.Count > 1)
+        {
+            // It might really be application/octet-stream, which is OK if that's the best we can do
+            distinctTypes.RemoveAll(ct => ct == "application/octet-stream");
+        }
+
+        if (distinctTypes.Count > 1)
+        {
+            // It might really be application/octet-stream, which is OK if that's the best we can do
+            distinctTypes.RemoveAll(ct => ct == "binary/octet-stream");
+        }
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedDirectory.cs
@@ -365,7 +365,7 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
                     $"File {combinedFile.LocalPath} has different sizes in deposit and mets or does not have a size at all");
             }
             
-            var contentType = combinedFile.GetSingleContentType();
+            var contentType = combinedFile.GetSingleContentTypeFromMetsAndDeposit();
             if (contentType is null)
             {
                 if (combinedFile.LocalPath == metsXmlPath)
@@ -376,8 +376,10 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
                 }
                 else
                 {
-                    return Result.FailNotNull<Container>(ErrorCodes.BadRequest, 
-                        $"File {combinedFile.LocalPath} has different content types in deposit and mets - " + string.Join(", ", combinedFile.GetAllContentTypes()));
+                    return Result.FailNotNull<Container>(ErrorCodes.BadRequest,
+                        $"File {combinedFile.LocalPath} has different content types in METS " 
+                        + $"({combinedFile.FileInMets?.ContentType}) and Deposit " 
+                        + $"({string.Join(", ", ContentTypes.GetAllContentTypes(combinedFile.FileInDeposit))})");
                 }
             }
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -10,9 +10,16 @@ public class WorkingFile : WorkingBase
     [JsonPropertyName("type")]
     public override string Type { get; set; } = nameof(WorkingFile); 
     
+    /// <summary>
+    /// For files in deposits, this will be the mimetype supplied at upload time,
+    /// or determined by the MimeTypes library, or determined by AWS S3, in that
+    /// order. Compare with the same property on FileFormatMetadata.
+    ///
+    /// For files in METS, this is the mets:file element's MIMETYPE property.
+    /// </summary>
     [JsonPropertyName("contentType")]
     [JsonPropertyOrder(14)]
-    public required string ContentType { get; set; }
+    public string? ContentType { get; set; }
 
     [JsonPropertyName("digest")]
     [JsonPropertyOrder(15)]
@@ -112,8 +119,11 @@ public class WorkingFile : WorkingBase
 
         // Should we require that ALL of these agree?
         // Pronom keys should definitely agree.
-
         // In practice, as Brunnhilde is using Siegfried, they should always agree.
+        
+        // Content types may be different from different sources - so while we can coalesce
+        // them here, we must check them elsewhere.
+
         // (for now - we may have other sources later)
         if (pronomKeys.Count > 0)
         {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -143,7 +143,7 @@ File is in both
             </span>
         </td>
         @{
-            var contentType = file.GetSingleContentType();
+            var contentType = file.GetSingleContentTypeFromMetsAndDeposit();
             var contentTypeDisplay = contentType;
             if (contentType is { Length: > 22 })
             {

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Net.Mime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;
@@ -77,10 +78,17 @@ public class UploadFileToDepositHandler(
                 {
                     throw new Exception("HEAD checksum does not match PUT checksum");
                 }
+                
+                var s3AssignedContentType = headResponse.Headers.ContentType;
+                var contentTypeToBeStored = request.ContentType;
+                if (contentTypeToBeStored.IsNullOrWhiteSpace())
+                {
+                    contentTypeToBeStored = s3AssignedContentType.HasText() ? s3AssignedContentType : ContentTypes.NotIdentified;
+                }
                 var file = new WorkingFile
                 {
                     LocalPath = fullKey.RemoveStart(s3Uri.Key)!,
-                    ContentType = request.ContentType,
+                    ContentType = contentTypeToBeStored,
                     Digest = request.Checksum.ToLowerInvariant(),
                     Size = request.Size,
                     Name = request.DepositFileName,

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/UploadFileToDeposit.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Mime;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Util;

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetadataManager.cs
@@ -29,7 +29,8 @@ public class MetadataManager : IMetadataManager
 
 
         ProcessFileFormatDataForFile(workingFile, operationPath, newUpload);
-
+        
+        
         if (newUpload)
         {
             File = new FileType
@@ -49,9 +50,13 @@ public class MetadataManager : IMetadataManager
             fullMets.Mets.FileSec.FileGrp[0].File.Add(File);
         }
 
-        if (PremisFile != null && PremisFile.ContentType.HasText() && PremisFile.ContentType != ContentTypes.NotIdentified && File != null)
+        if (File != null)
         {
-            File.Mimetype = PremisFile.ContentType;
+            var contentTypeFromDeposit = ContentTypes.GetBestContentType(workingFile);
+            if (contentTypeFromDeposit.HasText() && contentTypeFromDeposit != ContentTypes.NotIdentified)
+            {
+                File.Mimetype = contentTypeFromDeposit;
+            }
         }
 
         ProcessVirusDataForFile(workingFile);

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetadataManager.cs
@@ -37,7 +37,6 @@ public class MetadataManager : IMetadataManager
             {
                 Id = fileId,
                 Admid = { admId },
-                Mimetype = PremisFile?.ContentType ?? workingFile.ContentType,
                 FLocat =
                 {
                     new FileTypeFLocat

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -346,9 +346,11 @@ public class MetsManager(
                     premisXml = PremisManager.GetXmlElement(premisType, true);
                     amdSec.TechMd[0].MdWrap.XmlData = new MdSecTypeMdWrapXmlData { Any = { premisXml } };
 
-                    if (patchPremis.ContentType.HasText() && patchPremis.ContentType != ContentTypes.NotIdentified)
+                    var contentTypeFromDeposit = ContentTypes.GetBestContentType(workingFile);
+                    if (contentTypeFromDeposit.HasText() && contentTypeFromDeposit != ContentTypes.NotIdentified)
                     {
-                        file.Mimetype = patchPremis.ContentType;
+                        // We won't overwrite METS with an invalid or blank one - but do we ever want to do that?
+                        file.Mimetype = contentTypeFromDeposit;
                     }
 
                     EventComplexType? virusEventComplexType = null;
@@ -474,13 +476,17 @@ public class MetsManager(
                     return Result.Fail(ErrorCodes.BadRequest, mex.Message);
                 }
 
-
+                var contentTypeFromDeposit = ContentTypes.GetBestContentType(workingFile);
+                if (contentTypeFromDeposit.IsNullOrWhiteSpace() || contentTypeFromDeposit == ContentTypes.NotIdentified)
+                {
+                    contentTypeFromDeposit = null;
+                }
                 fullMets.Mets.FileSec.FileGrp[0].File.Add(
                     new FileType
                     {
                         Id = fileId, 
                         Admid = { admId },
-                        Mimetype = premisFile.ContentType ?? workingFile.ContentType,
+                        Mimetype = contentTypeFromDeposit,
                         FLocat = { 
                             new FileTypeFLocat
                             {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -485,21 +485,10 @@ public class MetsParser(
                 }
 
                 var parts = flocat.Split('/');
-                if (string.IsNullOrEmpty(mimeType))
-                {
-                    // In the real version, we would have got this from Siegfried for born-digital archives,
-                    // but we'd still be reading it from the METS file we made.
-                    if (MimeTypes.TryGetMimeType(parts[^1], out var foundMimeType))
-                    {
-                        logger.LogWarning(
-                            $"Content Type for {flocat} was deduced from file extension: {foundMimeType}");
-                        mimeType = foundMimeType;
-                    }
-                }
 
                 var file = new WorkingFile
                 {
-                    ContentType = mimeType ?? ContentTypes.NotIdentified,
+                    ContentType = mimeType,
                     LocalPath = flocat,
                     Digest = digest,
                     Size = size,


### PR DESCRIPTION
- Get a "Best Content Type" from the Deposit WorkingFile - taking into account 0..n content types from `FileFormatMetadata` values as well as the ContentType initially determined on the file (and stored in S3 metadata and/or __metslike.json filesystem)
- `ContentTypes.GetBestContentType(WorkingFile? fileInDeposit)` is an extension point for adding in more complex decisions later, perhaps by looking at the outputs of further tools such as EXIFTool or even FFProbe. I have added in some started logic here to favour video/mp4 over application/mp4 and similar patterns - but this needs more work. It's now where we start removing generic content types if we have more than one.
- When adding to or updating METS via patchPremis / premisFile logic, use this "best Content Type" if present
- Mismatch between METS and Deposit is a mismatch between this BEST value and what's currently in the METS file.
- Actually list all the content types when there is a mismatch when trying to create an import job


Additional changes

- In MetsParser, remove fallback determination of content type via MimeTypes. If it's not in the METS, MetsParser shouldn't invent it.
