### PR TITLE
Feat/lpii 6/surface exif and metadata

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -147,7 +147,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
         foreach (var exifItemDeposit in arrayDeposit.Select((value, i) => (value, i)))
         {
             var exifItemDepositTagName = exifItemDeposit.value.TagName;
-            var exifItemDepositTagValue = exifItemDeposit.value.TagValue;
+            var exifItemDepositTagValue = exifItemDeposit.value.TagValue?.ReplaceLineEndings().Replace("\\r", string.Empty).Replace("\\n", string.Empty); 
             var depositItemArrayIndex = exifItemDeposit.i;
 
             if ((!isEqual && !arrayMets.Any()) || (arrayMets.Length < (depositItemArrayIndex + 1))) //will get an out of bound array exception
@@ -193,7 +193,8 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
             if (exifItemDepositTagName != null && metsExifItem.TagName != null && !string.Equals(exifItemDepositTagName, metsExifItem.TagName, StringComparison.CurrentCultureIgnoreCase)) continue;
 
-            if (string.Equals(exifItemDepositTagValue, metsExifItem.TagValue, StringComparison.CurrentCultureIgnoreCase)) continue;
+            var metsTagValue = metsExifItem.TagValue?.ReplaceLineEndings().Replace("\\r", string.Empty).Replace("\\n", string.Empty);
+            if (string.Equals(exifItemDepositTagValue, metsTagValue, StringComparison.CurrentCultureIgnoreCase)) continue;
 
             if (exifItemDepositTagName == null) continue;
             arrayMets[depositItemArrayIndex].MismatchAdded = true;

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -147,7 +147,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
         foreach (var exifItemDeposit in arrayDeposit.Select((value, i) => (value, i)))
         {
             var exifItemDepositTagName = exifItemDeposit.value.TagName;
-            var exifItemDepositTagValue = exifItemDeposit.value.TagValue?.ReplaceLineEndings().Replace("\\r", string.Empty).Replace("\\n", string.Empty); 
+            var exifItemDepositTagValue = exifItemDeposit.value.TagValue?.RemoveLineEndings();
             var depositItemArrayIndex = exifItemDeposit.i;
 
             if ((!isEqual && !arrayMets.Any()) || (arrayMets.Length < (depositItemArrayIndex + 1))) //will get an out of bound array exception
@@ -193,7 +193,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
             if (exifItemDepositTagName != null && metsExifItem.TagName != null && !string.Equals(exifItemDepositTagName, metsExifItem.TagName, StringComparison.CurrentCultureIgnoreCase)) continue;
 
-            var metsTagValue = metsExifItem.TagValue?.ReplaceLineEndings().Replace("\\r", string.Empty).Replace("\\n", string.Empty);
+            var metsTagValue = metsExifItem.TagValue?.RemoveLineEndings();
             if (string.Equals(exifItemDepositTagValue, metsTagValue, StringComparison.CurrentCultureIgnoreCase)) continue;
 
             if (exifItemDepositTagName == null) continue;

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -342,7 +342,6 @@
                                     <th scope="col">Type</th>
                                     <th scope="col">Pronom</th>
                                     <th scope="col">Virus</th>
-                                    <th scope="col">Metadata</th>
                                 </tr>
                                 </thead>
                                 <tbody>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -348,7 +348,7 @@
                                 @if (Model.WorkspaceManager.IsBagItLayout)
                                 {
                                     <tr>
-                                        <td colspan="9">
+                                        <td colspan="8">
                                             <svg class="bi"><use xlink:href="#bag-heart"/></svg>
                                             <em>This Deposit uses BagIt layout on disk/S3.</em>
                                         </td>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -342,13 +342,14 @@
                                     <th scope="col">Type</th>
                                     <th scope="col">Pronom</th>
                                     <th scope="col">Virus</th>
+                                    <th scope="col">Metadata</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 @if (Model.WorkspaceManager.IsBagItLayout)
                                 {
                                     <tr>
-                                        <td colspan="8">
+                                        <td colspan="9">
                                             <svg class="bi"><use xlink:href="#bag-heart"/></svg>
                                             <em>This Deposit uses BagIt layout on disk/S3.</em>
                                         </td>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -193,20 +193,6 @@ File is in both
         {
             <td aria-label="td-virus">@virusMetadata?.GetDisplay()</td>
         }
-        
-@*         <td>
-            @if (!isMetadata)
-            {
-                var toolOutput = file.FileInDeposit?.Metadata.OfType<ToolOutput>().SingleOrDefault();
-                if (toolOutput != null && toolOutput.Content.HasText())
-                {
-                    var textBytes = System.Text.Encoding.UTF8.GetBytes(toolOutput.Content);
-                    var base64Encoded = System.Convert.ToBase64String(textBytes);
-
-                    <a href="javascript:openHtmlStringInNewTab('@base64Encoded');"><strong>view metadata</strong></a>
-                }
-            }
-        </td> *@
 
     </tr>
 } 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -74,7 +74,6 @@ File is in both
        <td></td>
        <td></td>
         <td></td>
-        <td></td>
     </tr>
 }
 @foreach (var dir in combinedDirectory.Directories)
@@ -137,6 +136,17 @@ File is in both
                         @file.GetName();
                     }
                 }
+                else if (!isMetadata)
+                {
+                    var toolOutput = file.FileInDeposit?.Metadata.OfType<ToolOutput>().SingleOrDefault();
+                    if (toolOutput != null && toolOutput.Content.HasText())
+                    {
+                        var textBytes = System.Text.Encoding.UTF8.GetBytes(toolOutput.Content);
+                        var base64Encoded = System.Convert.ToBase64String(textBytes);
+
+                        <a href="javascript:openHtmlStringInNewTab('@base64Encoded');"><strong>@file.GetName()</strong></a>
+                    }
+                }
                 else
                 {
                     @(file.GetName() ?? "{{ NO LOCALPATH }}")
@@ -180,7 +190,7 @@ File is in both
             <td aria-label="td-virus">@virusMetadata?.GetDisplay()</td>
         }
         
-        <td>
+@*         <td>
             @if (!isMetadata)
             {
                 var toolOutput = file.FileInDeposit?.Metadata.OfType<ToolOutput>().SingleOrDefault();
@@ -192,7 +202,7 @@ File is in both
                     <a href="javascript:openHtmlStringInNewTab('@base64Encoded');"><strong>view metadata</strong></a>
                 }
             }
-        </td>
+        </td> *@
 
     </tr>
 } 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -73,7 +73,8 @@ File is in both
        <td></td>
        <td></td>
        <td></td>
-       <td></td>
+        <td></td>
+        <td></td>
     </tr>
 }
 @foreach (var dir in combinedDirectory.Directories)
@@ -178,6 +179,20 @@ File is in both
         {
             <td aria-label="td-virus">@virusMetadata?.GetDisplay()</td>
         }
+        
+        <td>
+            @if (!isMetadata)
+            {
+                var toolOutput = file.FileInDeposit?.Metadata.OfType<ToolOutput>().SingleOrDefault();
+                if (toolOutput != null && toolOutput.Content.HasText())
+                {
+                    var textBytes = System.Text.Encoding.UTF8.GetBytes(toolOutput.Content);
+                    var base64Encoded = System.Convert.ToBase64String(textBytes);
+
+                    <a href="javascript:openHtmlStringInNewTab('@base64Encoded');"><strong>view metadata</strong></a>
+                }
+            }
+        </td>
 
     </tr>
 } 

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/_RenderCombinedDirectoryAsTableRows.cshtml
@@ -146,6 +146,10 @@ File is in both
 
                         <a href="javascript:openHtmlStringInNewTab('@base64Encoded');"><strong>@file.GetName()</strong></a>
                     }
+                    else
+                    {
+                        @file.GetName();
+                    }
                 }
                 else
                 {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -19,7 +19,7 @@
         virusDict = CollectionUtils.GetValues(virusScanMetadata);
 }
 
-<table class="table small">
+<table class="table small table-striped">
     <tr>
         <th scope="row">Name</th>
         <td>
@@ -105,65 +105,79 @@
 
 </table>
 
-<div>
-    <h3>Brunnhilde</h3>
-    <table class="table small" style="width: 30%;">
-        <tr>
-            @if (workingFile != null)
-            {
-                @if (fileFormatDict != null && fileFormatDict.Any())
-                {
-                    foreach (var fileFormatMetadata in fileFormatDict)
+@if (workingFile != null)
+{
+    @if ((fileFormatDict != null && fileFormatDict.Any()) || (virusDict != null && virusDict.Any()) || exifMetadata is { Tags: not null })
+    {
+        <div>
+            <h3>Metadata</h3>
+        </div>
+    }
+}
+
+
+@if (workingFile != null)
+{
+    @if (fileFormatDict != null && fileFormatDict.Any())
+    {
+        <div>
+            <h4>Brunnhilde</h4>
+            <table class="table small" style="width: 30%;">
+                <tr>
+                    @foreach (var fileFormatMetadata in fileFormatDict)
                     {
                         <tr>
                             <th scope="row">@fileFormatMetadata.Key</th>
                             <td>@fileFormatMetadata.Value</td>
                         </tr>
                     }
-                }
-            }
-        </tr>
-    </table>
-</div>
+                </tr>
+            </table>
+        </div>
+    }
+}
 
-<div>
-    <h3>Clam AV</h3>
-    <table class="table small" style="width: 30%;">
-        <tr>
-            @if (workingFile != null)
-            {
-                @if (virusDict != null && virusDict.Any())
-                {
-                    foreach (var virusMetadata in virusDict)
+@if (workingFile != null)
+{
+    @if (virusDict != null && virusDict.Any())
+    {
+        <div>
+            <h4>Clam AV</h4>
+            <table class="table small" style="width: 30%;">
+                <tr>
+                    @foreach (var virusMetadata in virusDict)
                     {
                         <tr>
                             <th scope="row">@virusMetadata.Key</th>
                             <td>@virusMetadata.Value</td>
                         </tr>
                     }
-                }
-            }
-        </tr>
-    </table>
-</div>
+                </tr>
+            </table>
+        </div>
+    }
+}
 
-<div>
-    <h3>Exif Metadata</h3>
-    <table class="table small" style="width: 30%;">
-        <tr>
-            @if (workingFile != null)
-            {
-                @if (exifMetadata is { Tags: not null })
-                {
-                    foreach (var exifPair in exifMetadata.Tags.Where(x => x.TagName?.ToLower() != "rawoutput"))
+@if (workingFile != null)
+{
+    @if (exifMetadata is { Tags: not null })
+    {
+        <div>
+            <h4>Exif Metadata</h4>
+            <table class="table small" style="width: 30%;">
+                <tr>
+                    @foreach (var exifPair in exifMetadata.Tags.Where(x => x.TagName?.ToLower() != "rawoutput"))
                     {
                         <tr>
                             <th scope="row">@exifPair.TagName</th>
                             <td>@exifPair.TagValue</td>
                         </tr>
                     }
-                }
-            }
-        </tr>
-    </table>
-</div>
+                </tr>
+            </table>
+        </div>
+    }
+}
+
+
+

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -19,7 +19,7 @@
         virusDict = CollectionUtils.GetValues(virusScanMetadata);
 }
 
-<table class="table small table-striped">
+<table class="table small">
     <tr>
         <th scope="row">Name</th>
         <td>
@@ -101,77 +101,69 @@
             <td>🚫 <a href="@binary.Content">Binary content (Storage API)</a></td>
         </tr>
     }
-    
-    <tr>
-        <th scope="row">&nbsp;</th>
-        <td></td>
-    </tr>
-    <tr>
-        <th scope="row"><strong>Brunnhilde</strong></th>
-        <td></td>
-    </tr>
-    <tr>
-        @if (workingFile != null)
-        {
-            @if (fileFormatDict != null && fileFormatDict.Any())
-            {
-                foreach (var fileFormatMetadata in fileFormatDict)
-                {
-                    <tr>
-                        <th scope="row">@fileFormatMetadata.Key</th>
-                        <td>@fileFormatMetadata.Value</td>
-                    </tr>
-                }
-            }
-        }
-    </tr>
-    
-    <tr>
-        <th scope="row">&nbsp;</th>
-        <td></td>
-    </tr>
-    <tr>
-        <th scope="row"><strong>Clam AV</strong></th>
-        <td></td>
-    </tr>
-    <tr>
-        @if (workingFile != null)
-        {
-            @if (virusDict != null && virusDict.Any())
-            {
-                foreach (var virusMetadata in virusDict)
-                {
-                    <tr>
-                    <th scope="row">@virusMetadata.Key</th>
-                    <td>@virusMetadata.Value</td>
-                    </tr>
-                }
-            }
-        }
-    </tr>
 
-    <tr>
-        <th scope="row">&nbsp;</th>
-        <td></td>
-    </tr>
-    <tr>
-        <th scope="row"><strong>Exif Metadata</strong></th>
-        <td></td>
-    </tr>
-    <tr>
-        @if (workingFile != null)
-        {
-            @if (exifMetadata is { Tags: not null })
-            {
-                foreach (var exifPair in exifMetadata.Tags)
-                {
-                    <tr>
-                        <th scope="row">@exifPair.TagName</th>
-                        <td>@exifPair.TagValue</td>
-                    </tr>
-                }
-            }
-        }
-    </tr>
 
 </table>
+
+<div>
+    <h3>Brunnhilde</h3>
+    <table class="table small" style="width: 30%;">
+        <tr>
+            @if (workingFile != null)
+            {
+                @if (fileFormatDict != null && fileFormatDict.Any())
+                {
+                    foreach (var fileFormatMetadata in fileFormatDict)
+                    {
+                        <tr>
+                            <th scope="row">@fileFormatMetadata.Key</th>
+                            <td>@fileFormatMetadata.Value</td>
+                        </tr>
+                    }
+                }
+            }
+        </tr>
+    </table>
+</div>
+
+<div>
+    <h3>Clam AV</h3>
+    <table class="table small" style="width: 30%;">
+        <tr>
+            @if (workingFile != null)
+            {
+                @if (virusDict != null && virusDict.Any())
+                {
+                    foreach (var virusMetadata in virusDict)
+                    {
+                        <tr>
+                            <th scope="row">@virusMetadata.Key</th>
+                            <td>@virusMetadata.Value</td>
+                        </tr>
+                    }
+                }
+            }
+        </tr>
+    </table>
+</div>
+
+<div>
+    <h3>Exif Metadata</h3>
+    <table class="table small" style="width: 30%;">
+        <tr>
+            @if (workingFile != null)
+            {
+                @if (exifMetadata is { Tags: not null })
+                {
+                    foreach (var exifPair in exifMetadata.Tags.Where(x => x.TagName?.ToLower() != "rawoutput"))
+                    {
+                        <tr>
+                            <th scope="row">@exifPair.TagName</th>
+                            <td>@exifPair.TagValue</td>
+                        </tr>
+                    }
+                }
+            }
+        </tr>
+    </table>
+</div>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -6,8 +6,20 @@
 @{
     var binary = Model.Item1;
     var workingFile = Model.Item2;
+    var fileformatMetadata = Model.Item2?.GetFileFormatMetadata();
+    var virusScanMetadata = Model.Item2?.GetVirusScanMetadata();
+    var exifMetadata = Model.Item2?.GetExifMetadata();
+    IDictionary<string, string>? fileFormatDict = null;
+    IDictionary<string, string>? virusDict = null;
+
+    if (fileformatMetadata != null)
+        fileFormatDict = CollectionUtils.GetValues(fileformatMetadata);
+
+    if(virusScanMetadata != null)
+        virusDict = CollectionUtils.GetValues(virusScanMetadata);
 }
-<table class="table small">
+
+<table class="table small table-striped">
     <tr>
         <th scope="row">Name</th>
         <td>
@@ -68,18 +80,18 @@
     <tr>
         <th scope="row">Digest</th>
         <td>@((binary?.Digest ?? workingFile?.Digest) ?? "")
-        @if (binary?.Digest.HasText() is true && workingFile?.Digest.HasText() is true)
-        {
-            if (binary.Digest != workingFile.Digest)
+            @if (binary?.Digest.HasText() is true && workingFile?.Digest.HasText() is true)
             {
-                <div class="alert alert-danger" role="alert">
-                    <p>
-                        Binary Digest @binary.Digest <br/>
-                        does not match workingFile Digest @workingFile.Digest
-                    </p>
-                </div>
+                if (binary.Digest != workingFile.Digest)
+                {
+                    <div class="alert alert-danger" role="alert">
+                        <p>
+                            Binary Digest @binary.Digest <br/>
+                            does not match workingFile Digest @workingFile.Digest
+                        </p>
+                    </div>
+                }
             }
-        }
         </td>
     </tr>
     @if (binary != null)
@@ -89,4 +101,77 @@
             <td>🚫 <a href="@binary.Content">Binary content (Storage API)</a></td>
         </tr>
     }
+    
+    <tr>
+        <th scope="row">&nbsp;</th>
+        <td></td>
+    </tr>
+    <tr>
+        <th scope="row"><strong>Brunnhilde</strong></th>
+        <td></td>
+    </tr>
+    <tr>
+        @if (workingFile != null)
+        {
+            @if (fileFormatDict != null && fileFormatDict.Any())
+            {
+                foreach (var fileFormatMetadata in fileFormatDict)
+                {
+                    <tr>
+                        <th scope="row">@fileFormatMetadata.Key</th>
+                        <td>@fileFormatMetadata.Value</td>
+                    </tr>
+                }
+            }
+        }
+    </tr>
+    
+    <tr>
+        <th scope="row">&nbsp;</th>
+        <td></td>
+    </tr>
+    <tr>
+        <th scope="row"><strong>Clam AV</strong></th>
+        <td></td>
+    </tr>
+    <tr>
+        @if (workingFile != null)
+        {
+            @if (virusDict != null && virusDict.Any())
+            {
+                foreach (var virusMetadata in virusDict)
+                {
+                    <tr>
+                    <th scope="row">@virusMetadata.Key</th>
+                    <td>@virusMetadata.Value</td>
+                    </tr>
+                }
+            }
+        }
+    </tr>
+
+    <tr>
+        <th scope="row">&nbsp;</th>
+        <td></td>
+    </tr>
+    <tr>
+        <th scope="row"><strong>Exif Metadata</strong></th>
+        <td></td>
+    </tr>
+    <tr>
+        @if (workingFile != null)
+        {
+            @if (exifMetadata is { Tags: not null })
+            {
+                foreach (var exifPair in exifMetadata.Tags)
+                {
+                    <tr>
+                        <th scope="row">@exifPair.TagName</th>
+                        <td>@exifPair.TagValue</td>
+                    </tr>
+                }
+            }
+        }
+    </tr>
+
 </table>

--- a/src/DigitalPreservation/DigitalPreservation.Utils/CollectionUtils.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/CollectionUtils.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Primitives;
+﻿using Microsoft.Extensions.Primitives;
 
 namespace DigitalPreservation.Utils;
 
@@ -13,4 +13,9 @@ public static class CollectionUtils
             queryDictionary.Remove(key);
         }
     }
+
+    public static IDictionary<string, string> GetValues(object obj) =>
+        obj?.GetType().GetProperties()
+            .ToDictionary(p => p.Name, p => p.GetValue(obj)?.ToString() ?? "")
+        ?? []; // Returns empty dictionary if obj is null
 }

--- a/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
@@ -274,4 +274,9 @@ public static class StringUtils
         }
         return s + ")";
     }
+
+    public static string? RemoveLineEndings(this string? str)
+    {
+        return str?.ReplaceLineEndings().Replace("\\r", string.Empty).Replace("\\n", string.Empty);
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -268,7 +268,6 @@ public class MetadataReader : IMetadataReader
                 Tags = exifMetadata.ExifMetadata
             });
 
-            //SetMetadataHtml(metadataList, exifMetadata, timestamp);
         }
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -1,4 +1,5 @@
-﻿using DigitalPreservation.Common.Model.DepositHelpers;
+﻿using System.Text;
+using DigitalPreservation.Common.Model.DepositHelpers;
 using DigitalPreservation.Common.Model.ToolOutput.Siegfried;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
@@ -517,6 +518,8 @@ public class MetadataReader : IMetadataReader
             var i = 0;
             var exifMetadataForFile = new List<ExifTag>();
 
+            var sbRawOutput = new StringBuilder();
+
             foreach (var str in exifResultList)
             {
                 if (str.Contains("========") || str.Contains("directories scanned"))
@@ -524,7 +527,14 @@ public class MetadataReader : IMetadataReader
                     if (i > 0)
                     {
                         exifModel.ExifMetadata = new List<ExifTag>(exifMetadataForFile);
+                        exifModel.ExifMetadata.Add(new ExifTag
+                        {
+                            TagName = "RawOutput",
+                            TagValue = sbRawOutput.ToString()
+                        });
+
                         exifMetadataForFile.Clear();
+                        sbRawOutput.Clear();
                         result.Add(exifModel);
 
                         if (str.Contains("directories scanned"))
@@ -539,6 +549,9 @@ public class MetadataReader : IMetadataReader
                 }
                 else
                 {
+                    sbRawOutput.Append(str);
+                    sbRawOutput.Append("\\n");
+
                     var metadataPair = str.Split(":", 2);
 
                     var rgx = new Regex("[^a-zA-Z0-9]");

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -579,6 +579,7 @@ public class MetadataReader : IMetadataReader
 
     private void SetMetadataHtml(List<Metadata>? metadataList, ExifModel? exifMetadata, DateTime timestamp)
     {
+        if (metadataList == null) return;
         var brunnhildeMetadata = metadataList.FirstOrDefault(x => x.Source.ToLower() == "brunnhilde");
         var clamMetadata = metadataList.FirstOrDefault(x => x.Source.ToLower() == "clamav");
 

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -577,11 +577,6 @@ public class MetadataReader : IMetadataReader
 
     }
 
-    private IDictionary<string, string> GetValues(object obj) =>
-        obj?.GetType().GetProperties()
-            .ToDictionary(p => p.Name, p => p.GetValue(obj)?.ToString() ?? "")
-        ?? []; // Returns empty dictionary if obj is null
-
     private void SetMetadataHtml(List<Metadata>? metadataList, ExifModel? exifMetadata, DateTime timestamp)
     {
         var brunnhildeMetadata = metadataList.FirstOrDefault(x => x.Source.ToLower() == "brunnhilde");
@@ -591,11 +586,11 @@ public class MetadataReader : IMetadataReader
         IDictionary<string, string>? clamMetadataDictionary = null;
 
         if (brunnhildeMetadata is not null)
-            brunnhildeMetadataDictionary = GetValues(brunnhildeMetadata);
+            brunnhildeMetadataDictionary = CollectionUtils.GetValues(brunnhildeMetadata);
 
 
         if (clamMetadata is not null)
-            clamMetadataDictionary = GetValues(clamMetadata);
+            clamMetadataDictionary = CollectionUtils.GetValues(clamMetadata);
 
         IEnumerable<string>? brunnhildeStrings;
         var brunnhildeHtml = string.Empty;
@@ -612,28 +607,27 @@ public class MetadataReader : IMetadataReader
 
         var rawOutput = exifMetadata?.ExifMetadata.FirstOrDefault(x => x.TagName?.ToLower() == "rawoutput")?.TagValue;
 
-        //if (string.IsNullOrEmpty(rawOutput))
-        var replaceNewLineRawOutput = rawOutput.Replace("\\n", "<br>");
+        var replaceNewLineRawOutput = rawOutput?.Replace("\\n", "<br>");
         metadataList.Add(new ToolOutput
         {
             Source = "Exif",
             Timestamp = timestamp,
             Content = $@"<html>
-                            {GetHeader()}
+                            {GetStyle()}
                             <body>
-                                <h1>Exif Metadata</h1>
-                                <pre>{replaceNewLineRawOutput}</pre>
                                 <h1>Brunnhilde</h1>
                                 <pre>{brunnhildeHtml}</pre>
                                 <h1>ClamAV</h1>
                                 <pre>{clamHtml}</pre>
+                                <h1>Exif Metadata</h1>
+                                <pre>{replaceNewLineRawOutput}</pre>
                             </body>
-                        </html>", //raw tool output
+                        </html>",
             ContentType = "text/html"
         });
     }
 
-    private string GetHeader()
+    private string GetStyle()
     {
         return @"
             <head>


### PR DESCRIPTION
Surface Exif, pronom and Clam in a new tab and in the archival group Browse view
Tickets:
https://digirati.atlassian.net/browse/LPII-6
https://digirati.atlassian.net/browse/LPII-37
https://digirati.atlassian.net/browse/LPII-53
https://digirati.atlassian.net/browse/LPII-55

<img width="776" height="772" alt="image" src="https://github.com/user-attachments/assets/28376d6f-e4ae-45f8-ba8b-5b66f547a33e" />

Archival group browse view:

<img width="1578" height="822" alt="image" src="https://github.com/user-attachments/assets/b9c679b8-e221-416e-85be-3245e5bd4c43" />
