### PR TITLE
Handle digest mismatches for manually uploaded bagit generated files

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -442,6 +442,15 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
     public List<string> GetDistinctDigests()
     {
+        if (FileInDeposit != null && DepositFileFormatMetadata != null && FolderNames.IsMetadata(FileInDeposit.LocalPath))
+        {
+            if (FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
+            {
+                //means bagit file has been superseded like with a pipeline run
+                DepositFileFormatMetadata.Digest = null;
+            }
+
+        }
         var distinctDigests = new List<string?>
         {
             FileInMets?.Digest,

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -442,7 +442,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
     public List<string> GetDistinctDigests()
     {
-        if (FileInDeposit != null && DepositFileFormatMetadata != null && FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp))
+        if (FileInDeposit != null && DepositFileFormatMetadata != null && FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
             DepositFileFormatMetadata!.Digest = null;
 
         var distinctDigests = new List<string?>

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -443,9 +443,8 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
     public List<string> GetDistinctDigests()
     {
         if (FileInDeposit != null && DepositFileFormatMetadata != null && FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp))
-        {
             DepositFileFormatMetadata!.Digest = null;
-        }
+
         var distinctDigests = new List<string?>
         {
             FileInMets?.Digest,

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -448,9 +448,14 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
             FileInDeposit?.Digest ?? string.Empty
         };
 
-        if (FileInDeposit != null && DepositFileFormatMetadata != null &&
-            FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
-            distinctDigests.Add(DepositFileFormatMetadata?.Digest ?? string.Empty);
+        var bagItEntry = FileInDeposit?.Metadata
+            .OfType<DigestMetadata>()
+            .FirstOrDefault(m => m.Source == "BagIt");
+
+        // Only include the BagIt digest if the file has not been modified since the manifest was written.
+        // If Modified > bagItEntry.Timestamp the BagIt digest is stale and should be discarded.
+        if (bagItEntry != null && FileInDeposit!.Modified <= bagItEntry.Timestamp)
+            distinctDigests.Add(bagItEntry.Digest ?? string.Empty);
 
         return distinctDigests.Where(digest => digest.HasText())
             .Distinct()

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -442,14 +442,9 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
     public List<string> GetDistinctDigests()
     {
-        if (FileInDeposit != null && DepositFileFormatMetadata != null && FolderNames.IsMetadata(FileInDeposit.LocalPath))
+        if (FileInDeposit != null && DepositFileFormatMetadata != null && FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp))
         {
-            if (FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
-            {
-                //means bagit file has been superseded like with a pipeline run
-                DepositFileFormatMetadata.Digest = null;
-            }
-
+            DepositFileFormatMetadata!.Digest = null;
         }
         var distinctDigests = new List<string?>
         {

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -442,19 +442,20 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
     public List<string> GetDistinctDigests()
     {
-        if (FileInDeposit != null && DepositFileFormatMetadata != null && FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
-            DepositFileFormatMetadata!.Digest = null;
-
-        var distinctDigests = new List<string?>
+        var distinctDigests = new List<string>
         {
-            FileInMets?.Digest,
-            DepositFileFormatMetadata?.Digest,
-            FileInDeposit?.Digest
-        }.Where(digest => digest.HasText())
+            FileInMets?.Digest ?? string.Empty,
+            FileInDeposit?.Digest ?? string.Empty
+        };
+
+        if (FileInDeposit != null && DepositFileFormatMetadata != null &&
+            FileInDeposit.Modified > FileInDeposit.GetDigestMetadata()?.Timestamp)
+            distinctDigests.Add(DepositFileFormatMetadata?.Digest ?? string.Empty);
+
+        return distinctDigests.Where(digest => digest.HasText())
             .Distinct()
-            .Select(digest => digest!) // flip to non-nullable
+            .Select(digest => digest!)
             .ToList();
-        return distinctDigests;
     }
 
     public string? GetSingleDigest()

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -112,7 +112,7 @@ public class MetadataReader : IMetadataReader
                 {
                     Source = "BagIt",
                     Digest = kvp.Value.ToLowerInvariant(),
-                    Timestamp = bagitTimestamp //TODO: this should be the value the manifest-sha256 should be
+                    Timestamp = bagitTimestamp
                 });
             }
         }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -41,13 +41,15 @@ public class MetadataReader : IMetadataReader
     private async Task FindMetadata()
     {
         var timestamp = DateTime.UtcNow;
+        var bagitTimestamp = DateTime.UtcNow;
         bool isBagItLayout = false;
         // use storage to read and parse all sources of metadata
         var bagitSha256ManifestResult = await storage.GetStream(rootUri.AppendEscapedSlug("manifest-sha256.txt"));
-        if (bagitSha256ManifestResult is { Success: true, Value: not null })
+        if (bagitSha256ManifestResult is { Success: true, Value.ResponseStream: not null })
         {
             isBagItLayout = true;
-            await ReadBagItSha256(bagitSha256ManifestResult.Value);
+            await ReadBagItSha256(bagitSha256ManifestResult.Value.ResponseStream!);
+            bagitTimestamp = bagitSha256ManifestResult.Value.LastModified;
             // Look for other bagit manifests? (non sha-256)
         }
         // It still might be a bagit layout but without any root bagit files yet
@@ -73,14 +75,14 @@ public class MetadataReader : IMetadataReader
         if (await storage.Exists(brunnhildeProbe))
         {
             brunnhildeSiegfriedOutput = await ParseSiegfriedOutput(brunnhildeRoot.AppendEscapedSlug("siegfried.csv"));
-            if (brunnhildeAVResult is { Success: true, Value: not null })
+            if (brunnhildeAVResult is { Success: true, Value.ResponseStream: not null })
             {
-                infectedFiles = await ReadInfectedFilePaths(brunnhildeAVResult.Value);
+                infectedFiles = await ReadInfectedFilePaths(brunnhildeAVResult.Value.ResponseStream!);
             }
             var brunnhildeHtmlResult = await storage.GetStream(brunnhildeRoot.AppendEscapedSlug("report.html"));
-            if (brunnhildeHtmlResult is { Success: true, Value: not null })
+            if (brunnhildeHtmlResult is { Success: true, Value.ResponseStream: not null })
             {
-                var brunnhildeHtml = await GetTextFromStream(brunnhildeHtmlResult.Value);
+                var brunnhildeHtml = await GetTextFromStream(brunnhildeHtmlResult.Value.ResponseStream!);
                 GetMetadataList("metadata/brunnhilde/report.html").Add(
                     new ToolOutput
                     {
@@ -110,7 +112,7 @@ public class MetadataReader : IMetadataReader
                 {
                     Source = "BagIt",
                     Digest = kvp.Value.ToLowerInvariant(),
-                    Timestamp = timestamp
+                    Timestamp = bagitTimestamp //TODO: this should be the value the manifest-sha256 should be
                 });
             }
         }
@@ -142,12 +144,12 @@ public class MetadataReader : IMetadataReader
 
         var virusDefinition = string.Empty;
         var virusDefinitionFileExists = await storage.Exists(virusDefinitionRoot);
-        if (virusDefinitionFileExists && brunnhildeAVResult is { Success: true, Value: not null })
+        if (virusDefinitionFileExists && brunnhildeAVResult is { Success: true, Value.ResponseStream: not null })
         {
             var virusDefinitionResult = await storage.GetStream(virusDefinitionRoot);
-            if (virusDefinitionResult is { Success: true, Value: not null })
+            if (virusDefinitionResult is { Success: true, Value.ResponseStream: not null })
             {
-                virusDefinition = await GetTextFromStream(virusDefinitionResult.Value);
+                virusDefinition = await GetTextFromStream(virusDefinitionResult.Value.ResponseStream!);
             }
         }
 
@@ -155,9 +157,9 @@ public class MetadataReader : IMetadataReader
         {
             var brunnhildeVirusLogResult = await storage.GetStream(brunnhildeRoot.AppendEscapedSlug("logs").AppendEscapedSlug("viruscheck-log.txt"));
 
-            if (brunnhildeVirusLogResult is { Success: true, Value: not null })
+            if (brunnhildeVirusLogResult is { Success: true, Value.ResponseStream: not null })
             {
-                virusDefinition = await GetVirusDefinitionFromBrunnhilde(brunnhildeVirusLogResult.Value);
+                virusDefinition = await GetVirusDefinitionFromBrunnhilde(brunnhildeVirusLogResult.Value.ResponseStream!);
             }
         }
 
@@ -380,11 +382,11 @@ public class MetadataReader : IMetadataReader
     private async Task<SiegfriedOutput?> ParseSiegfriedOutput(Uri siegfriedUri)
     {
         var streamResult = await storage.GetStream(siegfriedUri);
-        if (streamResult is not { Success: true, Value: not null })
+        if (streamResult is not { Success: true, Value.ResponseStream: not null })
         {
             return null;
         }
-        var txt = await GetTextFromStream(streamResult.Value);
+        var txt = await GetTextFromStream(streamResult.Value.ResponseStream!);
 
         // first assume that the extension corresponds to the data - it might not!
         // (if siegfried used without format and > output.xxx being consistent)
@@ -506,8 +508,8 @@ public class MetadataReader : IMetadataReader
         var metadataRoot = workingRootUri.AppendEscapedSlug("metadata");
         var exifResult = await storage.GetStream(metadataRoot.AppendEscapedSlug("exif").AppendEscapedSlug("exif_output.txt"));
 
-        if (exifResult.Value == null) return [];
-        var txt = await GetTextFromStream(exifResult.Value);
+        if (exifResult.Value.ResponseStream == null) return [];
+        var txt = await GetTextFromStream(exifResult.Value.ResponseStream);
         return ParseExifToolOutput(txt);
 
     }

--- a/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/GetDistinctDigestsTests.cs
+++ b/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/GetDistinctDigestsTests.cs
@@ -1,0 +1,183 @@
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Combined;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+
+namespace Preservation.API.Tests.WorkingDirectories;
+
+public class GetDistinctDigestsTests
+{
+    private static readonly DateTime BagItTimestamp = new(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime PipelineTimestamp = new(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime FileModifiedBeforeBagIt = new(2024, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime FileModifiedAfterPipeline = new(2024, 1, 1, 13, 0, 0, DateTimeKind.Utc);
+
+    // Non-BagIt baseline
+
+    [Fact]
+    public void NoMetadata_ReturnsEmpty()
+    {
+        var combined = MakeCombined(metsDigest: null, fileDigest: null);
+        combined.GetDistinctDigests().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MetsDigestOnly_ReturnsMetsDigest()
+    {
+        var combined = MakeCombined(metsDigest: "abc", fileDigest: null);
+        combined.GetDistinctDigests().Should().ContainSingle().Which.Should().Be("abc");
+    }
+
+    [Fact]
+    public void MetsAndFileDigestMatch_ReturnsSingleDigest()
+    {
+        var combined = MakeCombined(metsDigest: "abc", fileDigest: "abc");
+        combined.GetDistinctDigests().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void MetsAndFileDigestMismatch_ReturnsTwoDistinctDigests()
+    {
+        var combined = MakeCombined(metsDigest: "abc", fileDigest: "xyz");
+        combined.GetDistinctDigests().Should().HaveCount(2);
+    }
+
+    // BagIt, no pipeline
+
+    [Fact]
+    public void BagItOnly_NoSiegfried_BagItDigestNotIncludedInDistincts()
+    {
+        // Without pipeline, GetFileFormatMetadata() returns null for objects/ files,
+        // so DepositFileFormatMetadata is null and the BagIt DigestMetadata never
+        // enters GetDistinctDigests regardless of timestamp.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "bagit-digest", Timestamp = BagItTimestamp }
+            ]
+        };
+        var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "mets-digest" };
+        var combined = new CombinedFile(depositFile, metsFile);
+
+        combined.GetDistinctDigests().Should().NotContain("bagit-digest");
+    }
+
+    // BagIt + pipeline, files unchanged
+
+    [Fact]
+    public void BagItAndSiegfried_SameDigest_FileModifiedBeforePipeline_ReturnsSingleDigest()
+    {
+        // Normal post-pipeline state: files unchanged so BagIt and Siegfried digests agree.
+        // File was uploaded before either timestamp, so Modified < both timestamps.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Digest = "digest-a",
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "digest-a", Timestamp = BagItTimestamp },
+                new FileFormatMetadata { Source = "Siegfried", Digest = "digest-a", Timestamp = PipelineTimestamp }
+            ]
+        };
+        var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "digest-a" };
+        var combined = new CombinedFile(depositFile, metsFile);
+
+        combined.GetDistinctDigests().Should().ContainSingle();
+    }
+
+    // Documents that the timestamp assumption is wrong
+
+    [Fact]
+    public void GetDigestMetadata_Timestamp_IsMaxAcrossAllSources_NotBagItSpecific()
+    {
+        // After pipeline runs, GetDigestMetadata().Timestamp reflects the Siegfried
+        // (pipeline) timestamp — the Max of all IDigestMetadata entries — not the
+        // BagIt manifest's S3 LastModified. The condition in GetDistinctDigests uses
+        // this value but assumes it is the BagIt timestamp.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "digest-a", Timestamp = BagItTimestamp },
+                new FileFormatMetadata { Source = "Siegfried", Digest = "digest-a", Timestamp = PipelineTimestamp }
+            ]
+        };
+
+        var result = depositFile.GetDigestMetadata();
+        result!.Timestamp.Should().Be(PipelineTimestamp, "Max() across all IDigestMetadata entries returns the pipeline timestamp");
+        result!.Timestamp.Should().NotBe(BagItTimestamp);
+    }
+
+    // Documents that GetDigestMetadata throws when BagIt and Siegfried disagree —
+    // which is the actual scenario this fix is targeting
+
+    [Fact]
+    public void GetDigestMetadata_ThrowsWhenBagItAndSiegfriedDigestsDiffer()
+    {
+        // This is the exact post-pipeline state the PR is supposed to fix:
+        // BagIt manifest has the old digest, Siegfried computed the new digest.
+        // GetDigestMetadata() throws MetadataException rather than returning a timestamp,
+        // so the condition in GetDistinctDigests cannot evaluate safely.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedAfterPipeline,
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "old-digest", Timestamp = BagItTimestamp },
+                new FileFormatMetadata { Source = "Siegfried", Digest = "new-digest", Timestamp = PipelineTimestamp }
+            ]
+        };
+
+        var act = () => depositFile.GetDigestMetadata();
+        act.Should().Throw<MetadataException>();
+    }
+
+    [Fact]
+    public void GetDistinctDigests_WhenBagItAndSiegfriedDigestsDiffer_Throws()
+    {
+        // When the stale-BagIt scenario actually occurs, the condition
+        // `FileInDeposit.GetDigestMetadata()?.Timestamp` throws MetadataException
+        // rather than returning a clean mismatch count. This is the bug the PR targets
+        // but does not fix correctly.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedAfterPipeline,
+            Digest = "new-digest",
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "old-digest", Timestamp = BagItTimestamp },
+                new FileFormatMetadata { Source = "Siegfried", Digest = "new-digest", Timestamp = PipelineTimestamp }
+            ]
+        };
+        var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "new-digest" };
+        var combined = new CombinedFile(depositFile, metsFile);
+
+        // The fix should make this return a single digest ("new-digest") without throwing.
+        // Currently it throws because GetDigestMetadata() is called inside the condition.
+        var act = () => combined.GetDistinctDigests();
+        act.Should().Throw<MetadataException>();
+    }
+
+    private static CombinedFile MakeCombined(string? metsDigest, string? fileDigest)
+    {
+        var deposit = fileDigest == null ? null : new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Digest = fileDigest
+        };
+        var mets = metsDigest == null ? null : new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Digest = metsDigest
+        };
+        return new CombinedFile(deposit, mets);
+    }
+}

--- a/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/GetDistinctDigestsTests.cs
+++ b/src/DigitalPreservation/Preservation.API.Tests/WorkingDirectories/GetDistinctDigestsTests.cs
@@ -44,15 +44,38 @@ public class GetDistinctDigestsTests
     // BagIt, no pipeline
 
     [Fact]
-    public void BagItOnly_NoSiegfried_BagItDigestNotIncludedInDistincts()
+    public void BagItOnly_NoSiegfried_FreshFile_BagItDigestIncluded()
     {
-        // Without pipeline, GetFileFormatMetadata() returns null for objects/ files,
-        // so DepositFileFormatMetadata is null and the BagIt DigestMetadata never
-        // enters GetDistinctDigests regardless of timestamp.
+        // Without pipeline, the fix still correctly includes the BagIt digest for a fresh
+        // file (Modified <= BagItTimestamp). The old code never included it (gated on
+        // DepositFileFormatMetadata being non-null, which required Siegfried to have run).
         var depositFile = new WorkingFile
         {
             LocalPath = "objects/file.jpg",
             Modified = FileModifiedBeforeBagIt,
+            Digest = "bagit-digest",
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "bagit-digest", Timestamp = BagItTimestamp }
+            ]
+        };
+        var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "bagit-digest" };
+        var combined = new CombinedFile(depositFile, metsFile);
+
+        combined.GetDistinctDigests().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void BagItOnly_NoSiegfried_BagItMetsDigestMismatch_ReturnsTwoDigests()
+    {
+        // Fresh file, BagIt digest does not match METS digest — a real mismatch.
+        // The fix correctly surfaces this; the old code would have missed it (BagIt
+        // digest was never included without pipeline).
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Digest = "bagit-digest",
             Metadata =
             [
                 new DigestMetadata { Source = "BagIt", Digest = "bagit-digest", Timestamp = BagItTimestamp }
@@ -61,7 +84,7 @@ public class GetDistinctDigestsTests
         var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "mets-digest" };
         var combined = new CombinedFile(depositFile, metsFile);
 
-        combined.GetDistinctDigests().Should().NotContain("bagit-digest");
+        combined.GetDistinctDigests().Should().HaveCount(2);
     }
 
     // BagIt + pipeline, files unchanged
@@ -119,10 +142,9 @@ public class GetDistinctDigestsTests
     [Fact]
     public void GetDigestMetadata_ThrowsWhenBagItAndSiegfriedDigestsDiffer()
     {
-        // This is the exact post-pipeline state the PR is supposed to fix:
-        // BagIt manifest has the old digest, Siegfried computed the new digest.
-        // GetDigestMetadata() throws MetadataException rather than returning a timestamp,
-        // so the condition in GetDistinctDigests cannot evaluate safely.
+        // GetDigestMetadata() aggregates all IDigestMetadata sources. When BagIt and
+        // Siegfried disagree it throws MetadataException. The fix avoids calling
+        // GetDigestMetadata() in GetDistinctDigests so this never triggers there.
         var depositFile = new WorkingFile
         {
             LocalPath = "objects/file.jpg",
@@ -139,12 +161,10 @@ public class GetDistinctDigestsTests
     }
 
     [Fact]
-    public void GetDistinctDigests_WhenBagItAndSiegfriedDigestsDiffer_Throws()
+    public void GetDistinctDigests_WhenBagItDigestIsStale_ExcludesBagItDigestAndReturnsSingleDigest()
     {
-        // When the stale-BagIt scenario actually occurs, the condition
-        // `FileInDeposit.GetDigestMetadata()?.Timestamp` throws MetadataException
-        // rather than returning a clean mismatch count. This is the bug the PR targets
-        // but does not fix correctly.
+        // The fix scenario: file was modified after the BagIt manifest was written (pipeline ran).
+        // The stale BagIt digest should be excluded; only the METS and actual file digests remain.
         var depositFile = new WorkingFile
         {
             LocalPath = "objects/file.jpg",
@@ -159,10 +179,29 @@ public class GetDistinctDigestsTests
         var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "new-digest" };
         var combined = new CombinedFile(depositFile, metsFile);
 
-        // The fix should make this return a single digest ("new-digest") without throwing.
-        // Currently it throws because GetDigestMetadata() is called inside the condition.
-        var act = () => combined.GetDistinctDigests();
-        act.Should().Throw<MetadataException>();
+        var digests = combined.GetDistinctDigests();
+        digests.Should().ContainSingle().Which.Should().Be("new-digest");
+        digests.Should().NotContain("old-digest");
+    }
+
+    [Fact]
+    public void GetDistinctDigests_WhenBagItDigestIsFresh_IncludesBagItDigest()
+    {
+        // File was NOT modified after the BagIt manifest — digest is still valid and included.
+        var depositFile = new WorkingFile
+        {
+            LocalPath = "objects/file.jpg",
+            Modified = FileModifiedBeforeBagIt,
+            Digest = "digest-a",
+            Metadata =
+            [
+                new DigestMetadata { Source = "BagIt", Digest = "digest-a", Timestamp = BagItTimestamp }
+            ]
+        };
+        var metsFile = new WorkingFile { LocalPath = "objects/file.jpg", Digest = "digest-a" };
+        var combined = new CombinedFile(depositFile, metsFile);
+
+        combined.GetDistinctDigests().Should().ContainSingle();
     }
 
     private static CombinedFile MakeCombined(string? metsDigest, string? fileDigest)

--- a/src/DigitalPreservation/Storage.API/Features/Binaries/ContentController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Binaries/ContentController.cs
@@ -40,9 +40,9 @@ public class ContentController(
         }
         
         var streamResult = await storage.GetStream(binary.Origin!);
-        if (streamResult is { Success: true, Value: not null })
+        if (streamResult is { Success: true, Value.ResponseStream: not null })
         {
-            return new FileStreamResult(streamResult.Value, binary.ContentType!);
+            return new FileStreamResult(streamResult.Value.ResponseStream!, binary.ContentType!);
         }
 
         var pdr = streamResult.ToProblemDetails("Cannot stream content");

--- a/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
+++ b/src/DigitalPreservation/Storage.API/Fedora/FedoraClient.cs
@@ -656,9 +656,9 @@ internal class FedoraClient(
         {
             logger.LogInformation("Getting stream from storage content at origin {origin}", binary.Origin);
             var streamResult = await storage.GetStream(binary.Origin!);
-            if (streamResult is { Success: true, Value: not null })
+            if (streamResult is { Success: true, Value.ResponseStream: not null })
             {
-                putStream = streamResult.Value;
+                putStream = streamResult.Value.ResponseStream!;
             }
             else
             {

--- a/src/DigitalPreservation/Storage.Repository.Common/IStorage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/IStorage.cs
@@ -65,5 +65,5 @@ public interface IStorage
     Task<Result<BulkDeleteResult>> EmptyStorageLocation(Uri storageLocation, CancellationToken cancellationToken);
     static string DepositFileSystem => "__METSlike.json";
     Task<Result<string?>> GetExpectedDigest(Uri? binaryOrigin, string? binaryDigest);
-    Task<Result<Stream?>> GetStream(Uri binaryOrigin);
+    Task<Result<(Stream? ResponseStream, DateTime LastModified)>> GetStream(Uri binaryOrigin);
 }

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -565,7 +565,7 @@ public class Storage(
         return Result.Ok(expected);
     }
 
-    public async Task<Result<Stream?>> GetStream(Uri binaryOrigin)
+    public async Task<Result<(Stream? ResponseStream, DateTime LastModified)>> GetStream(Uri binaryOrigin)
     {
         var s3Uri = new AmazonS3Uri(binaryOrigin);
         var s3Req = new GetObjectRequest
@@ -577,13 +577,14 @@ public class Storage(
             var s3Resp = await s3Client.GetObjectAsync(s3Req);
             if (s3Resp.HttpStatusCode == HttpStatusCode.OK)
             {
-                return Result.Ok(s3Resp.ResponseStream);
+                return Result.Ok<(Stream?, DateTime)>((s3Resp.ResponseStream, s3Resp.LastModified));
             }
-            return Result.Fail<Stream>(ErrorCodes.GetErrorCode((int)s3Resp.HttpStatusCode), "Could not get stream for " + binaryOrigin);
+            return Result.Fail<(Stream?, DateTime)>(ErrorCodes.GetErrorCode((int)s3Resp.HttpStatusCode), "Could not get stream for " + binaryOrigin);
         }
         catch (AmazonS3Exception e)
         {
-            return Result.Fail<Stream>(ErrorCodes.GetErrorCode((int)e.StatusCode), "Could not get stream for " + binaryOrigin);
+            return Result.Fail<(Stream?, DateTime)>(ErrorCodes.GetErrorCode((int)e.StatusCode), "Could not get stream for " + binaryOrigin);
         }
     }
+
 }


### PR DESCRIPTION
Ticket: https://digirati.atlassian.net/browse/LPII-69

If the metadata files timestamp changes like after a pipeline run the…n any manually uploaded files content could have changed like siegfried.csv filepaths. This would result in SHA256 digest mismatches as the bagit generated digest values will be no longer valid and thus unable to do an import job. This change checks when the mainfest-sha256.txt was generated and comapres with the file in deposit LastModified date.

Claude suggestions:
[project_pr173_review.md](https://github.com/user-attachments/files/26790670/project_pr173_review.md)


