### PR TITLE
Fix/lpii 59/report differences

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -59,6 +59,7 @@
             <td>@binary.ContentType</td>
         </tr>
     }
+
     @if (workingFile != null)
     {
         var premisFromMets = workingFile.Metadata.OfType<FileFormatMetadata>().SingleOrDefault();
@@ -126,6 +127,25 @@
                 <tr>
                     @foreach (var fileFormatMetadata in fileFormatDict)
                     {
+                        if ((fileFormatMetadata.Key.ToLower() == "contenttype" || fileFormatMetadata.Key.ToLower() == "size") && string.IsNullOrEmpty(fileFormatMetadata.Value) && binary != null)
+                        {
+
+                            <tr>
+                                <th scope="row">@fileFormatMetadata.Key</th>
+                                <td>@(fileFormatMetadata.Key.ToLower() == "contenttype" ? binary.ContentType : binary.Size)</td>
+                            </tr>
+                            continue;
+                        }
+
+                        if (fileFormatMetadata.Key.ToLower() == "timestamp" && binary != null)
+                        {
+                            <tr>
+                                <th scope="row">@fileFormatMetadata.Key</th>
+                                <td>@binary.Created</td>
+                            </tr>
+                            continue;
+                        }
+
                         <tr>
                             <th scope="row">@fileFormatMetadata.Key</th>
                             <td>@fileFormatMetadata.Value</td>
@@ -139,7 +159,7 @@
 
 @if (workingFile != null)
 {
-    @if (virusDict != null && virusDict.Any())
+    @if (virusDict != null && virusDict.Any() && virusScanMetadata?.Source.ToLower() == "clamav")
     {
         <div>
             <h4>Clam AV</h4>
@@ -160,7 +180,7 @@
 
 @if (workingFile != null)
 {
-    @if (exifMetadata is { Tags: not null })
+    @if (exifMetadata is { Tags: not null } && exifMetadata?.Source.ToLower() == "exif")
     {
         <div>
             <h4>Exif Metadata</h4>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -180,7 +180,7 @@
 
 @if (workingFile != null)
 {
-    @if (exifMetadata is { Tags: not null } && exifMetadata?.Source.ToLower() == "exif")
+    @if (exifMetadata is { Tags: not null })
     {
         <div>
             <h4>Exif Metadata</h4>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -21,7 +21,7 @@
     var toolsRun = fileformatMetadata?.PronomKey?.ToLower() != "unknown" && !string.IsNullOrEmpty(fileformatMetadata?.FormatName);
 }
 
-<table class="table small table-striped">
+<table class="table small table-striped" aria-label="table-core">
     <tr>
         <th scope="row">Name</th>
         <td>

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -17,6 +17,8 @@
 
     if(virusScanMetadata != null)
         virusDict = CollectionUtils.GetValues(virusScanMetadata);
+
+    var toolsRun = fileformatMetadata?.PronomKey?.ToLower() != "unknown" && !string.IsNullOrEmpty(fileformatMetadata?.FormatName);
 }
 
 <table class="table small table-striped">
@@ -106,7 +108,7 @@
 
 </table>
 
-@if (workingFile != null)
+@if (workingFile != null && toolsRun)
 {
     @if ((fileFormatDict != null && fileFormatDict.Any()) || (virusDict != null && virusDict.Any()) || exifMetadata is { Tags: not null })
     {
@@ -117,7 +119,7 @@
 }
 
 
-@if (workingFile != null)
+@if (workingFile != null && toolsRun)
 {
     @if (fileFormatDict != null && fileFormatDict.Any())
     {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Shared/_BinaryAndWorkingFile.cshtml
@@ -125,7 +125,7 @@
     {
         <div>
             <h4>Brunnhilde</h4>
-            <table class="table small" style="width: 30%;">
+            <table class="table small" style="width: 30%;" aria-label="table-brunnhilde">
                 <tr>
                     @foreach (var fileFormatMetadata in fileFormatDict)
                     {
@@ -165,7 +165,7 @@
     {
         <div>
             <h4>Clam AV</h4>
-            <table class="table small" style="width: 30%;">
+            <table class="table small" style="width: 30%;" aria-label="table-virus">
                 <tr>
                     @foreach (var virusMetadata in virusDict)
                     {
@@ -186,7 +186,7 @@
     {
         <div>
             <h4>Exif Metadata</h4>
-            <table class="table small" style="width: 30%;">
+            <table class="table small" style="width: 30%;" aria-label="table-exif">
                 <tr>
                     @foreach (var exifPair in exifMetadata.Tags.Where(x => x.TagName?.ToLower() != "rawoutput"))
                     {


### PR DESCRIPTION
Use binary metadata in Archival Group Browse view (essentially the deposit metadata) to supplement the metadata retrieved from METS.
Tickets:

https://digirati.atlassian.net/browse/LPII-57
https://digirati.atlassian.net/browse/LPII-59
https://digirati.atlassian.net/browse/LPII-58