### PR TITLE
Fix ULIIIFCS-26 - add items to mets bagit layout

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/MinimalItem.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/DepositHelpers/MinimalItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Combined;
 
 namespace DigitalPreservation.Common.Model.DepositHelpers;
@@ -17,4 +18,17 @@ public class MinimalItem
     [JsonPropertyOrder(3)]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public Whereabouts Whereabouts { get; set; }
+
+    /// <summary>
+    /// Find the minimalItem in a CombinedDirectory content root that may or may not be in BagIt layout
+    /// </summary>
+    /// <param name="contentRoot"></param>
+    /// <returns></returns>
+    public WorkingBase? ResolveFromContentRoot(CombinedDirectory contentRoot)
+    {
+        WorkingBase? wb = IsDirectory
+            ? contentRoot.FindDirectory(RelativePath)?.DirectoryInDeposit?.ToRootLayout()
+            : contentRoot.FindFile(RelativePath)?.FileInDeposit?.ToRootLayout();
+        return wb;
+    }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingDirectory.cs
@@ -90,14 +90,24 @@ public class WorkingDirectory : WorkingBase
 
     public WorkingDirectory ToRootLayout()
     {
-        if (!LocalPath.StartsWith($"{FolderNames.BagItData}/"))
+        string localPath;
+        if (LocalPath == FolderNames.BagItData)
         {
-            return this;
+            // This _is_ the root
+            localPath = string.Empty; 
+        }
+        else
+        {
+            if (!LocalPath.StartsWith($"{FolderNames.BagItData}/"))
+            {
+                return this;
+            }
+            localPath = LocalPath.RemoveStart($"{FolderNames.BagItData}/")!;
         }
 
         return new WorkingDirectory
         {
-            LocalPath = LocalPath.RemoveStart($"{FolderNames.BagItData}/")!,
+            LocalPath = localPath,
             Directories = Directories.Select(d => d.ToRootLayout()).ToList(),
             Files = Files.Select(f => f.ToRootLayout()).ToList(),
             MetsExtensions = MetsExtensions,

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -179,18 +179,11 @@ public class DepositModel(
                 TempData["Error"] = "Could not read deposit file system.";
                 return Redirect($"/deposits/{id}");
             }
-            var wbsToAdd = new List<WorkingBase>();
-            var contentRoot = combinedResult.Value;
-            foreach (var item in minimalItems)
-            {
-                WorkingBase? wbToAdd = item.IsDirectory
-                    ? contentRoot.FindDirectory(item.RelativePath)?.DirectoryInDeposit?.ToRootLayout()
-                    : contentRoot.FindFile(item.RelativePath)?.FileInDeposit?.ToRootLayout();
-                if (wbToAdd != null)
-                {
-                    wbsToAdd.Add(wbToAdd);
-                }
-            }
+            var contentRoot = combinedResult.Value!;
+            var wbsToAdd = minimalItems
+                .Select(m => m.ResolveFromContentRoot(contentRoot))
+                .OfType<WorkingBase>()
+                .ToList();
             var result = await WorkspaceManager.AddItemsToMets(wbsToAdd, User.GetCallerIdentity());
             if (result.Success)
             {

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
@@ -41,6 +41,11 @@ public class WorkspaceManager(
         return result;
     }
 
+    /// <summary>
+    /// Returns the layout on disk - does not adjunct for BagIt layout
+    /// </summary>
+    /// <param name="refresh">Read from storage rather than cached file system view</param>
+    /// <returns></returns>
     public async Task<Result<WorkingDirectory?>> GetFileSystemWorkingDirectory(bool refresh = false)
     {
         var readFilesResult = await mediator.Send(new GetWorkingDirectory(

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -825,20 +825,11 @@ public class ProcessPipelineJobHandler(
             logger.LogError("Could not read deposit file system.");
         }
 
-        var wbsToAdd = new List<WorkingBase>();
-        var contentRoot = combinedResult.Value;
-
-        foreach (var item in minimalItems)
-        {
-            WorkingBase? wbToAdd = item.IsDirectory
-                ? contentRoot?.FindDirectory(item.RelativePath)?.DirectoryInDeposit?.ToRootLayout()
-                : contentRoot?.FindFile(item.RelativePath)?.FileInDeposit?.ToRootLayout();
-
-            if (wbToAdd != null)
-            {
-                wbsToAdd.Add(wbToAdd);
-            }
-        }
+        var contentRoot = combinedResult.Value!;
+        var wbsToAdd = minimalItems
+            .Select(m => m.ResolveFromContentRoot(contentRoot))
+            .OfType<WorkingBase>()
+            .ToList();
 
         return await workspaceManager.AddItemsToMets(wbsToAdd, request.GetUserName());
     }

--- a/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/ToRootLayoutTests.cs
+++ b/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/ToRootLayoutTests.cs
@@ -1,0 +1,136 @@
+using DigitalPreservation.Common.Model.Transit;
+using Test.Helpers.TestData;
+
+namespace Preservation.API.Tests.WorkingDirectories;
+
+public class ToRootLayoutTests
+{
+    // ToRootLayout() strips the "data/" prefix from a WorkingDirectory and all its
+    // descendants, transforming a BagIt-layout subtree into a root-layout subtree.
+    // It is called on individual directories/files retrieved from a BagIt workspace
+    // (e.g. data/objects, data/metadata) before handing them to METS processing.
+    //
+    // The BagIt structure used in these tests (from TestStructure.GetBagItTestStructure()):
+    //
+    //   (root, LocalPath="")
+    //   ├── bagit.txt
+    //   └── data/                              (LocalPath="data")
+    //       ├── data/objects/                  (LocalPath="data/objects")
+    //       │   ├── data/objects/image1.jpg
+    //       │   ├── data/objects/image2.jpg
+    //       │   ├── data/objects/image3.jpg
+    //       │   └── data/objects/subdirectory/ (LocalPath="data/objects/subdirectory")
+    //       │       ├── data/objects/subdirectory/sub-image1.jpg
+    //       │       ├── data/objects/subdirectory/sub-image2.jpg
+    //       │       └── data/objects/subdirectory/sub-image3.jpg
+    //       └── data/metadata/                 (LocalPath="data/metadata")
+    //           └── data/metadata/tool-output.yaml
+
+    [Fact]
+    public void Can_Convert_BagIt_Root()
+    {
+        var data = TestStructure.GetBagItTestStructure().FindDirectory("data")!;
+
+        var result = data.ToRootLayout();
+
+        result.LocalPath.Should().Be("");
+        result.FindDirectory("objects")!.LocalPath.Should().Be("objects");
+    }
+    
+    [Fact]
+    public void Objects_directory_path_has_prefix_stripped()
+    {
+        var objects = TestStructure.GetBagItTestStructure().FindDirectory("data/objects")!;
+
+        var result = objects.ToRootLayout();
+
+        result.LocalPath.Should().Be("objects");
+    }
+
+    [Fact]
+    public void Nested_subdirectory_path_has_prefix_stripped()
+    {
+        var objects = TestStructure.GetBagItTestStructure().FindDirectory("data/objects")!;
+
+        var result = objects.ToRootLayout();
+
+        result.FindDirectory("subdirectory")!.LocalPath.Should().Be("objects/subdirectory");
+    }
+
+    [Fact]
+    public void Files_in_objects_directory_have_prefix_stripped()
+    {
+        var objects = TestStructure.GetBagItTestStructure().FindDirectory("data/objects")!;
+
+        var result = objects.ToRootLayout();
+
+        result.Files.Select(f => f.LocalPath).Should().BeEquivalentTo(
+        [
+            "objects/image1.jpg",
+            "objects/image2.jpg",
+            "objects/image3.jpg"
+        ]);
+    }
+
+    [Fact]
+    public void Files_in_nested_subdirectory_have_prefix_stripped()
+    {
+        var objects = TestStructure.GetBagItTestStructure().FindDirectory("data/objects")!;
+
+        var result = objects.ToRootLayout();
+
+        var subdir = result.FindDirectory("subdirectory")!;
+        subdir.Files.Select(f => f.LocalPath).Should().BeEquivalentTo(
+        [
+            "objects/subdirectory/sub-image1.jpg",
+            "objects/subdirectory/sub-image2.jpg",
+            "objects/subdirectory/sub-image3.jpg"
+        ]);
+    }
+
+    [Fact]
+    public void Metadata_directory_path_has_prefix_stripped()
+    {
+        var metadata = TestStructure.GetBagItTestStructure().FindDirectory("data/metadata")!;
+
+        var result = metadata.ToRootLayout();
+
+        result.LocalPath.Should().Be("metadata");
+    }
+
+    [Fact]
+    public void File_in_metadata_directory_has_prefix_stripped()
+    {
+        var metadata = TestStructure.GetBagItTestStructure().FindDirectory("data/metadata")!;
+
+        var result = metadata.ToRootLayout();
+
+        result.Files.Should().ContainSingle()
+            .Which.LocalPath.Should().Be("metadata/tool-output.yaml");
+    }
+
+    [Fact]
+    public void File_count_is_preserved_after_transformation()
+    {
+        var objects = TestStructure.GetBagItTestStructure().FindDirectory("data/objects")!;
+
+        var result = objects.ToRootLayout();
+
+        result.DescendantFileCount().Should().Be(objects.DescendantFileCount());
+    }
+
+    [Fact]
+    public void Directory_without_data_prefix_is_returned_unchanged()
+    {
+        var regular = new WorkingDirectory
+        {
+            LocalPath = "objects",
+            Files = [new WorkingFile { LocalPath = "objects/image.jpg" }],
+            Directories = []
+        };
+
+        var result = regular.ToRootLayout();
+
+        result.Should().BeSameAs(regular);
+    }
+}

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
@@ -106,17 +106,16 @@ public class DepositsController(
             return this.StatusResponseFromResult(filesystemResult);
         }
         var fileSystem = filesystemResult.Value;
+        if (workspaceManager.IsBagItLayout)
+        {
+            fileSystem = fileSystem.FindDirectory(FolderNames.BagItData)!.ToRootLayout();
+        }
         var wbsToAdd = new List<WorkingBase>();
         foreach (var path in localPaths)
         {
             // we don't know if it's a file or a directory from just the path,
             // but it's not expensive now to find out
-            WorkingBase? wbToAdd = fileSystem.FindFile(path);
-            if (wbToAdd is null)
-            {
-                wbToAdd = fileSystem.FindDirectory(path);
-            }
-
+            WorkingBase? wbToAdd = fileSystem.FindFile(path) ?? (WorkingBase?)fileSystem.FindDirectory(path);
             if (wbToAdd != null)
             {
                 wbsToAdd.Add(wbToAdd);

--- a/src/DigitalPreservation/Test.Helpers/TestData/TestStructure.cs
+++ b/src/DigitalPreservation/Test.Helpers/TestData/TestStructure.cs
@@ -3,7 +3,7 @@ using DigitalPreservation.Common.Model.Transit;
 
 namespace Test.Helpers.TestData;
 
-public class TestStructure
+public static class TestStructure
 {
     public static WorkingDirectory GetBagItTestStructure()
     {


### PR DESCRIPTION
Fix ULIIIFCS-26 — Add items to METS in BagIt layout deposits

BagIt-layout deposits have the objects and metadata under `data/` (e.g. data/objects/image.jpg), but the "add items to METS" endpoints were looking up paths without that prefix (objects/image.jpg), so items could never be found and METS entries were never added. Callers of AddItemsToMets should supply the relative path.

WorkingDirectory.ToRootLayout(): Previously only stripped "data/" from paths that started with "data/" (a trailing slash
 was required), so calling it on the data directory itself (which has LocalPath="data") was a no-op. The fix adds an explicit check for LocalPath == "data so the entire data/ subtree can now be converted to a root-layout view.

 - `DepositsController.AddItemsToMets` — when the workspace is BagIt layout, the filesystem is now run through
  FindDirectory("data").ToRootLayout() before path lookup, so callers can pass root-relative paths as expected.
 - ExecutePipelineJob and Deposit.cshtml.cs — both had duplicated foreach loops doing the same BagIt-aware CombinedDirectory lookup with ToRootLayout(). This logic is centralised into a new `MinimalItem.ResolveFromContentRoot()` method, and both call sites are replaced with a single LINQ expression.
 - New ToRootLayoutTests unit tests covering the ToRootLayout() transformation across the full BagIt directory structure.