### PR TITLE
Allow logical-only access condition inheritance

### DIFF
--- a/docs/effective-metadata-inheritance.md
+++ b/docs/effective-metadata-inheritance.md
@@ -1,0 +1,207 @@
+# Effective Metadata Inheritance
+
+This document describes how `EffectiveAccessRestrictions`, `EffectiveRightsStatement`, and
+`EffectiveRecordInfo` are computed for physical files, physical directories, and logical ranges
+by `MetsParser`. These are the values used downstream — by the IIIF builder, by access-control
+checks, and by deposit validation.
+
+See `EffectiveMetadataInheritanceTests` for unit tests of each rule.
+
+---
+
+## Background: METS structure
+
+A METS file has two structMaps that matter here:
+
+- **Physical structMap** (`TYPE="PHYSICAL"`): mirrors the deposit's actual directory layout.
+  Every file has a physical `div`, and every directory has a physical `div`. Access conditions
+  and record identifiers that are "about" the file as a physical object live here, attached via
+  `DMDID` to a MODS descriptor.
+
+- **Logical structMap** (`TYPE="LOGICAL"`): describes the *archival* structure — how the
+  archivist conceptually groups the content (interviews, chapters, items, sub-series). A logical
+  `div` (called a "logical range" in this codebase) represents an archival entity and may
+  reference files either as whole-file `fptr` elements, as time-segment or image-region `area`
+  elements, or (in Goobi METS) via a separate `structLink` section.
+
+---
+
+## Inheritance chains
+
+### Physical files — Access Restrictions
+
+| Step | Source | Condition |
+|------|--------|-----------|
+| A1 | File's own DMDID (`accessCondition type="restriction on access"`) | Own value present |
+| A2 | Walk up the physical directory tree | Parent or ancestor has a value |
+| A3 | *(physical always beats logical — A4 is only reached if A1+A2 yield nothing)* | |
+| A4a | The file's single whole-file fptr logical range | Physical silent; file in exactly **one** range via fptr |
+| A4b | The file's deepest structLink-associated logical range | Physical silent; Goobi smLink mapping exists |
+| A5 | `[]` (empty list) | No source found — **validation warning** |
+
+**Physical takes precedence (A3).** If the physical tree has any access value — even inherited
+from a grandparent directory — the logical structure is ignored entirely. Logical access is
+a fallback of last resort, not an override.
+
+**The "exactly one range" condition (A4a).** A file may appear in multiple logical ranges
+(e.g. the same page image used by two chapters). If those ranges have different access
+conditions there is no safe answer, so the fallback is skipped and the file gets empty access
+(A5). This is a data-quality problem that should be surfaced by validation.
+
+**A5 is a warning state.** A file with empty effective access in a deposit where other files
+have access declared is almost certainly a mistake — either a file was accidentally omitted
+from a logical range, or the physical root was cleared without ensuring full logical coverage.
+The Deposit UI should warn on this condition when any other file in the deposit has access set.
+
+### Physical files — Rights Statement
+
+| Step | Source | Condition |
+|------|--------|-----------|
+| 1 | File's own DMDID (`accessCondition type="use and reproduction"`) | Own value present, or div had the element even if empty/invalid |
+| 2 | Walk up the physical directory tree | Parent or ancestor has a value |
+| 3 | The file's single whole-file fptr logical range | Physical silent; file in exactly one range via fptr |
+| 4 | `null` | No source found |
+
+Rights follow the same physical-first, logical-fallback logic as access. The "explicit null"
+edge case (step 1): if a file's physical div has a `use and reproduction` element with an
+unrecognised or empty value, the file's own (null) rights are used rather than inheriting —
+the explicit presence of the element is treated as an intentional override.
+
+### Physical files — Record Info
+
+| Step | Source | Condition |
+|------|--------|-----------|
+| R1 | File's own DMDID (`recordInfo`) | Own value present |
+| R2 | The file's single whole-file fptr logical range (effective) | File in exactly **one** range via fptr (no `area`) |
+| R3 | *(falls through if referenced by area, or by multiple whole-file fptrs)* | |
+| R4 | structLink-associated logical range | Goobi smLink mapping exists |
+| R5 | Walk up the physical directory tree | |
+
+Record info uses logical inheritance **ahead** of the physical tree walk (unlike access/rights,
+where the physical tree always comes first). The reason: a file's RecordInfo identifies the
+archival entity the file *represents* — for a single-interview recording, the logical range
+IS the catalogue record. For a tape side that spans multiple interviews, no single range can
+claim it, so the fallback to physical (`objects/` → collection identifier) is correct.
+
+**Area references (R3).** A `mets:area` element refers to only *part* of a file (a time
+segment or image region). A file referenced only via area elements cannot belong to a
+single archival entity as a whole, so the logical inheritance step is skipped.
+
+---
+
+## Physical directories
+
+Directories inherit values by simple upward walk:
+
+- `EffectiveAccessRestrictions`: own value if present, else parent's effective value.
+- `EffectiveRightsStatement`: own value if present, else parent's effective value.
+- `EffectiveRecordInfo`: own value if present, else parent's effective value.
+
+There is no logical fallback for directories.
+
+---
+
+## Logical ranges
+
+A logical range represents an archival entity (e.g. an interview, a digitised item, a
+sub-series). Its effective access and rights describe the access policy for that entity —
+used when building IIIF manifests, and as the fallback source when files' physical trees
+are silent (rules A4a and step 3 for rights above).
+
+| Value | Source |
+|-------|--------|
+| Access | Own explicit value, else `DMD_PHYS_ROOT` access (the physical structMap root div) |
+| Rights | Own explicit value, else `DMD_PHYS_ROOT` rights |
+| RecordInfo | Own explicit value, else parent logical range's effective RecordInfo |
+
+**Why `DMD_PHYS_ROOT` and not `objects/`?** `objects/` is a physical layout convention —
+it tells you where files live on disk, not what collection they belong to. `DMD_PHYS_ROOT`
+is the collection-level descriptor, which is the appropriate default for a logical entity
+that has no more specific access declared. Logical ranges do **not** inherit from `objects/`
+or any other intermediate physical directory.
+
+---
+
+## Common patterns
+
+### Leeds standard (access on objects/)
+
+All files are Open. Access is declared once on `objects/`.
+
+```
+Physical: __ROOT → objects/ [Level1, InC] → file1, file2, ...
+Logical:  range → fptr→file1   (inherits RecordInfo from range)
+```
+
+`file1.EffectiveAccessRestrictions` = `["Level1"]` via A2 (physical walk).  
+`file1.EffectiveRecordInfo` = range's RecordInfo via R2 (single fptr range).
+
+### Women of Westminster (per-file physical access override)
+
+Most files are Open (`objects/`), but one file is Closed (own physical DMDID).
+
+```
+Physical: objects/ [Level1] → amber-rudd.m4a, angela-eagle.m4a [Closed]
+Logical:  Amber Rudd range → fptr→amber-rudd.m4a
+          (angela-eagle.m4a absent from logical map)
+```
+
+`amber-rudd.m4a.EffectiveAccessRestrictions` = `["Level1"]` via A2.  
+`angela-eagle.m4a.EffectiveAccessRestrictions` = `["Closed"]` via A1 (own value wins).  
+`angela-eagle.m4a.EffectiveRecordInfo` = `objects/` RecordInfo via R5 (not in logical map).
+
+### Liddle tapes (area references, no per-file record info)
+
+Each WAV file spans multiple interviews. Logical ranges use `mets:area` time segments.
+
+```
+Physical: objects/ [Level1, collection RecordInfo] → tape1.wav, tape2.wav
+Logical:  Interview A → area(tape1.wav 00:00–00:35)
+          Interview B → area(tape1.wav 00:35–01:10)
+```
+
+`tape1.wav.EffectiveRecordInfo` = `objects/` RecordInfo via R5 (area refs skip R2).
+
+### Goobi METS (structLink, access in logical DMDs)
+
+Physical tree has no access. Logical divs declare access. `structLink` connects them.
+
+```
+Physical:  PHYS_0001, PHYS_0002 (no access anywhere)
+Logical:   LOG_0000 [Open] → smLink→PHYS_0001
+           LOG_0001 [Restricted] → smLink→PHYS_0002
+structLink: LOG_0000→PHYS_0001, LOG_0001→PHYS_0002
+```
+
+`file-in-PHYS_0001.EffectiveAccessRestrictions` = `["Open"]` via A4b (structLink deepest-only).
+
+### Leeds-native logical access (fptr, physical silent)
+
+100 files. No access on `objects/`. All access declared in logical ranges, every file
+covered by exactly one range.
+
+```
+Physical: objects/ [no access] → file1...file90, file91...file100
+Logical:  "Open" range  [dlip-open]   → fptr→file1 ... fptr→file90
+          "Closed" range [dlip-4-closed] → fptr→file91 ... fptr→file100
+```
+
+`file1.EffectiveAccessRestrictions` = `["dlip-open"]` via A4a (single fptr range, physical silent).  
+`file91.EffectiveAccessRestrictions` = `["dlip-4-closed"]` via A4a.
+
+**Risk:** if `file101` is added to the deposit but forgotten in the logical map, it gets
+empty effective access (A5) with no safety net. The Deposit UI must warn on this condition.
+
+---
+
+## Impact on existing behaviour
+
+The fptr-based access/rights fallback (A4a) is a new code path added alongside the existing
+structLink fallback (A4b). It can only trigger when the entire physical tree from file to
+root has no access condition. All existing Leeds-native deposits set access on `objects/` or
+on individual file divs, so A4a is never reached in those deposits — **no existing behaviour
+changes**.
+
+The only way to reach A4a is to deliberately remove all access from the physical tree and
+rely entirely on logical ranges. This is a conscious authoring decision and is exactly the
+scenario `leeds-mets-version.xml` is designed to test.

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -1192,22 +1192,34 @@ public class MetsParser(
         Dictionary<string, LogicalRange> fileToAssociatedRange,
         HashSet<string> filesWithExplicitRights)
     {
-        // Access: own → physical parent → logical range (when physical parent has nothing)
+        // Access: own → physical parent → exactly-one whole-file fptr range → smLink-associated range → []
+        // Physical parent always takes precedence; logical is fallback only when the physical tree is silent.
         if (file.AccessRestrictions is { Count: > 0 })
             file.EffectiveAccessRestrictions = file.AccessRestrictions;
         else if (parentAccess.Count > 0)
             file.EffectiveAccessRestrictions = parentAccess;
+        else if (fileToWholeFileRanges.TryGetValue(file.LocalPath, out var wholeRangesForAccess)
+                 && wholeRangesForAccess.Count == 1
+                 && wholeRangesForAccess[0].EffectiveAccessRestrictions.Count > 0)
+            file.EffectiveAccessRestrictions = wholeRangesForAccess[0].EffectiveAccessRestrictions;
         else if (fileToAssociatedRange.TryGetValue(file.LocalPath, out var assocForAccess)
                  && assocForAccess.EffectiveAccessRestrictions.Count > 0)
             file.EffectiveAccessRestrictions = assocForAccess.EffectiveAccessRestrictions;
         else
             file.EffectiveAccessRestrictions = [];
 
+        // Rights: own/explicit → physical parent → exactly-one whole-file fptr range → null
         // If the div had an explicit use-and-reproduction element (even with an invalid value like "null(?)"),
-        // use the file's own rights (which may be null) rather than inheriting from the physical parent.
-        file.EffectiveRightsStatement = (file.RightsStatement != null || filesWithExplicitRights.Contains(file.LocalPath))
-            ? file.RightsStatement
-            : parentRights;
+        // use the file's own rights (which may be null) rather than inheriting.
+        if (file.RightsStatement != null || filesWithExplicitRights.Contains(file.LocalPath))
+            file.EffectiveRightsStatement = file.RightsStatement;
+        else if (parentRights != null)
+            file.EffectiveRightsStatement = parentRights;
+        else if (fileToWholeFileRanges.TryGetValue(file.LocalPath, out var wholeRangesForRights)
+                 && wholeRangesForRights.Count == 1)
+            file.EffectiveRightsStatement = wholeRangesForRights[0].EffectiveRightsStatement;
+        else
+            file.EffectiveRightsStatement = null;
 
         // RecordInfo: own → exactly-one whole-file logical range (effective) → smLink-associated range → physical parent
         if (file.RecordInfo != null)

--- a/src/DigitalPreservation/XmlGen.Tests/Parsing/EffectiveMetadataInheritanceTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Parsing/EffectiveMetadataInheritanceTests.cs
@@ -9,25 +9,32 @@ namespace XmlGen.Tests.Parsing;
 /// Inheritance rules (from comments in XmlGen.Tests.Experimental.Parsing):
 ///
 ///   Access / Rights (physical files and directories):
-///     - Use the resource's own explicit value if present.
-///     - Otherwise walk up the physical directory tree until a parent has the value.
-///     - The physical tree always takes precedence: logical structure cannot override physical access.
-///     - If the physical tree yields nothing (no access anywhere from file up to root), fall back to
-///       the file's logical assignment — deepest structLink range (Goobi), or single whole-file fptr
-///       range (Leeds-native). This handles third-party METS where access lives only in logical DMDs.
+///     - (A1) Use the resource's own explicit value if present.
+///     - (A2) Otherwise walk up the physical directory tree until a parent has the value.
+///     - (A3) Physical takes precedence: logical structure cannot override physical access/rights.
+///     - (A4) If the physical tree yields nothing, fall back to the file's logical assignment:
+///              * exactly-one whole-file fptr range (Leeds-native fptr linkage), or
+///              * deepest structLink-associated range (Goobi smLink linkage).
+///            This handles METS where access lives entirely in logical DMDs.
+///     - (A5) If none of the above yields a value, effective access is empty / rights is null.
+///            Files in this state should be surfaced as a validation warning.
 ///
 ///   RecordInfo (physical files):
-///     - Use the resource's own explicit value if present.
-///     - Otherwise, if the file is referenced as a WHOLE-FILE fptr (no mets:area) in exactly
-///       one logical range, inherit that range's RecordInfo.
-///     - If referenced only via mets:area (time segment or image region), or in multiple ranges,
-///       fall back to the physical tree.
-///     - Otherwise walk up the physical directory tree.
+///     - (R1) Use the resource's own explicit value if present.
+///     - (R2) Otherwise, if referenced as a WHOLE-FILE fptr (no mets:area) in exactly one logical
+///            range, inherit that range's effective RecordInfo.
+///     - (R3) If referenced only via mets:area, or as a whole-file fptr in multiple ranges,
+///            fall back to the physical tree.
+///     - (R4) Otherwise walk up the physical directory tree.
 ///
-///   Logical ranges (EffectiveAccessRestrictions / EffectiveRightsStatement):
-///     - Use the range's own explicit value if present.
-///     - Otherwise inherit only from the physical structMap root div (DMDID="DMD_PHYS_ROOT").
-///     - They do NOT inherit from the objects/ directory or other physical divs.
+///   Logical ranges (EffectiveAccessRestrictions / EffectiveRightsStatement / EffectiveRecordInfo):
+///     - A logical range represents an archival entity (interview, item, sub-series).
+///       Its effective access/rights describe the access policy for that entity — used
+///       when building IIIF manifests, and as the source for file access inheritance when
+///       the physical tree is silent (rule A4 above).
+///     - Access/rights: own explicit value, else inherit from DMD_PHYS_ROOT only.
+///       Objects/ and other physical directories do NOT propagate to logical ranges.
+///     - RecordInfo: own explicit value, else inherit from the parent logical range.
 /// 
 /// </summary>
 public class EffectiveMetadataInheritanceTests : MetsParserTestBase
@@ -1033,6 +1040,719 @@ public class EffectiveMetadataInheritanceTests : MetsParserTestBase
         // RecordInfo is explicitly on the range, so effective == direct
         range.EffectiveRecordInfo.Should().NotBeNull();
         range.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("ITEM/001");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PHYSICAL ACCESS / RIGHTS: MULTI-LEVEL TREE WALK
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void File_inherits_access_through_multiple_physical_directory_levels()
+    {
+        // Access is set on objects/, not on the intermediate sub-directory or the file.
+        // Rule A2: walk all the way up until a parent has a value.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_objects">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">Level1</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/sub/deep.txt">
+                <mets:techMD ID="TECH_objects/sub/deep.txt">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_deep" MIMETYPE="text/plain">
+                    <mets:FLocat xlink:href="objects/sub/deep.txt"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects" DMDID="DMD_objects">
+                  <mets:div ID="PHYS_objects/sub" TYPE="Directory" LABEL="sub">
+                    <!-- No DMDID on sub/ — no own access condition -->
+                    <mets:div ID="PHYS_objects/sub/deep.txt" TYPE="Item" ADMID="ADM_objects/sub/deep.txt">
+                      <mets:fptr FILEID="FILE_deep"/>
+                    </mets:div>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/sub/deep.txt");
+        file.AccessRestrictions.Should().BeNull();
+        file.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("Level1");
+    }
+
+    [Fact]
+    public void Sub_directory_inherits_EffectiveAccessRestrictions_from_parent_directory()
+    {
+        // A directory with no own access condition should inherit from its parent.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_objects">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">Level1</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/sub/x.txt">
+                <mets:techMD ID="TECH_objects/sub/x.txt">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_x" MIMETYPE="text/plain">
+                    <mets:FLocat xlink:href="objects/sub/x.txt"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects" DMDID="DMD_objects">
+                  <mets:div ID="PHYS_objects/sub" TYPE="Directory" LABEL="sub">
+                    <mets:div ID="PHYS_objects/sub/x.txt" TYPE="Item" ADMID="ADM_objects/sub/x.txt">
+                      <mets:fptr FILEID="FILE_x"/>
+                    </mets:div>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var sub = mets.PhysicalStructure!.Directories[0].Directories[0];
+        sub.AccessRestrictions.Should().BeNull();
+        sub.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("Level1");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PHYSICAL ACCESS / RIGHTS: LOGICAL FALLBACK (A4)
+    // The scenarios below only trigger the logical fallback because the physical
+    // tree is entirely silent on access — no access condition on objects/ or any
+    // ancestor.  This is the "Leeds-native logical access" pattern: all access
+    // is declared in logical DMDs, with every file covered by exactly one range.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void File_with_whole_file_fptr_in_exactly_one_range_inherits_access_when_physical_is_silent()
+    {
+        // Rule A4 (fptr path): physical tree has no access at all; file is in exactly one
+        // logical range which declares the access.  Mirrors the leeds-mets-version.xml scenario.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_LOG_open">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-open</mods:accessCondition>
+                      <mods:accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/doc.pdf">
+                <mets:techMD ID="TECH_objects/doc.pdf">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_doc" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/doc.pdf"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects">
+                  <!-- No DMDID: objects/ has no access condition -->
+                  <mets:div ID="PHYS_objects/doc.pdf" TYPE="Item" ADMID="ADM_objects/doc.pdf">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Collection">
+                  <mets:div ID="LOG_open" TYPE="Item" DMDID="DMD_LOG_open">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/doc.pdf");
+
+        // Physical tree is silent — effective access and rights come from the single logical range
+        file.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("dlip-open");
+        file.EffectiveRightsStatement.Should().Be(new Uri("http://rightsstatements.org/vocab/InC/1.0/"));
+    }
+
+    [Fact]
+    public void Physical_access_takes_precedence_over_logical_range_access()
+    {
+        // Rule A3: physical always beats logical, even when the file has a whole-file fptr
+        // in a logical range.  The range's access is irrelevant once the physical tree has
+        // a value.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_objects">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">Level1</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_open">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-open</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/doc.pdf">
+                <mets:techMD ID="TECH_objects/doc.pdf">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_doc" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/doc.pdf"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects" DMDID="DMD_objects">
+                  <mets:div ID="PHYS_objects/doc.pdf" TYPE="Item" ADMID="ADM_objects/doc.pdf">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Collection">
+                  <mets:div ID="LOG_open" TYPE="Item" DMDID="DMD_LOG_open">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/doc.pdf");
+
+        // Physical objects/ has "Level1" — this wins; the logical "dlip-open" is ignored
+        file.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("Level1");
+    }
+
+    [Fact]
+    public void File_in_multiple_logical_ranges_gets_empty_access_when_physical_is_silent()
+    {
+        // Rule A4: ambiguity — file is a whole-file fptr in two ranges with different access.
+        // "Exactly one range" condition is not met, so the logical fallback is skipped.
+        // Rule A5: effective access is empty (validation warning territory).
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_LOG_open">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-open</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_closed">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-4-closed</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/doc.pdf">
+                <mets:techMD ID="TECH_objects/doc.pdf">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_doc" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/doc.pdf"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects">
+                  <!-- No DMDID: objects/ has no access condition -->
+                  <mets:div ID="PHYS_objects/doc.pdf" TYPE="Item" ADMID="ADM_objects/doc.pdf">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Collection">
+                  <mets:div ID="LOG_open" TYPE="Item" DMDID="DMD_LOG_open">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                  <mets:div ID="LOG_closed" TYPE="Item" DMDID="DMD_LOG_closed">
+                    <mets:fptr FILEID="FILE_doc"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/doc.pdf");
+
+        // Ambiguous: two ranges claim the file with different access — falls through to empty
+        file.EffectiveAccessRestrictions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void File_not_covered_by_any_logical_range_gets_empty_access_when_physical_is_silent()
+    {
+        // Rule A5: physical tree is silent and the file appears in no logical range.
+        // This is the "validation warning" case — the METS is structurally valid but
+        // the file has no derivable access.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_LOG_open">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-open</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/covered.pdf">
+                <mets:techMD ID="TECH_objects/covered.pdf">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>111</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:amdSec ID="ADM_objects/orphan.pdf">
+                <mets:techMD ID="TECH_objects/orphan.pdf">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>222</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_covered" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/covered.pdf"/>
+                  </mets:file>
+                  <mets:file ID="FILE_orphan" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/orphan.pdf"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects">
+                  <!-- No DMDID: objects/ has no access condition -->
+                  <mets:div ID="PHYS_objects/covered.pdf" TYPE="Item" ADMID="ADM_objects/covered.pdf">
+                    <mets:fptr FILEID="FILE_covered"/>
+                  </mets:div>
+                  <mets:div ID="PHYS_objects/orphan.pdf" TYPE="Item" ADMID="ADM_objects/orphan.pdf">
+                    <mets:fptr FILEID="FILE_orphan"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Collection">
+                  <mets:div ID="LOG_open" TYPE="Item" DMDID="DMD_LOG_open">
+                    <mets:fptr FILEID="FILE_covered"/>
+                    <!-- FILE_orphan deliberately omitted — simulates the author forgetting a file -->
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var covered = mets.Files.Single(f => f.LocalPath == "objects/covered.pdf");
+        var orphan  = mets.Files.Single(f => f.LocalPath == "objects/orphan.pdf");
+
+        covered.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("dlip-open");
+        orphan.EffectiveAccessRestrictions.Should().BeEmpty();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RECORD INFO: OWN VALUE AND MULTIPLE-RANGE CASES
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void File_own_RecordInfo_takes_precedence_over_logical_range()
+    {
+        // Rule R1: a file's own explicit RecordInfo beats the logical range it belongs to.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_objects/file.wav">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:recordInfo>
+                        <mods:recordIdentifier source="EMu">OWN/001</mods:recordIdentifier>
+                      </mods:recordInfo>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_range">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:recordInfo>
+                        <mods:recordIdentifier source="EMu">RANGE/001</mods:recordIdentifier>
+                      </mods:recordInfo>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/file.wav">
+                <mets:techMD ID="TECH_objects/file.wav">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_wav" MIMETYPE="audio/x-wav">
+                    <mets:FLocat xlink:href="objects/file.wav"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects">
+                  <mets:div ID="PHYS_objects/file.wav" TYPE="Item"
+                            DMDID="DMD_objects/file.wav" ADMID="ADM_objects/file.wav">
+                    <mets:fptr FILEID="FILE_wav"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="C">
+                  <mets:div ID="LOG_range" TYPE="Item" DMDID="DMD_LOG_range">
+                    <mets:fptr FILEID="FILE_wav"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/file.wav");
+        file.RecordInfo.Should().NotBeNull();
+        file.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("OWN/001");
+    }
+
+    [Fact]
+    public void File_in_multiple_whole_file_fptr_ranges_falls_back_to_physical_RecordInfo()
+    {
+        // Rule R3: file is a whole-file fptr in two different logical ranges.
+        // "Exactly one range" condition not met → falls back to physical objects/.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_objects">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:recordInfo>
+                        <mods:recordIdentifier source="EMu">COLL/001</mods:recordIdentifier>
+                      </mods:recordInfo>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_A">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:recordInfo>
+                        <mods:recordIdentifier source="EMu">ITEM/A</mods:recordIdentifier>
+                      </mods:recordInfo>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_B">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:recordInfo>
+                        <mods:recordIdentifier source="EMu">ITEM/B</mods:recordIdentifier>
+                      </mods:recordInfo>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/shared.wav">
+                <mets:techMD ID="TECH_objects/shared.wav">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_shared" MIMETYPE="audio/x-wav">
+                    <mets:FLocat xlink:href="objects/shared.wav"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_objects" TYPE="Directory" LABEL="objects" DMDID="DMD_objects">
+                  <mets:div ID="PHYS_objects/shared.wav" TYPE="Item" ADMID="ADM_objects/shared.wav">
+                    <mets:fptr FILEID="FILE_shared"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Coll">
+                  <mets:div ID="LOG_A" TYPE="Item" DMDID="DMD_LOG_A">
+                    <mets:fptr FILEID="FILE_shared"/>
+                  </mets:div>
+                  <mets:div ID="LOG_B" TYPE="Item" DMDID="DMD_LOG_B">
+                    <mets:fptr FILEID="FILE_shared"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/shared.wav");
+
+        // Two whole-file fptr ranges — ambiguous, falls back to physical objects/
+        file.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("COLL/001");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // LOGICAL RANGE EFFECTIVE VALUES: OWN VALUE BEATS DMD_PHYS_ROOT
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Logical_range_own_access_overrides_DMD_PHYS_ROOT_access()
+    {
+        // Even when DMD_PHYS_ROOT has an access condition, a logical range with its own
+        // explicit access should use that value rather than inheriting from DMD_PHYS_ROOT.
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3"
+                       xmlns:mods="http://www.loc.gov/mods/v3">
+              <mets:dmdSec ID="DMD_PHYS_ROOT">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">ClosedCollection</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:dmdSec ID="DMD_LOG_0001">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">dlip-open</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_objects/f.txt">
+                <mets:techMD ID="TECH_objects/f.txt">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>abc</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_f" MIMETYPE="text/plain">
+                    <mets:FLocat xlink:href="objects/f.txt"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ID="PHYS_ROOT" TYPE="Directory" LABEL="__ROOT" DMDID="DMD_PHYS_ROOT">
+                  <mets:div ID="PHYS_objects/f.txt" TYPE="Item" ADMID="ADM_objects/f.txt">
+                    <mets:fptr FILEID="FILE_f"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+              <mets:structMap TYPE="LOGICAL">
+                <mets:div TYPE="Collection" LABEL="Coll">
+                  <mets:div ID="LOG_0001" TYPE="Item" DMDID="DMD_LOG_0001">
+                    <mets:fptr FILEID="FILE_f"/>
+                  </mets:div>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var range = mets.LogicalStructures[0].Ranges[0];
+        range.AccessRestrictions.Should().ContainSingle().Which.Should().Be("dlip-open");
+
+        // Range's own value beats the DMD_PHYS_ROOT fallback
+        range.EffectiveAccessRestrictions.Should().ContainSingle().Which.Should().Be("dlip-open");
     }
 
     [Fact]


### PR DESCRIPTION
This is a PR to the complex METS branch, not to `main`.

It relaxes a previous inheritance rule to allow Leeds to assign access conditions via logical structmap, ONLY if there is no access restrictions on the physical structure.

The documentation page [docs/effective-metadata-inheritance.md](https://github.com/digirati-co-uk/digital-preservation/compare/experimental/complex-mets-partial...experimental/access-inheritance?expand=1#diff-5b2bd2d898708cfd76adb8916884421c96eaa6270e7a97947e70857d2d383eb2) and the unit tests [src/DigitalPreservation/XmlGen.Tests/Parsing/EffectiveMetadataInheritanceTests.cs](https://github.com/digirati-co-uk/digital-preservation/compare/experimental/complex-mets-partial...experimental/access-inheritance?expand=1#diff-c910b7e245c3c5b6c0b0c681f183d0c80cd4a589c86015116367383031bb5732) demonstrate the behaviours.