### PR TITLE
Make RDF tests more robust wrt line endings

### DIFF
--- a/src/DigitalPreservation/Storage.API.Tests/Fedora/RdfTests.cs
+++ b/src/DigitalPreservation/Storage.API.Tests/Fedora/RdfTests.cs
@@ -4,10 +4,12 @@ namespace Storage.API.Tests.Fedora;
 
 public class RdfTests
 {
-    private static string Actual(HttpRequestMessage msg) =>
+    private static string[] Lines(HttpRequestMessage msg) =>
         ((StringContent)msg.Content!).ReadAsStringAsync().Result
-            .Replace("\r\n", "\n")
-            .TrimEnd();
+            .Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries);
+
+    private static string[] Expected(string s) =>
+        s.Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries);
 
     [Fact] public void Single_Rdf_Statement_Request_Content()
     {
@@ -18,11 +20,10 @@ public class RdfTests
         msg.AppendRdf("ex", "http://example.com", "<> ex:thing \"some-value\"");
 
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX ex: <http://example.com>
             <> ex:thing "some-value" .
-            """.TrimEnd());
+            """));
     }
 
     [Fact] public void Two_Rdf_Statements_Request_Content()
@@ -35,13 +36,12 @@ public class RdfTests
         msg.AppendRdf("dc", "http://dc2.com", "<> dc:yyyy \"some-other-value\"");
 
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX ex: <http://example.com>
             PREFIX dc: <http://dc2.com>
             <> ex:thing "some-value" .
             <> dc:yyyy "some-other-value" .
-            """.TrimEnd());
+            """));
     }
 
     [Fact] public void Three_Rdf_Statements_Request_Content()
@@ -55,15 +55,14 @@ public class RdfTests
         msg.AppendRdf("fedora", "http://fedora.info/definitions/v4/repository#", "<> fedora:createdBy \"Tom\"");
 
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX ex: <http://example.com>
             PREFIX dc: <http://dc2.com>
             PREFIX fedora: <http://fedora.info/definitions/v4/repository#>
             <> ex:thing "some-value" .
             <> dc:yyyy "some-other-value" .
             <> fedora:createdBy "Tom" .
-            """.TrimEnd());
+            """));
     }
 
     [Fact] public void Duplicate_Prefix_Request_Content()
@@ -78,8 +77,7 @@ public class RdfTests
         msg.AppendRdf("dc", "http://dc2.com", "<> dc:zzzz \"another-value\"");
 
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX ex: <http://example.com>
             PREFIX dc: <http://dc2.com>
             PREFIX fedora: <http://fedora.info/definitions/v4/repository#>
@@ -87,6 +85,6 @@ public class RdfTests
             <> dc:yyyy "some-other-value" .
             <> fedora:createdBy "Tom" .
             <> dc:zzzz "another-value" .
-            """.TrimEnd());
+            """));
     }
 }

--- a/src/DigitalPreservation/Storage.API.Tests/Fedora/RequestXTests.cs
+++ b/src/DigitalPreservation/Storage.API.Tests/Fedora/RequestXTests.cs
@@ -4,10 +4,12 @@ namespace Storage.API.Tests.Fedora;
 
 public class RequestXTests
 {
-    private static string Actual(HttpRequestMessage msg) =>
+    private static string[] Lines(HttpRequestMessage msg) =>
         ((StringContent)msg.Content!).ReadAsStringAsync().Result
-            .Replace("\r\n", "\n")
-            .TrimEnd();
+            .Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries);
+
+    private static string[] Expected(string s) =>
+        s.Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries);
 
     [Fact]
     public void Single_Rdf_Statement_Simple_Name()
@@ -19,11 +21,10 @@ public class RequestXTests
         msg.WithName("Simple name");
         
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX dc: <http://purl.org/dc/elements/1.1/>
             <> dc:title "Simple name" .
-            """.TrimEnd());
+            """));
     }
 
     [Fact]
@@ -36,10 +37,9 @@ public class RequestXTests
         msg.WithName("Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156");
 
         // Assert
-        Actual(msg).Should().Be(
-            """
+        Lines(msg).Should().Equal(Expected("""
             PREFIX dc: <http://purl.org/dc/elements/1.1/>
             <> dc:title "Barth Bridge. Original drawing used in \"The Yorkshire Dales\" (1956), page 156" .
-            """.TrimEnd());
+            """));
     }
 }


### PR DESCRIPTION
This commit broke tests:

https://github.com/digirati-co-uk/digital-preservation/commit/2ef62a5994549bc8327e4600c075bd1fab97e915#diff-4516a27dc0a8884746de5f08062f838c164643a1e90191d30a29c4976fcbb9b2

Fix:

Compares RDF with expected RDF as line strings rather than whole blocks of quoted RDF

More robust wrt whitespace and line endings.