### PR TITLE
change obsolete method signatures

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
@@ -77,6 +77,7 @@ public class SiegfriedOutput
     }
 }
 
+[Serializable]
 internal class SiegfriedCsvRow
 {
     public string? Filename { get; set; }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.Json.Serialization;
 using CsvHelper;
 using CsvHelper.Configuration;
 using DigitalPreservation.Utils;
@@ -22,11 +23,11 @@ public class SiegfriedOutput
             .Build();
 
         // Consume the stream start event "manually"
-        parser.Expect<StreamStart>();
+        parser.Consume<StreamStart>();
 
         var output = new SiegfriedOutput();
         bool first = true;
-        while (parser.Accept<DocumentStart>())
+        while (parser.Accept<DocumentStart>(out _))
         {
             if (first)
             {

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ToolOutput/Siegfried/SiegfriedOutput.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Text.Json.Serialization;
 using CsvHelper;
 using CsvHelper.Configuration;
 using DigitalPreservation.Utils;


### PR DESCRIPTION
Much simpler than I had anticipated.

the YAML parsing tests still pass - but we need to keep an eye on it.