### PR TITLE
add Exif UI tests

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -580,7 +580,7 @@ public class MetadataReader : IMetadataReader
 
     }
 
-    private void SetMetadataHtml(List<Metadata>? metadataList, ExifModel? exifMetadata, DateTime timestamp)
+    public static void SetMetadataHtml(List<Metadata>? metadataList, ExifModel? exifMetadata, DateTime timestamp)
     {
         if (metadataList == null) return;
         var brunnhildeMetadata = metadataList.FirstOrDefault(x => x.Source.ToLower() == "brunnhilde");
@@ -618,7 +618,7 @@ public class MetadataReader : IMetadataReader
             htmlBody.Append($@"<h1>File format</h1>
                            <pre>{brunnhildeHtml}</pre>");
 
-        if (!string.IsNullOrEmpty(brunnhildeHtml))
+        if (!string.IsNullOrEmpty(clamHtml))
             htmlBody.Append($@"<h1>Viruses</h1>
                            <pre>{clamHtml}</pre>");
 
@@ -642,7 +642,7 @@ public class MetadataReader : IMetadataReader
         htmlBody.Clear();
     }
 
-    private string GetStyle()
+    private static string GetStyle()
     {
         return @"
             <head>

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsParser.cs
@@ -439,7 +439,9 @@ public class MetsParser(
                                 Digest = digest,
                                 Source = Constants.Mets,
                                 PronomKey = key,
-                                FormatName = name
+                                FormatName = name,
+                                Size = size,
+                                ContentType = mimeType
                             };
                         }
                     }

--- a/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
@@ -14,7 +14,7 @@ using Xunit.Sdk;
 
 namespace XmlGen.Tests;
 
-public class ExifTests(ITestOutputHelper testOutputHelper)
+public class ExifTests()
 {
     [Fact]
     private void Build_Exif()

--- a/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
@@ -1,0 +1,159 @@
+﻿using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using DigitalPreservation.Workspace;
+using FluentAssertions;
+using FluentAssertions.Equivalency;
+using Storage.Repository.Common.Mets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace XmlGen.Tests;
+
+public class ExifTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    private void Build_Exif()
+    {
+        var premisManager = new PremisManager();
+        var testData = GetTestPremisData();
+        var premis = premisManager.Create(testData);
+        //patch the Premis with exif
+        var premisExifManager = new PremisManagerExif();
+        var testDataExif = GetTestExifData();
+        premisExifManager.Patch(premis, testDataExif);
+
+        var xmlElement = premisExifManager.GetXmlElement(premis, false);
+
+        var exifMetadataNodeList = xmlElement?.SelectNodes("//*[name()='ExifMetadata']");
+
+        exifMetadataNodeList.Should().NotBeNull();
+
+        if (exifMetadataNodeList != null)
+        {
+            foreach (XmlNode node in exifMetadataNodeList)
+            {
+                var exifToolVersion = node.SelectNodes("//*[name()='ExifToolVersion']");
+                var exifContentType = node.SelectNodes("//*[name()='ContentType']");
+
+                exifToolVersion?[0]?.InnerText.Should().Be("1.3.4");
+                exifContentType?[0]?.InnerText.Should().Be("text/plain");
+            }
+        }
+    }
+
+    [Fact]
+    private static void Can_Get_Metadata_Html()
+    {
+        var exifFi = new FileInfo("Samples/exif_output.txt");
+        var exifResultStr = string.Empty;
+        using (StreamReader sr = new StreamReader(exifFi.FullName))
+        {
+            exifResultStr += sr.ReadToEnd();
+        }
+
+        var exifMetadataList = MetadataReader.ParseExifToolOutput(exifResultStr);
+
+        var exifModel = exifMetadataList.FirstOrDefault();
+
+        //model contains RawOutput
+        exifModel?.ExifMetadata.LastOrDefault()?.TagName.Should().Be("RawOutput");
+        var metadataList = GetMetadataList();
+
+        metadataList.Should().HaveCount(3);
+
+        MetadataReader.SetMetadataHtml(metadataList, exifModel, DateTime.Now);
+
+        //tool output added
+        metadataList.Should().HaveCount(4);
+        var metadataType = metadataList[3].GetType();
+
+        metadataType.Name.Should().Be("ToolOutput");
+        var toolOutput = (ToolOutput)metadataList[3];
+
+        toolOutput.Content.Should().Contain("<h1>File format</h1>");
+        toolOutput.Content.Should().Contain("<h1>Viruses</h1>");
+        toolOutput.Content.Should().Contain("<h1>Exif</h1>");
+
+    } 
+
+    private static ExifMetadata GetTestExifData()
+    {
+        var testData = new ExifMetadata
+        {
+            Source = "Exif",
+            Tags =
+            [
+                new() { TagName = "ExifToolVersion", TagValue = "1.3.4" },
+                new() { TagName = "ContentType", TagValue = "text/plain" }
+            ],
+            Timestamp = DateTime.Now
+        };
+        return testData;
+    }
+
+    private static FileFormatMetadata GetTestPremisData()
+    {
+        var testData = new FileFormatMetadata
+        {
+            Source = "METS",
+            Digest = "efc63a2c4dbb61936b5028c637c76f066ce463b5de6f3d5d674c9f024fa08d79",
+            Size = 9999999,
+            FormatName = "Tagged Image File Format Test",
+            PronomKey = "fmt/999",
+            OriginalName = "files/a-file-path"
+        };
+        return testData;
+    }
+
+    private static List<Metadata> GetMetadataList()
+    {
+        return
+        [
+            new FileFormatMetadata
+            {
+                Source = "Brunnhilde",
+                Digest = "b42a6e9c",
+                ContentType = "text/plain",
+                FormatName = "Text File",
+                PronomKey = "fmt/101",
+                Size = 9999
+            },
+            new VirusScanMetadata
+            {
+                Source = "ClamAv",
+                HasVirus = true,
+                VirusDefinition = "1.3.4",
+                VirusFound = "EICAR-HDB",
+                Timestamp = DateTime.Now
+            },
+            new ExifMetadata
+            {
+                Source = "Exif",
+                Tags =
+                [
+                    new()
+                    {
+                        TagName = "ExifToolVersion",
+                        TagValue = "1.3.4"
+                    },
+
+                    new()
+                    {
+                        TagName = "ContentType",
+                        TagValue = "text/plain"
+                    },
+                    new()
+                    {
+                        TagName = "ContentType",
+                        TagValue = "text/plain"
+                    },
+                ]
+            }
+        ];
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/ExifTests.cs
@@ -1,16 +1,9 @@
 ﻿using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Workspace;
 using FluentAssertions;
-using FluentAssertions.Equivalency;
 using Storage.Repository.Common.Mets;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
-using Xunit.Abstractions;
-using Xunit.Sdk;
+
 
 namespace XmlGen.Tests;
 

--- a/src/DigitalPreservation/XmlGen.Tests/Samples/exif_output.txt
+++ b/src/DigitalPreservation/XmlGen.Tests/Samples/exif_output.txt
@@ -1,0 +1,18 @@
+======== /usr/deposit/deposits/sbsvf8pvrqt6/objects/testfile.txt
+ExifTool Version Number         : 12.57
+File Name                       : testfile.txt
+Directory                       : /usr/deposit/deposits/sbsvf8pvrqt6/objects
+File Size                       : 4.2 kB
+File Modification Date/Time     : 2026:02:13 11:28:14+00:00
+File Access Date/Time           : 2026:02:13 11:28:14+00:00
+File Inode Change Date/Time     : 2026:02:13 11:28:14+00:00
+File Permissions                : -rw-r--r--
+File Type                       : TXT
+File Type Extension             : txt
+MIME Type                       : text/plain
+MIME Encoding                   : us-ascii
+Newlines                        : Unix LF
+Line Count                      : 97
+Word Count                      : 470
+    1 directories scanned
+    1 image files read

--- a/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
+++ b/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
@@ -26,6 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\DigitalPreservation.Workspace\DigitalPreservation.Workspace.csproj" />
       <ProjectReference Include="..\DigitalPreservation.XmlGen\DigitalPreservation.XmlGen.csproj" />
       <ProjectReference Include="..\Storage.Repository.Common\Storage.Repository.Common.csproj" />
     </ItemGroup>
@@ -35,6 +36,9 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="Samples\EPrints.10315.METS.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Samples\exif_output.txt">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="Samples\goobi-wc-b29356350.xml">


### PR DESCRIPTION
changed scope of some of the MetadataReader class methods to allow testing.
Extended MetsParser FileFormatMetadata object to include size and ContentType. Added exif tests to check the ToolOutput is created after parsing the sample exif_output.txt file

Ticket: https://digirati.atlassian.net/browse/LPII-60