### PR TITLE
Refactor/mets parser lookups

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsParser.cs
@@ -13,7 +13,7 @@ public interface IMetsParser
     /// <returns></returns>
     Task<Result<MetsFileWrapper>> GetMetsFileWrapper(Uri metsLocation, bool parse = true);
 
-    Result<MetsFileWrapper> GetMetsFileWrapperFromXDocument(XDocument metsXDocument);
+    Result<MetsFileWrapper> GetMetsFileWrapperFromXDocument(Uri metsUri, XDocument metsXDocument);
     
     Task<Result<(Uri root, Uri? file)>> GetRootAndFile(Uri metsLocation);
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingDirectory.cs
@@ -107,4 +107,14 @@ public class WorkingDirectory : WorkingBase
             Metadata = Metadata
         };
     }
+    
+    public static WorkingDirectory RootDirectory()
+    {
+        return new WorkingDirectory
+        {
+            LocalPath = string.Empty,
+            Name = WorkingDirectory.DefaultRootName,
+            Modified = DateTime.UtcNow
+        };
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
@@ -166,7 +166,7 @@ public class BrowseModel(
                 try
                 {
                     var xMets = XDocument.Load(metsResult.Item1);
-                    var result = metsParser.GetMetsFileWrapperFromXDocument(xMets);
+                    var result = metsParser.GetMetsFileWrapperFromXDocument(CachedArchivalGroup.Id, xMets);
                     if (result is { Success: true, Value: not null })
                     {
                         metsWrapper = result.Value;

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -63,7 +63,7 @@ public class MetsParser(
         {
             RootUri = root,
             MetsUri = file,
-            PhysicalStructure = Storage.RootDirectory()
+            PhysicalStructure = WorkingDirectory.RootDirectory()
         };
 
         if (file is not null)
@@ -111,12 +111,14 @@ public class MetsParser(
     }
 
 
-    public Result<MetsFileWrapper> GetMetsFileWrapperFromXDocument(XDocument metsXDocument)
+    public Result<MetsFileWrapper> GetMetsFileWrapperFromXDocument(Uri metsUri, XDocument metsXDocument)
     {
         var mets = new MetsFileWrapper
         {
+            MetsUri = metsUri,
+            RootUri = metsUri.GetParentUri(),
             XDocument = metsXDocument,
-            PhysicalStructure = Storage.RootDirectory()
+            PhysicalStructure = WorkingDirectory.RootDirectory()
         };
         PopulateFromMets(mets, metsXDocument);
         mets.Editable = mets.Agent == Constants.MetsCreatorAgent;

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -39,7 +39,7 @@ public class Storage(
         var pResp = await s3Client.PutObjectAsync(pReq);
         if (pResp.HttpStatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
         {
-            var root = RootDirectory();
+            var root = WorkingDirectory.RootDirectory();
             switch (templateType)
             {
                 case TemplateType.RootLevel:
@@ -124,17 +124,6 @@ public class Storage(
         {
             return ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Unable to write Deposit File System File.", pReqDepositFileSystem.GetS3Uri());
         }
-    }
-
-  
-    public static WorkingDirectory RootDirectory()
-    {
-        return new WorkingDirectory
-        {
-            LocalPath = string.Empty,
-            Name = WorkingDirectory.DefaultRootName,
-            Modified = DateTime.UtcNow
-        };
     }
 
 
@@ -334,7 +323,7 @@ public class Storage(
         {
             var s3Location = new AmazonS3Uri(location);
             var s3Objects = await ListAllS3Objects(s3Location, cancellationToken);
-            var top = RootDirectory();
+            var top = WorkingDirectory.RootDirectory();
 
             // Create the directories
             foreach (var s3Object in s3Objects.OrderBy(o => o.Key.Replace('/', '~')))


### PR DESCRIPTION
This PR should have no functional changes, no new behaviour.

This matches the way the Python METS Parser works - to avoid repeated Xml document tree traversal it builds maps of the main elements per file.

It also moves the static helper class that generates the root working directory to the `WorkingDirectory` class itself, avoiding a dependency on Storage.cs in MetsParser.