### PR TITLE
Experimental/mets parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,7 @@ MigrationBackup/
 fedora.bat
 
 .venv
+
+.claude
+
+CLAUDE.md

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/IMetsManager.cs
@@ -1,5 +1,6 @@
 ﻿using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
 
 namespace DigitalPreservation.Common.Model.Mets;
 
@@ -19,9 +20,49 @@ public interface IMetsManager
     Result AddToMets(FullMets fullMets, WorkingBase workingBase); // , Uri? storageLocation
     Result DeleteFromMets(FullMets fullMets, string deletePath); // , Uri? storageLocation
     Task<Result> WriteMets(FullMets fullMets);
-
+   
+    
+    
+    
+        // The following are made obsolete because they are handled by the more general cases below.
+    [Obsolete]
     List<string> GetRootAccessRestrictions(FullMets fullMets);
+    [Obsolete]
     void SetRootAccessRestrictions(FullMets fullMets, List<string> accessRestrictions);
+    [Obsolete]
     void SetRootRightsStatement(FullMets fullMets, Uri? uri);
+    [Obsolete]
     Uri? GetRootRightsStatement(FullMets fullMets);
+
+    // Extensions
+    // We don't need getters because this information will be exposed in either WorkingFile/Dir or Logical ... Ranges
+    // These need to be settable on DIVs in Logical Struct Maps as well as on physical paths.
+    // Both are strings; is it safe for the same method to be used for both?
+    // ...instead of `string physicalPath` it's `string divID` 
+    // `string locator` is either a physical path of a file or directory,
+    // or the "ID" of a mets:Div - usually a logical one but can be a physical one
+    // SetRecordIdentifier(mets, "objects/child-folder", "EMu", "MS 1234/8")
+    // SetRecordIdentifier(mets, "LOG_0003", "EMu", "MS 1234/9")
+    // SetRecordIdentifier(mets, "PHYS_objects/child-folder", "EMu", "MS 1234/8")  // equiv to first one
+    // always look for both, throw an exception if you find both?
+    void SetRecordIdentifier(FullMets mets, string locator, string source, string value);
+    void SetRightsStatement(FullMets mets, string locator, Uri? rightsStatement);
+    void SetAccessRestrictions(FullMets mets, string locator, List<string> accessRestrictions);
+
+
+    // There may be more than one so we need to address them better than this, which assumes only one
+    // address by ID? There will almost always be only one so we don't want to complicate the UI
+    // Sets a logical struct map (never a physical one)
+    void SetStructMap(FullMets mets, LogicalRange logSm);
+    // This will overwrite a structMap with the same ID, and append one if the ID is different to any currently existing.
+
+    // maybe this rarely used operation, if we need to change the order:
+    void SetStructMapOrder(FullMets mets, string[] ids);
+
+    // And we also need to remove a structMap; always require the id even if only one, as a safety measure
+    void RemoveStructMap(FullMets mets, string id);
+
+    // from and to are always physical file paths (?)
+    void LinkFile(FullMets mets, string from, string to, Uri role);
+    void UnLinkFile(FullMets mets, string from, string to, Uri role);
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/MetsFileWrapper.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Mets/MetsFileWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
 using Microsoft.Extensions.Primitives;
 
 namespace DigitalPreservation.Common.Model.Mets;
@@ -36,4 +37,5 @@ public class MetsFileWrapper
     public bool Editable { get; set; }
     public List<string> RootAccessConditions { get; set; } = [];
     public Uri? RootRightsStatement { get; set; }
+    public List<LogicalRange> LogicalStructures { get; set; } = [];
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/LogicalRange.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/LogicalRange.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace DigitalPreservation.Common.Model.Transit.Extensions;
+
+/// <summary>
+/// Logical resources in METS
+/// </summary>
+public class LogicalRange : ResourceBase
+{
+    [JsonPropertyOrder(0)]
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    public List<LogicalRange> Ranges { get; set; } = [];
+    public List<FilePointer> Files { get; set; } = [];
+    public override required string Type { get; set; }
+}
+
+public class FilePointer
+{
+    public required string LocalPath { get; set; } // not WorkingFile, caller can look it up
+    public Rectangle? Region { get; set; }
+    public double? BeginTime { get; set; }
+    public double? EndTime { get; set; }
+}
+
+public class Rectangle
+{
+    public int X1 { get; set; }
+    public int Y1 { get; set; }
+    public int X2 { get; set; }
+    public int Y2 { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExtentMetadata.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/Metadata/ExtentMetadata.cs
@@ -1,0 +1,9 @@
+namespace DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+
+public class ExtentMetadata : Metadata
+{
+    public int? PixelWidth { get; set; }
+    public int? PixelHeight { get; set; }
+
+    public double? Duration { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FileLink.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FileLink.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace DigitalPreservation.Common.Model.Transit;
+
+public class FileLink
+{
+    [JsonPropertyName("to")]
+    [JsonPropertyOrder(1)]
+    public required string To { get; set; }
+    
+    [JsonPropertyName("role")]
+    [JsonPropertyOrder(2)]
+    public Uri? Role { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/RecordInfo.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/RecordInfo.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace DigitalPreservation.Common.Model.Transit;
+
+public class RecordInfo
+{
+    [JsonPropertyName("recordIdentifiers")]
+    [JsonPropertyOrder(1)]
+    public List<RecordIdentifier> RecordIdentifiers { get; set; } = [];
+}
+
+public class RecordIdentifier
+{
+    [JsonPropertyName("source")]
+    [JsonPropertyOrder(1)]
+    public required string Source  { get; set; }
+    
+    [JsonPropertyName("value")]
+    [JsonPropertyOrder(2)]
+    public required string Value { get; set; }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/ResourceBase.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/ResourceBase.cs
@@ -34,4 +34,12 @@ public abstract class ResourceBase
     [JsonPropertyName("effectiveRightsStatement")]
     [JsonPropertyOrder(11)]
     public Uri? EffectiveRightsStatement { get; set; }
+    
+    [JsonPropertyName("recordInfo")]
+    [JsonPropertyOrder(15)]
+    public RecordInfo? RecordInfo { get; set; }
+
+    [JsonPropertyName("effectiveRecordInfo")]
+    [JsonPropertyOrder(16)]
+    public RecordInfo? EffectiveRecordInfo { get; set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -29,6 +29,10 @@ public class WorkingFile : WorkingBase
     [JsonPropertyOrder(16)]
     public long? Size { get; set; }
 
+    [JsonPropertyName("links")]
+    [JsonPropertyOrder(50)]
+    public List<FileLink> Links { get; set; } = [];
+
     public WorkingFile ToRootLayout()
     {
         if (!LocalPath.StartsWith($"{FolderNames.BagItData}/"))

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsManager.cs
@@ -2,6 +2,7 @@
 using DigitalPreservation.Common.Model.Mets;
 using DigitalPreservation.Common.Model.Results;
 using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Mets;
@@ -582,4 +583,48 @@ public class MetsManager(
     }
     private FileType? File { get; set; }
     private MetsTypeFileSecFileGrp? FileGroup { get; set; }
+    
+    
+    
+    
+    
+    public void SetRecordIdentifier(FullMets mets, string locator, string source, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetRightsStatement(FullMets mets, string locator, Uri? rightsStatement)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetAccessRestrictions(FullMets mets, string locator, List<string> accessRestrictions)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetStructMap(FullMets mets, LogicalRange logSm)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetStructMapOrder(FullMets mets, string[] ids)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void RemoveStructMap(FullMets mets, string id)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void LinkFile(FullMets mets, string from, string to, Uri role)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void UnLinkFile(FullMets mets, string from, string to, Uri role)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
@@ -1,0 +1,301 @@
+using DigitalPreservation.Common.Model.Mets;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+using Storage.Repository.Common.Mets.StorageImpl;
+
+namespace XmlGen.Tests.Experimental;
+
+public class Liddle
+{
+    private readonly IMetsManager metsManager;
+    private readonly MetsParser parser;
+
+    public Liddle()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        parser = new MetsParser(new FileSystemMetsLoader(), parserLogger);
+        var storage = new FileSystemMetsStorage(parser);
+        metsManager = new MetsManager(parser, storage, new MetadataManager());
+    }
+
+    [Fact(Skip = "Experimental")]
+    public async Task Extended_Mets()
+    {
+        var mets = await Basic_Liddle();
+
+        //await metsManager.WriteMets(mets);
+
+        // The archivist doesn't assign any identifier to the root of the object
+        // because it doesn't correspond to any particular archival record; it's neither a collection nor an item
+        // (This may not happen IRL, it may be a business rule that a unit of preservation (the AG) always
+        // corresponds to some archival record, whatever the level)
+
+        // or...
+        // The archivist assigns LIDDLE/WW1/TAPES/1-2 to the root of the object
+        metsManager.SetRecordIdentifier(mets, "objects", "identity-service", "a8n9e4c2");
+        metsManager.SetRecordIdentifier(mets, "objects", "EMu", "LIDDLE/WW1/TAPES/1-2");
+        // This pair of tapes (i.e., physical objects) is LIDDLE/WW1/TAPES/1-2 
+
+        // apply access condition and rights statement to origin, though
+        metsManager.SetAccessRestrictions(mets, "objects", ["Level1"]);
+        metsManager.SetRightsStatement(mets, "objects", new Uri("http://rightsstatements.org/vocab/InC/1.0/"));
+
+
+
+        // The archivist creates a logical structure over the raw files for each interview, aligned with EMu archival description.
+        var logSm = new LogicalRange
+        {
+            Id = "LOG_0000",
+            Name = "Tapes 1 and 2",  // Unlikely
+            Type = "Collection",     // ...but maybe?
+            Ranges =
+            [
+                new LogicalRange
+                {
+                    Id = "LOG_0001",
+                    Type = "Item",
+                    Name = "ADDAMS-WILLIAMS, DONALD ARTHUR",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "mg56cva7"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "LIDDLE/WW1/XXX/1"
+                            }
+                        ]
+                    },
+                    Files = [
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape1side1.wav",
+                            BeginTime = 15.0,
+                            EndTime = 2109.5
+                        }
+                    ]
+                },
+                new LogicalRange
+                {
+                    Id = "LOG_0002",
+                    Type = "Item",
+                    Name = "AITCHISON, BERTRAM STEWART",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "vvdd4433"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "LIDDLE/WW1/XXX/2"
+                            }
+                        ]
+                    },
+                    Files = [                     // spans sides 1 and 2
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape1side1.wav",
+                            BeginTime = 2200,
+                            EndTime = 2700  // end of side 1
+                        },
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape1side2.wav",
+                            BeginTime = 9.2, // start of side 2
+                            EndTime = 1209  
+                        }
+                    ]
+                },
+                new LogicalRange
+                {
+                    Id = "LOG_0003",
+                    Type = "Item",
+                    Name = "ALEXANDER, C",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "adfa234d"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "LIDDLE/WW1/XXX/3"
+                            }
+                        ]
+                    },
+                    Files = [   
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape1side2.wav",
+                            BeginTime = 1250,
+                            EndTime = 1900  // rest of side 2 blank
+                        }
+                    ]
+                },
+                new LogicalRange
+                {
+                    Id = "LOG_0004",
+                    Type = "Item",
+                    Name = "ALLANSON, CECIL JOHN LYONS",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "e34e2ads"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "LIDDLE/WW1/XXX/4"
+                            }
+                        ]
+                    },
+                    Files = [   
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape2side1.wav",
+                            BeginTime = 13.9,
+                            EndTime = 2690.54  
+                        },   
+                        new FilePointer
+                        {
+                            LocalPath = "objects/tape2side2.wav",
+                            BeginTime = 20.6,
+                            EndTime = 1387.51  
+                        }
+                    ]
+                }
+            ]
+        };
+        metsManager.SetStructMap(mets, logSm);
+
+        await metsManager.WriteMets(mets);
+    }
+
+    public async Task<FullMets> Basic_Liddle()
+    {
+        var name = "Liddle Tapes 1 and 2";
+        var metsFi = new FileInfo("C:\\git\\uol-dlip\\design\\complex-mets\\liddle.mets.xml");
+        var metsUri = new Uri(metsFi.FullName);
+        var result = await metsManager.CreateStandardMets(new Uri(metsFi.FullName), name);
+
+        result.Success.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        var metsWrapper = result.Value!;
+        var metsResult = await metsManager.GetFullMets(metsUri, metsWrapper.ETag!);
+        var mets = metsResult.Value!;
+        mets.Should().NotBeNull();
+
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/tape1side1.wav",
+            Digest = "abcd1234",
+            ContentType = "audio/x-wav",
+            Name = "Tape 1 Side 1",
+            Size = 500000,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "abcd1234",
+                    ContentType = "audio/x-wav",
+                    FormatName = "Broadcast WAVE 0 Generic",
+                    PronomKey = "fmt/1",
+                    Size = 500000
+                },
+                new ExtentMetadata
+                {
+                    Source = "FFProbe",
+                    Duration = 2704.7
+                }
+            ]
+        });        
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/tape1side2.wav",
+            Digest = "3e421bb1",
+            ContentType = "audio/x-wav",
+            Name = "Tape 1 Side 2",
+            Size = 500001,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "3e421bb1",
+                    ContentType = "audio/x-wav",
+                    FormatName = "Broadcast WAVE 0 Generic",
+                    PronomKey = "fmt/1",
+                    Size = 500001
+                },
+                new ExtentMetadata
+                {
+                    Source = "FFProbe",
+                    Duration = 2720.1
+                }
+            ]
+        });        
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/tape2side1.wav",
+            Digest = "d4d4e3e3",
+            ContentType = "audio/x-wav",
+            Name = "Tape 2 Side 1",
+            Size = 499999,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "d4d4e3e3",
+                    ContentType = "audio/x-wav",
+                    FormatName = "Broadcast WAVE 0 Generic",
+                    PronomKey = "fmt/1",
+                    Size = 499999
+                }
+            ]
+        });        
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/tape2side2.wav",
+            Digest = "a2d3e4f5",
+            ContentType = "audio/x-wav",
+            Name = "Tape 2 Side 2",
+            Size = 500100,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "a2d3e4f5",
+                    ContentType = "audio/x-wav",
+                    FormatName = "Broadcast WAVE 0 Generic",
+                    PronomKey = "fmt/1",
+                    Size = 500100
+                }
+            ]
+        });
+        return mets;
+    }
+
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
@@ -8,12 +8,11 @@ using Microsoft.Extensions.Logging;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.Mets.StorageImpl;
 
-namespace XmlGen.Tests.Experimental;
+namespace XmlGen.Tests.Experimental.Creating;
 
 public class Liddle
 {
     private readonly IMetsManager metsManager;
-    private readonly MetsParser parser;
 
     public Liddle()
     {
@@ -23,9 +22,9 @@ public class Liddle
 
         var factory = serviceProvider.GetService<ILoggerFactory>();
         var parserLogger = factory!.CreateLogger<MetsParser>();
-        parser = new MetsParser(new FileSystemMetsLoader(), parserLogger);
-        var storage = new FileSystemMetsStorage(parser);
-        metsManager = new MetsManager(parser, storage, new MetadataManager());
+        var parser1 = new MetsParser(new FileSystemMetsLoader(), parserLogger);
+        var storage = new FileSystemMetsStorage(parser1);
+        metsManager = new MetsManager(parser1, storage, new MetadataManager());
     }
 
     [Fact(Skip = "Experimental")]

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/Liddle.cs
@@ -24,7 +24,16 @@ public class Liddle
         var parserLogger = factory!.CreateLogger<MetsParser>();
         var parser1 = new MetsParser(new FileSystemMetsLoader(), parserLogger);
         var storage = new FileSystemMetsStorage(parser1);
-        metsManager = new MetsManager(parser1, storage, new MetadataManager());
+
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManagerVirus = new PremisEventManagerVirus();
+        metsManager = new MetsManager(
+            parser1, 
+            storage, 
+            new MetadataManager(premisManager, premisManagerExif, premisEventManagerVirus),
+            premisManager, 
+            premisEventManagerVirus);
     }
 
     [Fact(Skip = "Experimental")]

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
@@ -1,0 +1,345 @@
+using DigitalPreservation.Common.Model.Mets;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+using Storage.Repository.Common.Mets.StorageImpl;
+
+namespace XmlGen.Tests.Experimental;
+
+public class WomenOfWestminster
+{
+    private readonly IMetsManager metsManager;
+    private readonly MetsParser parser;
+
+    private const string MetsFilePath = "C:\\git\\uol-dlip\\design\\complex-mets\\wow.example.mets.xml";
+
+    public WomenOfWestminster()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        parser = new MetsParser(new FileSystemMetsLoader(), parserLogger);
+        var storage = new FileSystemMetsStorage(parser);
+        metsManager = new MetsManager(parser, storage, new MetadataManager());
+    }
+
+
+    [Fact(Skip = "Experimental")]
+    public async Task Extended_Mets()
+    {
+        var metsFi = new FileInfo(MetsFilePath);
+        var metsUri = new Uri(metsFi.FullName);
+        var mets = await Basic_Women_of_Westminster(metsUri);
+
+
+        // The archivist assigns MS 2249 to the root of the object
+        metsManager.SetRecordIdentifier(mets, "objects", "identity-service", "b6n9e4c2");
+        metsManager.SetRecordIdentifier(mets, "objects", "EMu", "MS 2249");
+
+
+        // apply access condition and rights statement to origin
+        metsManager.SetAccessRestrictions(mets, "objects", ["Level1"]);
+        metsManager.SetRightsStatement(mets, "objects", new Uri("http://rightsstatements.org/vocab/InC/1.0/"));
+
+
+        // The archivist marks some files as not for publication
+        metsManager.SetAccessRestrictions(mets, "objects/angela-eagle-redacted.m4a", ["Level2"]);
+        metsManager.SetRightsStatement(mets, "objects/angela-eagle-redacted.m4a", null); //???
+
+
+        // The archivist creates a "presentation" structure over the raw files, aligned with EMu archival description.
+        var logSm = new LogicalRange
+        {
+            Id = "LOG_0000", // Should we assign these? Or should MetsManager mint them? 
+            Name = "Women of Westminster",
+            Type = "Collection",
+            Ranges =
+            [
+                new LogicalRange
+                {
+                    Id = "LOG_0001",
+                    Type = "Item",
+                    Name = "Amber Rudd",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "mg56cva7"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "MS 2249/1"
+                            }
+                        ]
+                    },
+                    Files = [
+                        new FilePointer { LocalPath = "objects/amber-rudd.m4a" },
+                        new FilePointer { LocalPath = "objects/amber-rudd.docx" }
+                    ]
+                },
+                new LogicalRange
+                {
+                    Id = "LOG_0002",
+                    Type = "Item",
+                    Name = "Angela Eagle",
+                    RecordInfo = new RecordInfo
+                    {
+                        RecordIdentifiers = [
+                            new RecordIdentifier
+                            {
+                                Source = "identity-service",
+                                Value = "hh43pd32"
+                            },
+                            new RecordIdentifier
+                            {
+                                Source = "EMu",
+                                Value = "MS 2249/2"
+                            }
+                        ]
+                    },
+                    Files = [
+                        new FilePointer { LocalPath = "objects/angela-eagle-redacted.m4a" },
+                        new FilePointer { LocalPath = "objects/angela-eagle-transcript.docx" }
+                    ]
+                }
+            ]
+        };
+        metsManager.SetStructMap(mets, logSm);
+
+
+
+        // The archivist asserts that the transcripts are _supplementing_ the audio files
+        var supplementing = new Uri("http://iiif.io/api/presentation/3#supplementing"); // this will be a const somewhere
+        metsManager.LinkFile(mets, "objects/amber-rudd.m4a", "objects/amber-rudd.docx", supplementing);
+        metsManager.LinkFile(mets, "objects/angela-eagle-redacted.m4a", "objects/angela-eagle-transcript.docx", supplementing);
+
+        //
+        await metsManager.WriteMets(mets);
+
+        // Later
+        var metsResult = await metsManager.GetFullMets(metsUri, null);
+        mets = metsResult.Value!;
+
+        // I have just set the whole structMap in one go.
+        // How do I patch it? e.g.,
+        //  - add a third section
+        //  - set the recordInfo on that section in a separate operation
+
+        // here's me addressing a logical div to apply a rights statement
+        metsManager.SetRightsStatement(mets, "LOG_0002", new Uri("http://rightsstatements.org/vocab/InC/1.0/"));
+
+        // OK let's randomly add a folder
+        metsManager.AddToMets(mets, new WorkingDirectory
+        {
+            LocalPath = "objects/child-folder",
+            Name = "Child Folder"
+        });
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/child-folder/bercow-notes.txt",
+            Digest = "b42a6e9c",
+            ContentType = "text/plain",
+            Name = "Bercow notes.txt",
+            Size = 200,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "b42a6e9c",
+                    ContentType = "text/plain",
+                    FormatName = "Text File",
+                    PronomKey = "fmt/101",
+                    Size = 200
+                }
+            ]
+        });
+
+        // but now I want to manipulate a logical struct map and update it
+
+        // going to need to save it before it can be parsed
+        await metsManager.WriteMets(mets);
+        // That's where it feels a bit off - like I shouldn't have to do that - but then:
+        var parseResult = await parser.GetMetsFileWrapper(metsUri, true);
+        var pMets = parseResult.Value;
+
+        // Should MetsManager be holding a parsed METS?
+        // ...that it keeps up-to-date on every operation, so you can always obtain it after any changing operation
+        // ...and carry on making changes without a cycle of saving?
+
+        // How is a UI going to deal with this?
+        // Compare iiif-vault, for binding a IIIF representation to UI.
+        // We could do the same for METS - but it that overkill?
+
+        // We are passing in our simplified structures to IMetsManager operations, which 
+        // under the hood is turning them into the XmlGen classes that are the "real" METS 
+        // (because we don't want to deal with those classes at the API level)
+        // This is where it differs from iiif-vault, where there is only the IIIF model, 
+        // both bound to the UI and serialised to JSON.
+
+        // So in our world, you can make a series of changes to a METS file via IMetsManager operations,
+        // but any originally acquired representation is static, it won't change; you need to re-acquire it:
+
+        LogicalRange reloadedLogSm = pMets!.LogicalStructures[0];
+
+        // right now, this should be true:
+        reloadedLogSm.Should().BeEquivalentTo(logSm);
+
+        reloadedLogSm.Ranges.Add(new LogicalRange
+        {
+            Id = "LOG_000Bercow",
+            Type = "Item",
+            Name = "Bercow notes",
+            RecordInfo = new RecordInfo
+            {
+                RecordIdentifiers =
+                [
+                    new RecordIdentifier
+                    {
+                        Source = "identity-service",
+                        Value = "a2c4e5b1"
+                    },
+                    new RecordIdentifier
+                    {
+                        Source = "EMu",
+                        Value = "MS 2249/B"
+                    }
+                ]
+            },
+            Files =
+            [
+                new FilePointer { LocalPath = "objects/child-folder/bercow-notes.txt" }
+            ]
+        });
+
+        // That was a "parsing" session, now I need a "managing" session"
+        var metsResult2 = await metsManager.GetFullMets(metsUri, null);
+        mets = metsResult2.Value!;
+
+        // apply the whole edited structmap - not patch it. Is that ok?
+        metsManager.SetStructMap(mets, reloadedLogSm);
+        await metsManager.WriteMets(mets);
+    }
+
+    public async Task<FullMets> Basic_Women_of_Westminster(Uri metsUri)
+    {
+        var name = "Women of Westminster";
+        var result = await metsManager.CreateStandardMets(metsUri, name);
+
+        result.Success.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        var metsWrapper = result.Value!;
+        var metsResult = await metsManager.GetFullMets(metsUri, metsWrapper.ETag!);
+        var mets = metsResult.Value!;
+        mets.Should().NotBeNull();
+
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/amber-rudd.m4a",
+            Digest = "abcd1234",
+            ContentType = "audio/m4a",
+            Name = "Amber Rudd.m4a",
+            Size = 1000,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "abcd1234",
+                    ContentType = "audio/m4a",
+                    FormatName = "M4A Audio",
+                    PronomKey = "fmt/100",
+                    Size = 1000
+                }
+            ]
+        });
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/amber-rudd.docx",
+            Digest = "1234abcd",
+            ContentType = "application/msword",
+            Name = "Amber Rudd Transcript.docx",
+            Size = 500,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "1234abcd",
+                    ContentType = "application/msword",
+                    FormatName = "Microsoft Word",
+                    PronomKey = "fmt/200",
+                    Size = 500
+                }
+            ]
+        });
+
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/angela-eagle.m4a",
+            Digest = "aabbccdd",
+            ContentType = "audio/m4a",
+            Name = "Angela Eagle.m4a",
+            Size = 2000,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "aabbccdd",
+                    ContentType = "audio/m4a",
+                    FormatName = "M4A Audio",
+                    PronomKey = "fmt/100",
+                    Size = 2000
+                }
+            ]
+        });
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/angela-eagle-redacted.m4a",
+            Digest = "99887766",
+            ContentType = "audio/m4a",
+            Name = "Angela Eagle - redacted.m4a",
+            Size = 1500,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "99887766",
+                    ContentType = "audio/m4a",
+                    FormatName = "M4A Audio",
+                    PronomKey = "fmt/100",
+                    Size = 1500
+                }
+            ]
+        });
+        metsManager.AddToMets(mets, new WorkingFile
+        {
+            LocalPath = "objects/angela-eagle-transcript.docx",
+            Digest = "a1b2c3d4",
+            ContentType = "application/msword",
+            Name = "Angela Eagle redacted transcript.docx",
+            Size = 600,
+            Metadata = [
+                new FileFormatMetadata
+                {
+                    Source = "Brunnhilde",
+                    Digest = "a1b2c3d4",
+                    ContentType = "application/msword",
+                    FormatName = "Microsoft Word",
+                    PronomKey = "fmt/200",
+                    Size = 600
+                }
+            ]
+        });
+
+        return mets;
+    }
+
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
@@ -50,7 +50,7 @@ public class WomenOfWestminster
 
 
         // The archivist marks some files as not for publication
-        metsManager.SetAccessRestrictions(mets, "objects/angela-eagle-redacted.m4a", ["Level2"]);
+        metsManager.SetAccessRestrictions(mets, "objects/angela-eagle-redacted.m4a", ["Closed"]);
         metsManager.SetRightsStatement(mets, "objects/angela-eagle-redacted.m4a", null); //???
 
 

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.Mets.StorageImpl;
 
-namespace XmlGen.Tests.Experimental;
+namespace XmlGen.Tests.Experimental.Creating;
 
 public class WomenOfWestminster
 {

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Creating/WomenOfWestminster.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.Mets.StorageImpl;
 
-namespace XmlGen.Tests.Experimental.Creating;
+namespace XmlGen.Tests.Experimental;
 
 public class WomenOfWestminster
 {
@@ -27,7 +27,16 @@ public class WomenOfWestminster
         var parserLogger = factory!.CreateLogger<MetsParser>();
         parser = new MetsParser(new FileSystemMetsLoader(), parserLogger);
         var storage = new FileSystemMetsStorage(parser);
-        metsManager = new MetsManager(parser, storage, new MetadataManager());
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManagerVirus = new PremisEventManagerVirus();
+        
+        metsManager = new MetsManager(
+            parser, 
+            storage, 
+            new MetadataManager(premisManager, premisManagerExif, premisEventManagerVirus),
+            premisManager, 
+            premisEventManagerVirus);
     }
 
 

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ComplexMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ComplexMetsParsing.cs
@@ -1,5 +1,6 @@
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using DigitalPreservation.XmlGen.Mets;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -38,24 +39,37 @@ public class ComplexMetsParsing
         phys!.Files.Should().Contain(f => f.Name == "wow.mets.xml");
         
         
-        result.Value.Name.Should().Be("[Example title]");
+        result.Value.Name.Should().Be("Women of Westminster");
         phys.Directories.Should().HaveCount(1);
         var objects = phys.Directories[0];
         objects.Name.Should().Be(FolderNames.Objects);
         objects.Files.Should().HaveCount(5);
+        
+        // Explicitly set access restrictions on objects folder
         objects.AccessRestrictions.Should().HaveCount(1);
         objects.AccessRestrictions[0].Should().Be("Level1");
+        // ... and these are matched by effective access restrictions
         objects.EffectiveAccessRestrictions.Should().HaveCount(1);
         objects.EffectiveAccessRestrictions[0].Should().Be("Level1");
         var inCopyright = new Uri("http://rightsstatements.org/vocab/InC/1.0/");
+        
+        // and similarly for rights:
         objects.RightsStatement.Should().Be(inCopyright);
         objects.EffectiveRightsStatement.Should().Be(inCopyright);
+        
+        // ... and recordInfo:
         objects.RecordInfo.Should().NotBeNull();
         objects.RecordInfo!.RecordIdentifiers.Should().HaveCount(2);
         objects.RecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
         objects.RecordInfo.RecordIdentifiers[0].Value.Should().Be("b6n9e4c2");
         objects.RecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
         objects.RecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249");
+        objects.EffectiveRecordInfo.Should().NotBeNull();
+        objects.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        objects.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        objects.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("b6n9e4c2");
+        objects.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        objects.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249");
         
         
         // physical files
@@ -69,7 +83,7 @@ public class ComplexMetsParsing
         objects.Files[3].LocalPath.Should().Be("objects/angela-eagle-redacted.m4a");
         objects.Files[4].LocalPath.Should().Be("objects/angela-eagle-transcript.docx");
 
-        // links
+        // links between files
         var supplementing = new Uri("http://iiif.io/api/presentation/3#supplementing");
         objects.Files[0].Links.Should().HaveCount(1);
         objects.Files[0].Links[0].To.Should().Be("objects/amber-rudd.docx");
@@ -81,11 +95,186 @@ public class ComplexMetsParsing
         objects.Files[4].Links.Should().HaveCount(0);
 
         // logical structmap
+        result.Value.LogicalStructures.Should().HaveCount(1);
+        var logsm = result.Value.LogicalStructures[0];
+        logsm.Type.Should().Be("Collection");
+        logsm.Name.Should().Be("Women of Westminster");
+        // No direct file children
+        logsm.Files.Should().HaveCount(0);
+        
+        // Two child ranges:
+        logsm.Ranges.Should().HaveCount(2);
+        
+        // First range:
+        logsm.Ranges[0].Type.Should().Be("Item");
+        // mods:title from DMD, fall back to label "Amber Rudd" - need another test
+        logsm.Ranges[0].Name.Should().Be("Interview with Amber Rudd"); 
+        logsm.Ranges[0].RecordInfo.Should().NotBeNull();
+        logsm.Ranges[0].RecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        logsm.Ranges[0].RecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        logsm.Ranges[0].RecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        logsm.Ranges[0].RecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        logsm.Ranges[0].RecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        // Effective should match explicit
+        logsm.Ranges[0].EffectiveRecordInfo.Should().NotBeNull();
+        logsm.Ranges[0].EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        logsm.Ranges[0].EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        logsm.Ranges[0].EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        logsm.Ranges[0].EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        logsm.Ranges[0].EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        // Child file pointers
+        logsm.Ranges[0].Files.Should().HaveCount(2);
+        logsm.Ranges[0].Files[0].LocalPath.Should().Be("objects/amber-rudd.m4a");
+        logsm.Ranges[0].Files[0].BeginTime.Should().BeNull();
+        logsm.Ranges[0].Files[0].EndTime.Should().BeNull();
+        logsm.Ranges[0].Files[0].Region.Should().BeNull();
+        logsm.Ranges[0].Files[1].LocalPath.Should().Be("objects/amber-rudd.docx");
+        // No child ranges
+        logsm.Ranges[0].Ranges.Should().HaveCount(0);
+        // No explicit access or rights, just recordinfo above
+        logsm.Ranges[0].AccessRestrictions.Should().HaveCount(0);
+        logsm.Ranges[0].RightsStatement.Should().BeNull();
+        // TODO: Does a logical range inherit from the physical structMap?
+        // ONLY if there is something declared on the physical structmap root (DMD_PHYS_ROOT), which is not the case here
+        logsm.Ranges[0].EffectiveAccessRestrictions.Should().HaveCount(0);
+        logsm.Ranges[0].EffectiveRightsStatement.Should().BeNull();
+        
+        // Second range:
+        logsm.Ranges[1].Type.Should().Be("Item");
+        logsm.Ranges[1].Name.Should().Be("Interview with Angela Eagle");
+        logsm.Ranges[1].RecordInfo.Should().NotBeNull();
+        logsm.Ranges[1].RecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        logsm.Ranges[1].RecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        logsm.Ranges[1].RecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        logsm.Ranges[1].RecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        logsm.Ranges[1].RecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        logsm.Ranges[1].EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        logsm.Ranges[1].EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        logsm.Ranges[1].EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        logsm.Ranges[1].EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        logsm.Ranges[1].EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        // Child file pointers
+        logsm.Ranges[1].Files.Should().HaveCount(2);
+        logsm.Ranges[1].Files[0].LocalPath.Should().Be("objects/angela-eagle-redacted.m4a");
+        logsm.Ranges[1].Files[1].LocalPath.Should().Be("objects/angela-eagle-transcript.docx");
+        logsm.Ranges[1].Files[1].BeginTime.Should().BeNull();
+        logsm.Ranges[1].Files[1].EndTime.Should().BeNull();
+        logsm.Ranges[1].Files[1].Region.Should().BeNull();
+        // No child ranges
+        logsm.Ranges[1].Ranges.Should().HaveCount(0);
+        // No explicit access or rights, just recordinfo above
+        logsm.Ranges[1].AccessRestrictions.Should().HaveCount(0);
+        logsm.Ranges[1].RightsStatement.Should().BeNull();
+        // see comment above - nothing to inherit at this level
+        logsm.Ranges[0].EffectiveAccessRestrictions.Should().HaveCount(0);
+        logsm.Ranges[0].EffectiveRightsStatement.Should().BeNull();
+        
 
-        // effective rights on files
+        // gather the references to the files
+        var ruddAudio = phys.FindFile("objects/amber-rudd.m4a")!;
+        var ruddTranscript = phys.FindFile("objects/amber-rudd.docx")!;
+        var eagleRedactedAudio = phys.FindFile("objects/angela-eagle-redacted.m4a")!;
+        var eagleTranscript = phys.FindFile("objects/angela-eagle-transcript.docx")!;
+        var eagleAudio = phys.FindFile("objects/angela-eagle")!;
+        
+        // 4 of the files have no explicit descriptive metadata - they inherit it
+        ruddAudio.RecordInfo.Should().BeNull();
+        ruddAudio.AccessRestrictions.Should().HaveCount(0);
+        ruddAudio.RightsStatement.Should().BeNull();
+        
+        ruddTranscript.RecordInfo.Should().BeNull();
+        ruddTranscript.AccessRestrictions.Should().HaveCount(0);
+        ruddTranscript.RightsStatement.Should().BeNull();
+        
+        eagleRedactedAudio.RecordInfo.Should().BeNull();
+        eagleRedactedAudio.AccessRestrictions.Should().HaveCount(0);
+        eagleRedactedAudio.RightsStatement.Should().BeNull();
+        
+        eagleTranscript.RecordInfo.Should().BeNull();
+        eagleTranscript.AccessRestrictions.Should().HaveCount(0);
+        eagleTranscript.RightsStatement.Should().BeNull();
+        
+        eagleAudio.RecordInfo.Should().BeNull();
+        // but Eagle Audio does have an explicit access and rights assignment:
+        eagleAudio.AccessRestrictions.Should().HaveCount(1);
+        eagleAudio.AccessRestrictions[0].Should().Be("Closed");
+        // TODO: how to override inherited? Effective will be null, correctly, but we can't tell directly that there is an explicit null assignment here
+        eagleAudio.RightsStatement.Should().BeNull();
 
+        // verify their effective (inherited or direct) properties:
+        // inherited from div in logical structMap
+        ruddAudio.EffectiveRecordInfo.Should().NotBeNull();
+        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        // inherited from physical structMap objects/ div
+        ruddAudio.EffectiveAccessRestrictions.Should().HaveCount(1);
+        ruddAudio.EffectiveAccessRestrictions[0].Should().Be("Level1");
+        ruddAudio.EffectiveRightsStatement.Should().Be(inCopyright);
+        
+        // rudd transcript should have same effective properties as ruddAudio
+        // inherited from div in logical structMap
+        ruddTranscript.EffectiveRecordInfo.Should().NotBeNull();
+        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        // inherited from physical structMap objects/ div
+        ruddTranscript.EffectiveAccessRestrictions.Should().HaveCount(1);
+        ruddTranscript.EffectiveAccessRestrictions[0].Should().Be("Level1");
+        ruddTranscript.EffectiveRightsStatement.Should().Be(inCopyright);
+        
+        // inherited from div in logical structMap
+        eagleRedactedAudio.EffectiveRecordInfo.Should().NotBeNull();
+        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        // inherited from physical structMap objects/ div
+        eagleRedactedAudio.EffectiveAccessRestrictions.Should().HaveCount(1);
+        eagleRedactedAudio.EffectiveAccessRestrictions[0].Should().Be("Level1");
+        eagleRedactedAudio.EffectiveRightsStatement.Should().Be(inCopyright);
+        
+        // Eagle transcript should have same effective properties as eagleRedactedAudio
+        // inherited from div in logical structMap
+        eagleTranscript.EffectiveRecordInfo.Should().NotBeNull();
+        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
+        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        // inherited from physical structMap objects/ div
+        eagleTranscript.EffectiveAccessRestrictions.Should().HaveCount(1);
+        eagleTranscript.EffectiveAccessRestrictions[0].Should().Be("Level1");
+        eagleTranscript.EffectiveRightsStatement.Should().Be(inCopyright);
 
+        // The original, unredacted Eagle audio is (for the purposes of this experiment) not part of MS 2249/2
+        // inherited from physical structMap objects/ div
+        eagleAudio.EffectiveRecordInfo.Should().NotBeNull();
+        eagleAudio.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        eagleAudio.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        eagleAudio.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("b6n9e4c2");
+        eagleAudio.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        eagleAudio.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249");
+        // directly asserted (therefore also effective)
+        eagleAudio.EffectiveAccessRestrictions.Should().HaveCount(1);
+        eagleAudio.EffectiveAccessRestrictions[0].Should().Be("Closed");
+        eagleAudio.EffectiveRightsStatement.Should().Be(null);
 
+        // divIds, other props we might be interested in
+        // This needs more work to be consistent.
+        eagleAudio.MetsExtensions!.DivId.Should().Be("PHYS_objects/angela-eagle.m4a");
+        eagleAudio.MetsExtensions!.AdmId.Should().Be("ADM_objects/angela-eagle.m4a");
+
+        // locate files by ID and localpath
+        // This is the ID of the file's mets:div in the physical structMap. Do we want to be able to get by mets:file ID property? 
+        var ruddAudioById = phys.Files.SingleOrDefault(f => f.MetsExtensions!.DivId == "PHYS_objects/amber-rudd.m4a");
+        ruddAudioById.Should().NotBeNull();
+        
 
 
     }

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ComplexMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ComplexMetsParsing.cs
@@ -1,0 +1,92 @@
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+using Storage.Repository.Common.Mets.StorageImpl;
+
+namespace XmlGen.Tests.Experimental;
+
+public class ComplexMetsParsing
+{
+    private readonly MetsParser parser;
+    
+    public ComplexMetsParsing()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        parser = new MetsParser(metsLoader, parserLogger);
+    }
+
+    [Fact]
+    public async Task Can_Parse_Women_Of_Westminster()
+    {
+        var wowMets = new FileInfo("Samples/wow.mets.xml");
+        var result = await parser.GetMetsFileWrapper(new Uri(wowMets.FullName));
+        
+        result.Success.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Self.Should().NotBeNull();
+        result.Value.Self!.Digest.Should().NotBeEmpty();
+        var phys = result.Value!.PhysicalStructure;
+        phys!.Files.Should().Contain(f => f.Name == "wow.mets.xml");
+        
+        
+        result.Value.Name.Should().Be("[Example title]");
+        phys.Directories.Should().HaveCount(1);
+        var objects = phys.Directories[0];
+        objects.Name.Should().Be(FolderNames.Objects);
+        objects.Files.Should().HaveCount(5);
+        objects.AccessRestrictions.Should().HaveCount(1);
+        objects.AccessRestrictions[0].Should().Be("Level1");
+        objects.EffectiveAccessRestrictions.Should().HaveCount(1);
+        objects.EffectiveAccessRestrictions[0].Should().Be("Level1");
+        var inCopyright = new Uri("http://rightsstatements.org/vocab/InC/1.0/");
+        objects.RightsStatement.Should().Be(inCopyright);
+        objects.EffectiveRightsStatement.Should().Be(inCopyright);
+        objects.RecordInfo.Should().NotBeNull();
+        objects.RecordInfo!.RecordIdentifiers.Should().HaveCount(2);
+        objects.RecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        objects.RecordInfo.RecordIdentifiers[0].Value.Should().Be("b6n9e4c2");
+        objects.RecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        objects.RecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249");
+        
+        
+        // physical files
+        objects.Files[0].LocalPath.Should().Be("objects/amber-rudd.m4a");
+        objects.Files[0].ContentType.Should().Be("audio/m4a");
+        objects.Files[1].LocalPath.Should().Be("objects/amber-rudd.docx");
+        objects.Files[1].ContentType.Should().Be("application/msword");
+        objects.Files[1].Metadata.OfType<FileFormatMetadata>().Single().PronomKey.Should().Be("fmt/200");
+        objects.Files[1].Metadata.OfType<FileFormatMetadata>().Single().FormatName.Should().Be("Microsoft Word");
+        objects.Files[2].LocalPath.Should().Be("objects/angela-eagle.m4a");
+        objects.Files[3].LocalPath.Should().Be("objects/angela-eagle-redacted.m4a");
+        objects.Files[4].LocalPath.Should().Be("objects/angela-eagle-transcript.docx");
+
+        // links
+        var supplementing = new Uri("http://iiif.io/api/presentation/3#supplementing");
+        objects.Files[0].Links.Should().HaveCount(1);
+        objects.Files[0].Links[0].To.Should().Be("objects/amber-rudd.docx");
+        objects.Files[0].Links[0].Role.Should().Be(supplementing);
+        objects.Files[1].Links.Should().HaveCount(0);
+        objects.Files[2].Links.Should().HaveCount(0);
+        objects.Files[3].Links[0].To.Should().Be("objects/angela-eagle-transcript.docx");
+        objects.Files[3].Links[0].Role.Should().Be(supplementing);
+        objects.Files[4].Links.Should().HaveCount(0);
+
+        // logical structmap
+
+        // effective rights on files
+
+
+
+
+
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseLiddle.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseLiddle.cs
@@ -1,0 +1,46 @@
+﻿using DigitalPreservation.Common.Model.Transit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+using Storage.Repository.Common.Mets.StorageImpl;
+
+namespace XmlGen.Tests.Experimental.Parsing;
+
+public class ParseLiddle
+{
+    
+    private readonly MetsParser parser;
+    
+    public ParseLiddle()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        parser = new MetsParser(metsLoader, parserLogger);
+    }
+
+    [Fact]
+    public async Task Can_Parse_Liddle()
+    {
+        var liddleMets = new FileInfo("Samples/liddle.mets.xml");
+        var result = await parser.GetMetsFileWrapper(new Uri(liddleMets.FullName));
+        
+        result.Success.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Self.Should().NotBeNull();
+        result.Value.Self!.Digest.Should().NotBeEmpty();
+        var phys = result.Value!.PhysicalStructure;
+        phys!.Files.Should().Contain(f => f.Name == "liddle.mets.xml");
+        
+        result.Value.Name.Should().Be("Liddle Tapes 1 and 2");
+        phys.Directories.Should().HaveCount(1);
+        var objects = phys.Directories[0];
+        objects.Name.Should().Be(FolderNames.Objects);
+        objects.Files.Should().HaveCount(4);
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseWomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseWomenOfWestminster.cs
@@ -1,19 +1,18 @@
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
-using DigitalPreservation.XmlGen.Mets;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.Mets.StorageImpl;
 
-namespace XmlGen.Tests.Experimental;
+namespace XmlGen.Tests.Experimental.Parsing;
 
-public class ComplexMetsParsing
+public class ParseWomenOfWestminster
 {
     private readonly MetsParser parser;
     
-    public ComplexMetsParsing()
+    public ParseWomenOfWestminster()
     {
         var serviceProvider = new ServiceCollection()
             .AddLogging()

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+using Storage.Repository.Common.Mets.StorageImpl;
+
+namespace XmlGen.Tests.Experimental;
+
+public class ThirdPartyMetsParsing
+{
+    private readonly MetsParser parser;
+    
+    public ThirdPartyMetsParsing()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        parser = new MetsParser(metsLoader, parserLogger);
+    }
+    
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using Storage.Repository.Common.Mets;
 using Storage.Repository.Common.Mets.StorageImpl;
 
-namespace XmlGen.Tests.Experimental;
+namespace XmlGen.Tests.Experimental.Parsing;
 
 public class ThirdPartyMetsParsing
 {

--- a/src/DigitalPreservation/XmlGen.Tests/Samples/liddle.mets.xml
+++ b/src/DigitalPreservation/XmlGen.Tests/Samples/liddle.mets.xml
@@ -1,0 +1,302 @@
+<mets:mets xmlns:mods="http://www.loc.gov/mods/v3" xmlns:premis="http://www.loc.gov/premis/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mets="http://www.loc.gov/METS/">
+  <mets:metsHdr CREATEDATE="2026-01-07T10:00:24.3999414+00:00">
+    <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+      <mets:name>University of Leeds Digital Library Infrastructure Project</mets:name>
+    </mets:agent>
+  </mets:metsHdr>
+  <mets:dmdSec ID="DMD_PHYS_ROOT">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods>
+          <mods:titleInfo>
+            <mods:title>Liddle Tapes 1 and 2</mods:title><!-- here at all? -->
+          </mods:titleInfo>
+        </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMD_objects">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>Liddle Tapes 1 and 2</mods:title>
+            </mods:titleInfo>
+            <mods:accessCondition type="restriction on access" xlink:type="simple">Level1</mods:accessCondition>
+            <mods:accessCondition type="use and reproduction" xlink:type="simple">http://rightsstatements.org/vocab/InC/1.0/</mods:accessCondition>              
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">a8n9e4c2</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">LIDDLE/WW1/TAPES/1-2</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+
+  
+  <mets:dmdSec ID="DMD_LOG_0001">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>ADDAMS-WILLIAMS, DONALD ARTHUR</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">mg56cva7</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">LIDDLE/WW1/XXX/1</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  
+  <mets:dmdSec ID="DMD_LOG_0002">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>AITCHISON, BERTRAM STEWART</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">vvdd4433</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">LIDDLE/WW1/XXX/2</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  
+  <mets:dmdSec ID="DMD_LOG_0003">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>ALEXANDER, C</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">adfa234d</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">LIDDLE/WW1/XXX/3</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  
+  <mets:dmdSec ID="DMD_LOG_0004">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>ALLANSON, CECIL JOHN LYONS</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">e34e2ads</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">LIDDLE/WW1/XXX/4</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+
+  <mets:amdSec ID="ADM_objects">
+    <mets:techMD ID="TECH_objects">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics />
+            <premis:originalName>objects</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_metadata">
+    <mets:techMD ID="TECH_metadata">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics />
+            <premis:originalName>metadata</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/tape1side1.wav">
+    <mets:techMD ID="TECH_objects/tape1side1.wav">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>abcd1234</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>500000</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Broadcast WAVE 0 Generic</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/1</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/tape1side1.wav</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/tape1side2.wav">
+    <mets:techMD ID="TECH_objects/tape1side2.wav">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>3e421bb1</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>500001</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Broadcast WAVE 0 Generic</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/1</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/tape1side2.wav</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/tape2side1.wav">
+    <mets:techMD ID="TECH_objects/tape2side1.wav">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>d4d4e3e3</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>499999</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Broadcast WAVE 0 Generic</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/1</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/tape2side1.wav</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/tape2side2.wav">
+    <mets:techMD ID="TECH_objects/tape2side2.wav">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>a2d3e4f5</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>500100</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Broadcast WAVE 0 Generic</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/1</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/tape2side2.wav</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="OBJECTS">
+      <mets:file ID="FILE_objects/tape1side1.wav" MIMETYPE="audio/x-wav" ADMID="ADM_objects/tape1side1.wav">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/tape1side1.wav" />
+      </mets:file>
+      <mets:file ID="FILE_objects/tape1side2.wav" MIMETYPE="audio/x-wav" ADMID="ADM_objects/tape1side2.wav">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/tape1side2.wav" />
+      </mets:file>
+      <mets:file ID="FILE_objects/tape2side1.wav" MIMETYPE="audio/x-wav" ADMID="ADM_objects/tape2side1.wav">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/tape2side1.wav" />
+      </mets:file>
+      <mets:file ID="FILE_objects/tape2side2.wav" MIMETYPE="audio/x-wav" ADMID="ADM_objects/tape2side2.wav">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/tape2side2.wav" />
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="PHYSICAL">
+    <mets:div ID="PHYS_ROOT" LABEL="__ROOT" DMDID="DMD_PHYS_ROOT" TYPE="Directory">
+      <mets:div ID="PHYS_metadata" LABEL="metadata" DMDID="DMD_metadata" ADMID="ADM_metadata" TYPE="Directory" />
+      <mets:div ID="PHYS_objects" LABEL="objects" DMDID="DMD_objects" ADMID="ADM_objects" TYPE="Directory">
+        <mets:div ID="PHYS_objects/tape1side1.wav" LABEL="Tape 1 Side 1" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/tape1side1.wav" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/tape1side2.wav" LABEL="Tape 1 Side 2" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/tape1side2.wav" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/tape2side1.wav" LABEL="Tape 2 Side 1" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/tape2side1.wav" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/tape2side2.wav" LABEL="Tape 2 Side 2" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/tape2side2.wav" />
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+
+  
+  <mets:structMap TYPE="LOGICAL">
+      <mets:div ADMID="AMDLOG_0000" DMDID="DMDLOG_0000" ID="LOG_0000" LABEL="Tapes 1 and 2" TYPE="Collection">
+          <mets:div ID="LOG_0001" LABEL="ADDAMS-WILLIAMS, DONALD ARTHUR" TYPE="Item" DMDID="DMD_LOG_0001">                        
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape1side1.wav" BETYPE="time" BEGIN="00:00:15" END="00:35:09.5"/>
+            </mets:fptr>
+          </mets:div>          
+          <mets:div ID="LOG_0002" LABEL="AITCHISON, BERTRAM STEWART" TYPE="Item" DMDID="DMD_LOG_0002">                        
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape1side1.wav" BETYPE="time" BEGIN="00:36:40" END="00:45:00"/>
+            </mets:fptr>                   
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape1side2.wav" BETYPE="time" BEGIN="00:00:09.2" END="00:20:09"/>
+            </mets:fptr>
+          </mets:div>
+          <mets:div ID="LOG_0003" LABEL="ALEXANDER, C" TYPE="Item" DMDID="DMD_LOG_0003">                        
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape1side2.wav" BETYPE="time" BEGIN="00:20:50" END="00:31:40"/>
+            </mets:fptr>
+          </mets:div>
+          <mets:div ID="LOG_0004" LABEL="ALLANSON, CECIL JOHN LYONS" TYPE="Item" DMDID="DMD_LOG_0004">                        
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape2side1.wav" BETYPE="time" BEGIN="00:00:13.9" END="00:44:50.54"/>
+            </mets:fptr>                        
+            <mets:fptr>
+                <mets:area FILEID="FILE_objects/tape2side2.wav" BETYPE="time" BEGIN="00:00:20.6" END="00:23:07.51"/>
+            </mets:fptr>
+          </mets:div>
+      </mets:div>
+  </mets:structMap>
+
+
+</mets:mets>

--- a/src/DigitalPreservation/XmlGen.Tests/Samples/wow.mets.xml
+++ b/src/DigitalPreservation/XmlGen.Tests/Samples/wow.mets.xml
@@ -1,0 +1,300 @@
+<mets:mets xmlns:mods="http://www.loc.gov/mods/v3" xmlns:premis="http://www.loc.gov/premis/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mets="http://www.loc.gov/METS/">
+  <mets:metsHdr CREATEDATE="2025-11-10T11:28:24.1258902+00:00">
+    <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
+      <mets:name>University of Leeds Digital Library Infrastructure Project</mets:name>
+    </mets:agent>
+  </mets:metsHdr>
+  <mets:dmdSec ID="DMD_PHYS_ROOT">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods>
+          <mods:titleInfo>
+            <mods:title>Women of Westminster</mods:title><!-- here at all? -->
+          </mods:titleInfo>
+        </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMD_objects">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>Women of Westminster</mods:title>
+            </mods:titleInfo>
+            <mods:accessCondition type="restriction on access" xlink:type="simple">Level1</mods:accessCondition>
+            <mods:accessCondition type="use and reproduction" xlink:type="simple">http://rightsstatements.org/vocab/InC/1.0/</mods:accessCondition>              
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">b6n9e4c2</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">MS 2249</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMD_LOG_0001">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>Interview with Amber Rudd</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">mg56cva7</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">MS 2249/1</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMD_LOG_0002">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+            <mods:titleInfo>
+              <mods:title>Interview with Angela Eagle</mods:title>
+            </mods:titleInfo>             
+            <mods:recordInfo>
+              <mods:recordIdentifier source="identity-service">hh43pd32</mods:recordIdentifier>
+              <mods:recordIdentifier source="EMu">MS 2249/2</mods:recordIdentifier>
+            </mods:recordInfo>
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMD_objects/angela-eagle.m4a">
+    <mets:mdWrap MDTYPE="MODS">
+        <mets:xmlData>
+          <mods:mods>
+              <mods:accessCondition type="restriction on access" xlink:type="simple">Closed</mods:accessCondition>
+              <mods:accessCondition type="use and reproduction" xlink:type="simple">null(?)</mods:accessCondition><!-- how to override with no right statement?-->
+          </mods:mods>
+        </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="ADM_objects">
+    <mets:techMD ID="TECH_objects">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics />
+            <premis:originalName>objects</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_metadata">
+    <mets:techMD ID="TECH_metadata">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics />
+            <premis:originalName>metadata</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/amber-rudd.m4a">
+    <mets:techMD ID="TECH_objects/amber-rudd.m4a">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>abcd1234</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>1000</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">M4A Audio</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/100</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/amber-rudd.m4a</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/amber-rudd.docx">
+    <mets:techMD ID="TECH_objects/amber-rudd.docx">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>1234abcd</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>500</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Microsoft Word</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/200</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/amber-rudd.docx</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/angela-eagle.m4a">
+    <mets:techMD ID="TECH_objects/angela-eagle.m4a">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>aabbccdd</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>2000</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">M4A Audio</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/100</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/angela-eagle.m4a</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/angela-eagle-redacted.m4a">
+    <mets:techMD ID="TECH_objects/angela-eagle-redacted.m4a">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>99887766</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>1500</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">M4A Audio</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/100</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/angela-eagle-redacted.m4a</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:amdSec ID="ADM_objects/angela-eagle-transcript.docx">
+    <mets:techMD ID="TECH_objects/angela-eagle-transcript.docx">
+      <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+        <mets:xmlData>
+          <premis:object xsi:type="premis:file">
+            <premis:objectCharacteristics>
+              <premis:fixity>
+                <premis:messageDigestAlgorithm xsi:type="premis:messageDigestAlgorithm">SHA256</premis:messageDigestAlgorithm>
+                <premis:messageDigest>a1b2c3d4</premis:messageDigest>
+              </premis:fixity>
+              <premis:size>600</premis:size>
+              <premis:format>
+                <premis:formatDesignation>
+                  <premis:formatName xsi:type="premis:formatName">Microsoft Word</premis:formatName>
+                </premis:formatDesignation>
+                <premis:formatRegistry>
+                  <premis:formatRegistryName xsi:type="premis:formatRegistryName">PRONOM</premis:formatRegistryName>
+                  <premis:formatRegistryKey xsi:type="premis:formatRegistryKey">fmt/200</premis:formatRegistryKey>
+                </premis:formatRegistry>
+              </premis:format>
+            </premis:objectCharacteristics>
+            <premis:originalName>objects/angela-eagle-transcript.docx</premis:originalName>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="OBJECTS">
+      <mets:file ID="FILE_objects/amber-rudd.m4a" MIMETYPE="audio/m4a" ADMID="ADM_objects/amber-rudd.m4a">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/amber-rudd.m4a" />
+      </mets:file>
+      <mets:file ID="FILE_objects/amber-rudd.docx" MIMETYPE="application/msword" ADMID="ADM_objects/amber-rudd.docx">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/amber-rudd.docx" />
+      </mets:file>
+      <mets:file ID="FILE_objects/angela-eagle.m4a" MIMETYPE="audio/m4a" ADMID="ADM_objects/angela-eagle.m4a">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/angela-eagle.m4a" />
+      </mets:file>
+      <mets:file ID="FILE_objects/angela-eagle-redacted.m4a" MIMETYPE="audio/m4a" ADMID="ADM_objects/angela-eagle-redacted.m4a">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/angela-eagle-redacted.m4a" />
+      </mets:file>
+      <mets:file ID="FILE_objects/angela-eagle-transcript.docx" MIMETYPE="application/msword" ADMID="ADM_objects/angela-eagle-transcript.docx">
+        <mets:FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="objects/angela-eagle-transcript.docx" />
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="PHYSICAL">
+    <mets:div ID="PHYS_ROOT" LABEL="__ROOT" DMDID="DMD_PHYS_ROOT" TYPE="Directory">
+      <mets:div ID="PHYS_metadata" LABEL="metadata" DMDID="DMD_metadata" ADMID="ADM_metadata" TYPE="Directory" />
+      <mets:div ID="PHYS_objects" LABEL="objects" DMDID="DMD_objects" ADMID="ADM_objects" TYPE="Directory">
+
+
+        <mets:div ID="PHYS_objects/amber-rudd.docx" LABEL="Amber Rudd Transcript.docx" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/amber-rudd.docx" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/amber-rudd.m4a" LABEL="Amber Rudd.m4a" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/amber-rudd.m4a" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/angela-eagle-redacted.m4a" LABEL="Angela Eagle - redacted.m4a" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/angela-eagle-redacted.m4a" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/angela-eagle-transcript.docx" LABEL="Angela Eagle redacted transcript.docx" TYPE="Item">
+          <mets:fptr FILEID="FILE_objects/angela-eagle-transcript.docx" />
+        </mets:div>
+        <mets:div ID="PHYS_objects/angela-eagle.m4a" LABEL="Angela Eagle.m4a" TYPE="Item" DMDID="DMD_objects/angela-eagle.m4a" >
+          <mets:fptr FILEID="FILE_objects/angela-eagle.m4a" />
+        </mets:div>
+
+
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+
+  
+    <mets:structMap TYPE="LOGICAL">
+        <mets:div ADMID="AMDLOG_0000" DMDID="DMDLOG_0000" ID="LOG_0000" LABEL="Women of Westminster" TYPE="Collection">
+            <mets:div ID="LOG_0001" LABEL="Amber Rudd" TYPE="Item" DMDID="DMD_LOG_0001">            
+              <mets:fptr FILEID="FILE_objects/amber-rudd.m4a" />
+              <mets:fptr FILEID="FILE_objects/amber-rudd.docx" />
+            </mets:div>
+            <mets:div ID="LOG_0002" LABEL="Angela Eagle" TYPE="Item" DMDID="DMD_LOG_0002">
+              <mets:fptr FILEID="FILE_objects/angela-eagle-redacted.m4a" />
+              <mets:fptr FILEID="FILE_objects/angela-eagle-transcript.docx" />
+            </mets:div>
+        </mets:div>
+    </mets:structMap>
+
+    <mets:structLink>
+        <mets:smLink xlink:from="FILE_objects/amber-rudd.m4a" xlink:to="FILE_objects/amber-rudd.docx" 
+                    xlink:arcrole="http://iiif.io/api/presentation/3#supplementing" />
+        <mets:smLink xlink:from="FILE_objects/angela-eagle-redacted" xlink:to="angela-eagle-transcript.docx" 
+                    xlink:arcrole="http://iiif.io/api/presentation/3#supplementing" />
+    </mets:structLink>
+  </mets:mets>

--- a/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
+++ b/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.4.2"/>
@@ -61,6 +62,12 @@
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="Samples\goobi-wc-b29356350-3.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Samples\liddle.mets.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Samples\wow.mets.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>


### PR DESCRIPTION
## Summary

This is a purely experimental, draft branch exploring what parser and model changes are needed to support **complex METS** — that is, METS files with logical structMaps, file-to-file links, per-node record identifiers, and time/region extents. The design context is documented at [`design/complex-mets/readme.md`](https://github.com/digirati-co-uk/digital-preservation/tree/experimental/mets-parser/src/DigitalPreservation/XmlGen.Tests/Experimental).

The approach is to **write the tests first** — the tests act as a specification for what the parser and manager need to produce. None of the new `IMetsManager` methods are implemented yet (they all throw `NotImplementedException`); the goal of this branch is to establish the shape of the interfaces and models through executable tests before committing to implementations.

## New model types

- **`LogicalRange`** — represents a node in a logical structMap, with nested `Ranges`, `Files` (as `FilePointer` with optional `BeginTime`/`EndTime`/`Region`), and the same access/rights/record properties as `WorkingBase`
- **`FilePointer`** — a reference from a logical structMap node to a physical file, optionally with a time extent (`BEGIN`/`END`) or image region
- **`Rectangle`** — for image region extents
- **`RecordInfo` / `RecordIdentifier`** — carries `mods:recordIdentifier` values (e.g., EMu ref, identity-service PID) attached to any structMap node
- **`FileLink`** — represents a `mets:structLink` entry on a `WorkingFile`, with a target path and a role URI (e.g., `http://iiif.io/api/presentation/3#supplementing`)
- **`ExtentMetadata`** — new metadata type for pixel dimensions and duration, needed for time-extent assertions

## Changes to existing types

- `ResourceBase` gains `RecordInfo` and `EffectiveRecordInfo` — so that both physical (`WorkingDirectory`/`WorkingFile`) and logical (`LogicalRange`) nodes carry these properties uniformly, with the same explicit/effective pattern already used for access restrictions and rights statements
- `WorkingFile` gains a `Links` list of `FileLink`
- `MetsFileWrapper` gains a `LogicalStructures` list of `LogicalRange`

## Extended `IMetsManager` interface

New general-purpose methods that address any physical path or logical div ID (as a `locator` string), replacing the now-obsoleted root-only helpers:

```csharp
void SetRecordIdentifier(FullMets mets, string locator, string source, string value);
void SetRightsStatement(FullMets mets, string locator, Uri? rightsStatement);
void SetAccessRestrictions(FullMets mets, string locator, List<string> accessRestrictions);
void SetStructMap(FullMets mets, LogicalRange logSm);
void SetStructMapOrder(FullMets mets, string[] ids);
void RemoveStructMap(FullMets mets, string id);
void LinkFile(FullMets mets, string from, string to, Uri role);
void UnLinkFile(FullMets mets, string from, string to, Uri role);
```

The old root-only methods (`GetRootAccessRestrictions`, `SetRootAccessRestrictions`, `SetRootRightsStatement`, `GetRootRightsStatement`) are marked `[Obsolete]`.

## Test cases

Two real-world Leeds collections are used as test fixtures:

**Women of Westminster** (`ParseWomenOfWestminster`) — 49 audio interviews with transcripts. Tests cover:
- Parsing the physical structMap with access restrictions, rights statement, and `mods:recordIdentifier` on the `objects/` div
- `structLink`-based file links (audio → transcript with `supplementing` role)
- A logical structMap grouping audio + transcript by interviewee, with EMu/identity-service identifiers per range
- Effective (inherited) access/rights/recordInfo on individual files — both from the physical structMap and from the logical structMap

**Liddle Tapes** (`ParseLiddle`) — interviews on cassette tapes where a single interview spans multiple tape sides. Tests cover the basic physical structure (4 wav files); the logical structMap with `mets:area` time extents is the next step.

A `Creating/WomenOfWestminster.cs` test (`[Fact(Skip = "Experimental")]`) sketches the intended `IMetsManager` call sequence that would produce the Women of Westminster METS from scratch, and explores questions about the write/re-read cycle.

## What this branch is NOT

- No parser implementation changes yet — tests will currently fail
- No HTTP API additions
- No UI changes
- The `ThirdPartyMetsParsing` fixture is a placeholder for testing that existing Archivematica/Goobi/EPrints METS still parse correctly once the new features are added