### PR TITLE
Change to how siegfried.csv URI is retrieved and allowing non-standard metadata folders to be deleted when not in METS

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/DeleteSelection.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/DeleteSelection.cs
@@ -23,4 +23,6 @@ public class DeleteSelection
     [JsonPropertyOrder(4)]
     [JsonPropertyName("items")]
     public List<MinimalItem> Items { get; set; } = [];
+
+    public string[]? ContinueIfFail { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -433,7 +433,7 @@ public class MetadataReader : IMetadataReader
 
         if (candidateStrings.Count > 1)
         {
-            candidateStrings.RemoveAll(s => !s.Split('/')[0].StartsWith("siegfried."));
+            candidateStrings.RemoveAll(s => !s.Split('/')[^1].StartsWith("siegfried."));
         }
         
         // ideally, this is one of the three above:

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/DeleteItems.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/DeleteItems.cs
@@ -34,7 +34,6 @@ public class DeleteItemsHandler(
     IAmazonS3 s3Client,
     IMetsManager metsManager) : IRequestHandler<DeleteItems, Result<ItemsAffected>>
 {
-    private string[] pipelineMetadataFolders = ["metadata/brunnhilde", "metadata/exif", "metadata/virus-definition"]; 
     public async Task<Result<ItemsAffected>> Handle(DeleteItems request, CancellationToken cancellationToken)
     { 
         var goodResult = new ItemsAffected();
@@ -218,7 +217,7 @@ public class DeleteItemsHandler(
                 }
             }
 
-            if (failedDeleteResult == null || !pipelineMetadataFolders.Contains(item.RelativePath))
+            if (failedDeleteResult == null || (request.DeleteSelection.ContinueIfFail != null && !request.DeleteSelection.ContinueIfFail.Contains(item.RelativePath)))
             {
                 goodResult.Items.Add(item);
             }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/DeleteItems.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/DeleteItems.cs
@@ -34,6 +34,7 @@ public class DeleteItemsHandler(
     IAmazonS3 s3Client,
     IMetsManager metsManager) : IRequestHandler<DeleteItems, Result<ItemsAffected>>
 {
+    private string[] pipelineMetadataFolders = ["metadata/brunnhilde", "metadata/exif", "metadata/virus-definition"]; 
     public async Task<Result<ItemsAffected>> Handle(DeleteItems request, CancellationToken cancellationToken)
     { 
         var goodResult = new ItemsAffected();
@@ -217,7 +218,7 @@ public class DeleteItemsHandler(
                 }
             }
 
-            if (failedDeleteResult == null)
+            if (failedDeleteResult == null || !pipelineMetadataFolders.Contains(item.RelativePath))
             {
                 goodResult.Items.Add(item);
             }

--- a/src/DigitalPreservation/Pipeline.API/Config/BrunnhildeOptions.cs
+++ b/src/DigitalPreservation/Pipeline.API/Config/BrunnhildeOptions.cs
@@ -9,4 +9,5 @@ public class BrunnhildeOptions
     public string? ProcessFolder { get; set; }
     public string? ExifToolLocation { get; set; }
     public int? ReleaseLockAttemptTime { get; set; }
+    public string? PipelineMetadataFolders { get; set; }
 }

--- a/src/DigitalPreservation/Pipeline.API/Config/PipelineToolOptions.cs
+++ b/src/DigitalPreservation/Pipeline.API/Config/PipelineToolOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Pipeline.API.Config;
 
-public class BrunnhildeOptions
+public class PipelineToolOptions
 {
     public string? PathToBrunnhilde { get; set; }
     public string? PathToPython { get; set; }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -552,6 +552,7 @@ public class ProcessPipelineJobHandler(
             }
         }
 
+        deleteSelection.ContinueIfFail = brunnhildeOptions.Value.PipelineMetadataFolders?.Split(",");
         var resultDelete = await workspaceManager.DeleteItems(deleteSelection, request.GetUserName());
         return resultDelete;
     }

--- a/src/DigitalPreservation/Pipeline.API/Program.cs
+++ b/src/DigitalPreservation/Pipeline.API/Program.cs
@@ -41,8 +41,8 @@ try
     builder.Services.Configure<StorageOptions>(
         builder.Configuration.GetSection("StorageOptions"));
 
-    builder.Services.Configure<BrunnhildeOptions>(
-        builder.Configuration.GetSection("BrunnhildeOptions"));
+    builder.Services.Configure<PipelineToolOptions>(
+        builder.Configuration.GetSection("PipelineToolOptions"));
 
     builder.Services.Configure<PipelineOptions>(
         builder.Configuration.GetSection("PipelineOptions"));

--- a/src/DigitalPreservation/Pipeline.API/appsettings.Example.json
+++ b/src/DigitalPreservation/Pipeline.API/appsettings.Example.json
@@ -40,8 +40,8 @@
   "StorageOptions": {
     "FileMountPath": "C:\\Test_1\\MountTest" //will be local directory for now (installed Python)
   },
-  "BrunnhildeOptions": {
-    "PathToBrunnhilde": "\\Python\\Python314\Lib\\site-packages\\brunnhilde.py",
+  "PipelineToolOptions": {
+    "PathToBrunnhilde": "\\\\Python\\\\Python314\\Lib\\\\site-packages\\\\brunnhilde.py",
     "PathToPython": "\\Programs\\Python\\Python314\\python.exe",
     "DirectorySeparator": "\\",
     "ObjectsFolder": "objects"

--- a/src/DigitalPreservation/Pipeline.API/appsettings.json
+++ b/src/DigitalPreservation/Pipeline.API/appsettings.json
@@ -32,6 +32,7 @@
     "ObjectsFolder": "objects",
     "ProcessFolder": "/usr/process-brunnhilde",
     "ExifToolLocation": "exiftool",
-    "ReleaseLockAttemptTime": 10
+    "ReleaseLockAttemptTime": 10,
+    "PipelineMetadataFolders": "metadata/brunnhilde,metadata/exif,metadata/virus-definition"
   }
 }

--- a/src/DigitalPreservation/Pipeline.API/appsettings.json
+++ b/src/DigitalPreservation/Pipeline.API/appsettings.json
@@ -25,7 +25,7 @@
     "DisableAuth": "true",
     "UseLocalHostedServiceForPipeline": "false"
   },
-  "BrunnhildeOptions": {
+  "PipelineToolOptions": {
     "PathToBrunnhilde": "",
     "PathToPython": "brunnhilde.py",
     "DirectorySeparator": "/",


### PR DESCRIPTION
Change to how siegfried.csv URI is retrieved
We could configure these folder values so we can calculate which non-standard/manual metadata folders we can ignore the METS delete result for.
Ticket(s):
https://digirati.atlassian.net/browse/LPII-50