### PR TITLE
Couple of bugs after all PRs merged

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Deposit.Archiver/Functions.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Deposit.Archiver/Functions.cs
@@ -97,7 +97,7 @@ public class Functions
                 "LAST_MODIFIED_MONTHS must be a non-zero value.");
         }
 
-        var cutoffDate = DateTime.UtcNow.AddMonths(-1);
+        var cutoffDate = DateTime.UtcNow.AddMonths(-months);
 
         return new DepositQuery
         {

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/ArchiveDeposit.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/ArchiveDeposit.cs
@@ -34,7 +34,7 @@ public class ArchiveDepositHandler(
             EndTime = request.ArchiveDepositJob.EndTime,
             BatchNumber = request.ArchiveDepositJob.BatchNumber!,
             Id = request.ArchiveDepositJob.Id!,
-            DeletedCount = request.ArchiveDepositJob.DeletedCount!.Value,
+            DeletedCount = request.ArchiveDepositJob.DeletedCount ?? 0,
             Errors = request.ArchiveDepositJob.Errors
         };
 


### PR DESCRIPTION
  Bug 1: LAST_MODIFIED_MONTHS env var is read but never used
  Functions.cs:100 — cutoffDate is hardcoded to -1 month regardless of the env var value:

```
  var months = Math.Abs(rawMonthsValue);  // computed...
  if (months == 0) throw ...;
  var cutoffDate = DateTime.UtcNow.AddMonths(-1);  // ...but -1 is hardcoded
```

  Should be `DateTime.UtcNow.AddMonths(-months)`.

  Bug 2: Null dereference in ArchiveDeposit.cs:37

When a deposit has no files to delete, DeletedCount is null because deleteFilesResult.Value is null on a "No items to delete." failure
  result. But ArchiveDeposit.cs then does:

```
DeletedCount = request.ArchiveDepositJob.DeletedCount!.Value,  // throws if null
```

This will throw InvalidOperationException for any deposit that was already clean when the archiver ran. Fix: `?? 0`.