### PR TITLE
Fix/lpii 133/still issue with import job

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -113,7 +113,7 @@ public class MetsParser(
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Unable to Load Mets File");
+                logger.LogError(e, $"Unable to Load Mets File (file URI: {file.AbsoluteUri}) at location {metsLocation} due to error {e.Message}");
                 return Result.FailNotNull<MetsFileWrapper>(ErrorCodes.UnknownError, e.Message);
             }
         }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -146,6 +146,7 @@ public class MetsParser(
             }
             mets.Editable = mets.Agent == Constants.MetsCreatorAgent;
         }
+        logger.LogInformation("Mets {mets}", mets);
         return Result.OkNotNull(mets);
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -113,7 +113,7 @@ public class MetsParser(
             }
             catch (Exception e)
             {
-                logger.LogError(e, $"Unable to Load Mets File (file URI: {file.AbsoluteUri}) at location {metsLocation} due to error {e.Message}");
+                logger.LogError(e, "Unable to Load Mets File (file URI: {FileUri}) at location {MetsLocation}", file.AbsoluteUri, metsLocation);
                 return Result.FailNotNull<MetsFileWrapper>(ErrorCodes.UnknownError, e.Message);
             }
         }
@@ -146,7 +146,6 @@ public class MetsParser(
             }
             mets.Editable = mets.Agent == Constants.MetsCreatorAgent;
         }
-        logger.LogInformation("Mets {mets}", mets);
         return Result.OkNotNull(mets);
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/CreateFolder.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/CreateFolder.cs
@@ -80,7 +80,15 @@ public class CreateFolderHandler(
             var dirForMets = request.IsBagItLayout ? dir.ToRootLayout() : dir;
             if (newRootResult.Success)
             {
-                await metsManager.HandleCreateFolder(request.RootUri, dirForMets, request.MetsETag);
+                // Previously this result was discarded and the method always returned Ok(dir) here,
+                // regardless of whether the METS write actually succeeded - e.g. an ETag mismatch
+                // (PreconditionFailed) would silently leave the S3 folder marker created but the METS
+                // entry missing, with the caller told the call succeeded. See LPII-133.
+                var metsResult = await metsManager.HandleCreateFolder(request.RootUri, dirForMets, request.MetsETag);
+                if (metsResult.Failure)
+                {
+                    return Result.Generify<WorkingDirectory?>(metsResult);
+                }
                 return Result.Ok(dir);
             }
             return Result.Generify<WorkingDirectory?>(newRootResult);

--- a/src/DigitalPreservation/Preservation.API.Tests/Workspace/CreateFolderHandlerTests.cs
+++ b/src/DigitalPreservation/Preservation.API.Tests/Workspace/CreateFolderHandlerTests.cs
@@ -1,0 +1,78 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Workspace.Requests;
+using FakeItEasy;
+using Storage.Repository.Common;
+
+namespace Preservation.API.Tests.Workspace;
+
+public class CreateFolderHandlerTests
+{
+    private readonly IAmazonS3 s3Client = A.Fake<IAmazonS3>();
+    private readonly IStorage storage = A.Fake<IStorage>();
+    private readonly IMetsManager metsManager = A.Fake<IMetsManager>();
+    private readonly CreateFolderHandler handler;
+
+    public CreateFolderHandlerTests()
+    {
+        handler = new CreateFolderHandler(s3Client, storage, metsManager);
+
+        A.CallTo(() => s3Client.PutObjectAsync(A<PutObjectRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(Task.FromResult(new PutObjectResponse { HttpStatusCode = System.Net.HttpStatusCode.Created }));
+
+        A.CallTo(() => s3Client.GetObjectMetadataAsync(A<GetObjectMetadataRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(Task.FromResult(new GetObjectMetadataResponse { LastModified = DateTime.UtcNow }));
+
+        A.CallTo(() => storage.AddToDepositFileSystem(A<Uri>.Ignored, A<WorkingDirectory>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(Task.FromResult(Result.OkNotNull(new WorkingDirectory { LocalPath = "", Name = "root", Modified = DateTime.UtcNow })));
+    }
+
+    // LPII-133: CreateFolderHandler used to discard HandleCreateFolder's result and always return
+    // Result.Ok(dir) regardless, so an ETag mismatch (PreconditionFailed) on the METS write left the S3
+    // folder marker created but the METS entry silently missing - the caller was told the call succeeded.
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenMetsWriteFails()
+    {
+        A.CallTo(() => metsManager.HandleCreateFolder(A<Uri>.Ignored, A<WorkingDirectory>.Ignored, A<string>.Ignored))
+            .Returns(Task.FromResult(Result.Fail(ErrorCodes.PreconditionFailed, "Supplied ETag did not match METS")));
+
+        var request = new CreateFolder(
+            isBagItLayout: false,
+            rootUri: new Uri("s3://bucket/deposits/dep123/"),
+            name: "metadata",
+            newFolderSlug: "metadata",
+            parent: null,
+            metsETag: "stale-etag");
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        result.Failure.Should().BeTrue();
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.PreconditionFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuccess_WhenMetsWriteSucceeds()
+    {
+        A.CallTo(() => metsManager.HandleCreateFolder(A<Uri>.Ignored, A<WorkingDirectory>.Ignored, A<string>.Ignored))
+            .Returns(Task.FromResult(Result.Ok()));
+
+        var request = new CreateFolder(
+            isBagItLayout: false,
+            rootUri: new Uri("s3://bucket/deposits/dep123/"),
+            name: "metadata",
+            newFolderSlug: "metadata",
+            parent: null,
+            metsETag: "current-etag");
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Name.Should().Be("metadata");
+    }
+}

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -180,7 +180,9 @@ public class CreateDepositBase(
             var wrapperResult = await metsParser.GetMetsFileWrapper(createdDeposit.Files!);
 
             var editable = wrapperResult?.Value?.Editable;
+            var agent = wrapperResult?.Value?.Agent;
             logger.LogInformation("METS is editable: {editable}", editable);
+            logger.LogInformation("METS agent name: {agentName}", agent);
 
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -209,6 +209,7 @@ public class CreateDepositBase(
                     var result = await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
 
                     logger.LogInformation("Creating Metadata folder in mets result success: {resultSuccess}", result.Success);
+                    logger.LogInformation("Creating Metadata folder in mets result message: {resultSuccess}", result.CodeAndMessage());
                 }
 
                 var metadataAdhocFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
@@ -221,6 +222,7 @@ public class CreateDepositBase(
                     var result = await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
 
                     logger.LogInformation("Creating Metadata ad-hoc folder in mets result success: {resultSuccess}", result.Success);
+                    logger.LogInformation("Creating Metadata ad-hoc folder in mets result message: {resultSuccess}", result.CodeAndMessage());
                 }
             }
 

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -7,7 +7,6 @@ using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Core.Auth;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Workspace;
-using DigitalPreservation.XmlGen.Mets;
 using LeedsDlipServices.Identity;
 using Preservation.API.Data;
 using Preservation.API.Mutation;
@@ -84,10 +83,14 @@ public class CreateDepositBase(
             var callerIdentity = request.Principal.GetCallerIdentity();
             logger.LogInformation("Identity service gave us deposit Id: " + mintedId);
 
-            var createMetadataFolders = await ShouldCreateMetadataFolders(
-                archivalGroupExists, storageMapForExport, request.Deposit.ArchivalGroup, request.Deposit.VersionExported);
-
-            logger.LogInformation("create metadata folders boolean: {createMetadataFolders}", createMetadataFolders);
+            // For a deposit against an existing Archival Group, the AG's own (exported) content
+            // defines the deposit's content - including whether it has metadata/ad-hoc folders.
+            // Scaffolding them here unconditionally caused a bug (LPII-133): for an export, the AG's
+            // METS arrives asynchronously and isn't present yet, so the matching "add these folders to
+            // METS" step below silently skips (see the Editable check), leaving the folders present in
+            // S3 but absent from METS. GetDepositBase reconciles this once the export has finished and
+            // the real METS is available (see the wasExportingAndNowFinished branch there).
+            var createMetadataFolders = archivalGroupExists is not true;
 
             var filesLocation = await storage.GetWorkingFilesLocation(
                 mintedId, request.Deposit.Template, callerIdentity, createMetadataFolders);
@@ -179,49 +182,19 @@ public class CreateDepositBase(
 
             var wrapperResult = await metsParser.GetMetsFileWrapper(createdDeposit.Files!);
 
-            logger.LogInformation("Created Deposit files {depositFiles} which is a URI", createdDeposit.Files!);
-            
-            logger.LogInformation("wrapper result {wrapperResultSuccess}", wrapperResult.Success);
-            logger.LogInformation("wrapper result value {wrapperResult}", wrapperResult.Value);
-
-            var editable = wrapperResult?.Value?.Editable;
-            var agent = wrapperResult?.Value?.Agent;
-            logger.LogInformation("METS is editable: {editable}", editable);
-            logger.LogInformation("METS agent name: {agentName}", agent);
-
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder
-            // would fail internally (GetFullMets returns NotFound / BadRequest).
-            if (wrapperResult.Value.Editable || createMetadataFolders) //if (wrapperResult.Value is { Editable: true } metsWrapper)
+            // would fail internally (GetFullMets returns NotFound / BadRequest). For an export whose METS
+            // hasn't arrived yet, wrapperResult.Value will be non-editable (or absent) here regardless of
+            // createMetadataFolders - that's fine, since createMetadataFolders is now false for exports and
+            // GetDepositBase performs the equivalent reconciliation once the real METS has arrived.
+            if (wrapperResult.Value is { Editable: true } metsWrapper)
             {
-                var metsWrapper = wrapperResult.Value;
-                logger.LogInformation("Create folders");
+                if (metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) == null)
+                    await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
 
-                var metadataFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
-
-                logger.LogInformation("Metadata folder exists: {metadataFolderExists}", metadataFolderExists);
-
-                if (!metadataFolderExists)
-                {
-                    logger.LogInformation("Creating Metadata folder in mets");
-                    var result = await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
-
-                    logger.LogInformation("Creating Metadata folder in mets result success: {resultSuccess}", result.Success);
-                    logger.LogInformation("Creating Metadata folder in mets result message: {resultSuccess}", result.CodeAndMessage());
-                }
-
-                var metadataAdhocFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
-
-                logger.LogInformation("Metadata adhoc folder exists: {metadataAdHocFolderExists}", metadataAdhocFolderExists);
-
-                if (!metadataAdhocFolderExists)
-                {
-                    logger.LogInformation("Creating Metadata ad-hoc folder in mets");
-                    var result = await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
-
-                    logger.LogInformation("Creating Metadata ad-hoc folder in mets result success: {resultSuccess}", result.Success);
-                    logger.LogInformation("Creating Metadata ad-hoc folder in mets result message: {resultSuccess}", result.CodeAndMessage());
-                }
+                if (metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) == null)
+                    await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
             }
 
             if (!request.Export)
@@ -376,67 +349,7 @@ public class CreateDepositBase(
         return Result.Ok();
     }
 
-    private async Task<bool> ShouldCreateMetadataFolders(
-        bool? archivalGroupExists, StorageMap? storageMapForExport, Uri? archivalGroup, string? version)
-    {
-        if (archivalGroupExists is not true)
-            return true;
-
-        var storageMap = storageMapForExport;
-        if (storageMap is null && archivalGroup is not null)
-        {
-            var smResult = await storageApiClient.GetStorageMap(archivalGroup.GetPathUnderRoot()!, version);
-            if (smResult is { Success: true, Value: not null })
-                storageMap = smResult.Value;
-        }
-
-        if (storageMap is null)
-            return true;
-
-        // Keys in storageMap.Files are logical paths within the AG (e.g. "mets.xml")
-        var metsFileKey = storageMap.Files.Keys.FirstOrDefault(k => MetsUtils.IsMetsFile(k));
-        if (metsFileKey is null)
-            return true;
-
-        // Fetch METS via the Storage API (which has access to the Fedora bucket) rather than
-        // accessing OCFL S3 directly (the Preservation API's S3 client cannot read that bucket).
-        var metsPath = archivalGroup!.AbsolutePath + "/" + metsFileKey;
-        logger.LogInformation("Checking existing AG METS editability via Storage API at {metsPath}", metsPath);
-
-        var streamResult = await storageApiClient.GetBinaryStream(metsPath);
-        if (streamResult is not { Success: true, Value: not null })
-        {
-            logger.LogWarning("Unable to retrieve existing AG METS to check editability, defaulting to creating metadata folders");
-            return true;
-        }
-
-        System.Xml.Linq.XDocument xDoc;
-        try
-        {
-            xDoc = await System.Xml.Linq.XDocument.LoadAsync(
-                streamResult.Value, System.Xml.Linq.LoadOptions.None, CancellationToken.None);
-        }
-        catch (Exception e)
-        {
-            logger.LogWarning(e, "Unable to parse existing AG METS to check editability, defaulting to creating metadata folders");
-            return true;
-        }
-
-        var metsUri = new Uri(archivalGroup, metsFileKey);
-        var metsWrapperResult = metsParser.GetMetsFileWrapperFromXDocument(metsUri, xDoc);
-        if (metsWrapperResult is not { Success: true, Value: not null })
-        {
-            logger.LogWarning("Unable to determine existing AG METS editability, defaulting to creating metadata folders");
-            return true;
-        }
-
-        var editable = metsWrapperResult.Value.Editable;
-        logger.LogInformation("Existing AG METS editable: {editable}, metadata folders will{notStr} be created",
-            editable, editable ? "" : " not");
-        return editable;
-    }
-
-    private async Task<Result> CreateFolderInMets(string pathName, string folderName, Deposit deposit)
+    private async Task CreateFolderInMets(string pathName, string folderName, Deposit deposit)
     {
         var dir = new WorkingDirectory
         {
@@ -447,9 +360,7 @@ public class CreateDepositBase(
 
         var dirForMets = deposit.Template == TemplateType.BagIt ? dir.ToRootLayout() : dir;
 
-        logger.LogInformation("Directory for METS {deposit.MetsETag!}", deposit.MetsETag!);
-
-        return await metsManager.HandleCreateFolder(deposit.Files!, dirForMets, deposit.MetsETag!);
+        await metsManager.HandleCreateFolder(deposit.Files!, dirForMets, deposit.MetsETag!);
     }
 
 }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -206,7 +206,9 @@ public class CreateDepositBase(
                 if (!metadataFolderExists)
                 {
                     logger.LogInformation("Creating Metadata folder in mets");
-                    await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
+                    var result = await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
+
+                    logger.LogInformation("Creating Metadata folder in mets result success: {resultSuccess}", result.Success);
                 }
 
                 var metadataAdhocFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
@@ -216,7 +218,9 @@ public class CreateDepositBase(
                 if (!metadataAdhocFolderExists)
                 {
                     logger.LogInformation("Creating Metadata ad-hoc folder in mets");
-                    await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
+                    var result = await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
+
+                    logger.LogInformation("Creating Metadata ad-hoc folder in mets result success: {resultSuccess}", result.Success);
                 }
             }
 
@@ -432,7 +436,7 @@ public class CreateDepositBase(
         return editable;
     }
 
-    private async Task CreateFolderInMets(string pathName, string folderName, Deposit deposit)
+    private async Task<Result> CreateFolderInMets(string pathName, string folderName, Deposit deposit)
     {
         var dir = new WorkingDirectory
         {

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -179,6 +179,8 @@ public class CreateDepositBase(
 
             var wrapperResult = await metsParser.GetMetsFileWrapper(createdDeposit.Files!);
 
+            logger.LogInformation("Created Deposit files {depositFiles} which is a URI", createdDeposit.Files!);
+            
             logger.LogInformation("wrapper result {wrapperResult}", wrapperResult);
             logger.LogInformation("wrapper result value {wrapperResult}", wrapperResult.Value);
 

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -383,14 +383,37 @@ public class CreateDepositBase(
         if (storageMap is null)
             return true;
 
-        var metsOriginFile = storageMap.Files.Values.FirstOrDefault(f => MetsUtils.IsMetsFile(f.FullPath));
-        if (metsOriginFile is null)
+        // Keys in storageMap.Files are logical paths within the AG (e.g. "mets.xml")
+        var metsFileKey = storageMap.Files.Keys.FirstOrDefault(k => MetsUtils.IsMetsFile(k));
+        if (metsFileKey is null)
             return true;
 
-        var metsS3Uri = new Uri($"s3://{storageMap.Root}/{storageMap.ObjectPath}/{metsOriginFile.FullPath}");
-        logger.LogInformation("Checking existing AG METS editability at {metsUri}", metsS3Uri);
+        // Fetch METS via the Storage API (which has access to the Fedora bucket) rather than
+        // accessing OCFL S3 directly (the Preservation API's S3 client cannot read that bucket).
+        var metsPath = archivalGroup!.AbsolutePath + "/" + metsFileKey;
+        logger.LogInformation("Checking existing AG METS editability via Storage API at {metsPath}", metsPath);
 
-        var metsWrapperResult = await metsParser.GetMetsFileWrapper(metsS3Uri);
+        var streamResult = await storageApiClient.GetBinaryStream(metsPath);
+        if (streamResult is not { Success: true, Value: not null })
+        {
+            logger.LogWarning("Unable to retrieve existing AG METS to check editability, defaulting to creating metadata folders");
+            return true;
+        }
+
+        System.Xml.Linq.XDocument xDoc;
+        try
+        {
+            xDoc = await System.Xml.Linq.XDocument.LoadAsync(
+                streamResult.Value, System.Xml.Linq.LoadOptions.None, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Unable to parse existing AG METS to check editability, defaulting to creating metadata folders");
+            return true;
+        }
+
+        var metsUri = new Uri(archivalGroup, metsFileKey);
+        var metsWrapperResult = metsParser.GetMetsFileWrapperFromXDocument(metsUri, xDoc);
         if (metsWrapperResult is not { Success: true, Value: not null })
         {
             logger.LogWarning("Unable to determine existing AG METS editability, defaulting to creating metadata folders");

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -179,6 +179,9 @@ public class CreateDepositBase(
 
             var wrapperResult = await metsParser.GetMetsFileWrapper(createdDeposit.Files!);
 
+            logger.LogInformation("wrapper result {wrapperResult}", wrapperResult);
+            logger.LogInformation("wrapper result value {wrapperResult}", wrapperResult.Value);
+
             var editable = wrapperResult?.Value?.Editable;
             var agent = wrapperResult?.Value?.Agent;
             logger.LogInformation("METS is editable: {editable}", editable);

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -189,12 +189,12 @@ public class CreateDepositBase(
             logger.LogInformation("METS is editable: {editable}", editable);
             logger.LogInformation("METS agent name: {agentName}", agent);
 
-            
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder
             // would fail internally (GetFullMets returns NotFound / BadRequest).
-            if (wrapperResult.Value is { Editable: true } metsWrapper)
+            if (wrapperResult.Value.Editable || createMetadataFolders) //if (wrapperResult.Value is { Editable: true } metsWrapper)
             {
+                var metsWrapper = wrapperResult.Value;
                 logger.LogInformation("Create folders");
 
                 var metadataFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -7,6 +7,7 @@ using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Core.Auth;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Workspace;
+using DigitalPreservation.XmlGen.Mets;
 using LeedsDlipServices.Identity;
 using Preservation.API.Data;
 using Preservation.API.Mutation;
@@ -82,8 +83,12 @@ public class CreateDepositBase(
             var mintedId = identityService.MintIdentity(nameof(Deposit));
             var callerIdentity = request.Principal.GetCallerIdentity();
             logger.LogInformation("Identity service gave us deposit Id: " + mintedId);
+
+            var createMetadataFolders = await ShouldCreateMetadataFolders(
+                archivalGroupExists, storageMapForExport, request.Deposit.ArchivalGroup, request.Deposit.VersionExported);
+
             var filesLocation = await storage.GetWorkingFilesLocation(
-                mintedId, request.Deposit.Template, callerIdentity);
+                mintedId, request.Deposit.Template, callerIdentity, createMetadataFolders);
             if (filesLocation.Failure)
             {
                 logger.LogError("Unable to create GetWorkingFilesLocation for deposit " + mintedId + "; " + filesLocation.CodeAndMessage());
@@ -195,6 +200,14 @@ public class CreateDepositBase(
 
                 if (!metadataAdhocFolderExists)
                     await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
+            }
+            else
+            {
+                var metsWrapperResult = wrapperResult?.Value;
+                var metadataFolderExists = metsWrapperResult.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
+
+                //TODO: check if metadata and/or ad-hoc folder was created - check s3
+                //TODO: DELETE ad-hoc or metadata/ad-hoc folders if they exist and METS is not editable? But we don't know if it's a third-party METS or not, so we can't know if it should be deleted. For now, just leave them alone. 
             }
 
 
@@ -349,6 +362,43 @@ public class CreateDepositBase(
         logger.LogInformation("Ensure METS concludes no METS file should be created.");
 
         return Result.Ok();
+    }
+
+    private async Task<bool> ShouldCreateMetadataFolders(
+        bool? archivalGroupExists, StorageMap? storageMapForExport, Uri? archivalGroup, string? version)
+    {
+        if (archivalGroupExists is not true)
+            return true;
+
+        var storageMap = storageMapForExport;
+        if (storageMap is null && archivalGroup is not null)
+        {
+            var smResult = await storageApiClient.GetStorageMap(archivalGroup.GetPathUnderRoot()!, version);
+            if (smResult is { Success: true, Value: not null })
+                storageMap = smResult.Value;
+        }
+
+        if (storageMap is null)
+            return true;
+
+        var metsOriginFile = storageMap.Files.Values.FirstOrDefault(f => MetsUtils.IsMetsFile(f.FullPath));
+        if (metsOriginFile is null)
+            return true;
+
+        var metsS3Uri = new Uri($"s3://{storageMap.Root}/{storageMap.ObjectPath}/{metsOriginFile.FullPath}");
+        logger.LogInformation("Checking existing AG METS editability at {metsUri}", metsS3Uri);
+
+        var metsWrapperResult = await metsParser.GetMetsFileWrapper(metsS3Uri);
+        if (metsWrapperResult is not { Success: true, Value: not null })
+        {
+            logger.LogWarning("Unable to determine existing AG METS editability, defaulting to creating metadata folders");
+            return true;
+        }
+
+        var editable = metsWrapperResult.Value.Editable;
+        logger.LogInformation("Existing AG METS editable: {editable}, metadata folders will{notStr} be created",
+            editable, editable ? "" : " not");
+        return editable;
     }
 
     private async Task CreateFolderInMets(string pathName, string folderName, Deposit deposit)

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -181,7 +181,7 @@ public class CreateDepositBase(
 
             logger.LogInformation("Created Deposit files {depositFiles} which is a URI", createdDeposit.Files!);
             
-            logger.LogInformation("wrapper result {wrapperResult}", wrapperResult);
+            logger.LogInformation("wrapper result {wrapperResultSuccess}", wrapperResult.Success);
             logger.LogInformation("wrapper result value {wrapperResult}", wrapperResult.Value);
 
             var editable = wrapperResult?.Value?.Editable;

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -189,37 +189,36 @@ public class CreateDepositBase(
             logger.LogInformation("METS is editable: {editable}", editable);
             logger.LogInformation("METS agent name: {agentName}", agent);
 
+            
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder
             // would fail internally (GetFullMets returns NotFound / BadRequest).
-            if (wrapperResult.Value is { Editable: true } metsWrapper)
+            if ((editable.HasValue && editable.Value) || createMetadataFolders)
             {
+                var metsWrapper = wrapperResult?.Value;
+
                 logger.LogInformation("Create folders");
 
-                var metadataFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
+                var metadataFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
 
                 logger.LogInformation("Metadata folder exists: {metadataFolderExists}", metadataFolderExists);
 
                 if (!metadataFolderExists)
+                {
+                    logger.LogInformation("Creating Metadata folder in mets");
                     await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
+                }
 
-                var metadataAdhocFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
+                var metadataAdhocFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
 
                 logger.LogInformation("Metadata adhoc folder exists: {metadataAdHocFolderExists}", metadataAdhocFolderExists);
 
                 if (!metadataAdhocFolderExists)
+                {
+                    logger.LogInformation("Creating Metadata ad-hoc folder in mets");
                     await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
+                }
             }
-            else
-            {
-                var metsWrapperResult = wrapperResult?.Value;
-                var metadataFolderExists = metsWrapperResult.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
-
-                //TODO: check if metadata and/or ad-hoc folder was created - check s3
-                //TODO: DELETE ad-hoc or metadata/ad-hoc folders if they exist and METS is not editable? But we don't know if it's a third-party METS or not, so we can't know if it should be deleted. For now, just leave them alone. 
-            }
-
-
 
             if (!request.Export)
             {

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -447,7 +447,7 @@ public class CreateDepositBase(
 
         var dirForMets = deposit.Template == TemplateType.BagIt ? dir.ToRootLayout() : dir;
 
-        await metsManager.HandleCreateFolder(deposit.Files!, dirForMets, deposit.MetsETag!);
+        return await metsManager.HandleCreateFolder(deposit.Files!, dirForMets, deposit.MetsETag!);
     }
 
 }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -193,13 +193,11 @@ public class CreateDepositBase(
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder
             // would fail internally (GetFullMets returns NotFound / BadRequest).
-            if ((editable.HasValue && editable.Value) || createMetadataFolders)
+            if (wrapperResult.Value is { Editable: true } metsWrapper)
             {
-                var metsWrapper = wrapperResult?.Value;
-
                 logger.LogInformation("Create folders");
 
-                var metadataFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
+                var metadataFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
 
                 logger.LogInformation("Metadata folder exists: {metadataFolderExists}", metadataFolderExists);
 
@@ -212,7 +210,7 @@ public class CreateDepositBase(
                     logger.LogInformation("Creating Metadata folder in mets result message: {resultSuccess}", result.CodeAndMessage());
                 }
 
-                var metadataAdhocFolderExists = metsWrapper?.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
+                var metadataAdhocFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
 
                 logger.LogInformation("Metadata adhoc folder exists: {metadataAdHocFolderExists}", metadataAdhocFolderExists);
 
@@ -448,6 +446,8 @@ public class CreateDepositBase(
         };
 
         var dirForMets = deposit.Template == TemplateType.BagIt ? dir.ToRootLayout() : dir;
+
+        logger.LogInformation("Directory for METS {deposit.MetsETag!}", deposit.MetsETag!);
 
         return await metsManager.HandleCreateFolder(deposit.Files!, dirForMets, deposit.MetsETag!);
     }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -87,6 +87,8 @@ public class CreateDepositBase(
             var createMetadataFolders = await ShouldCreateMetadataFolders(
                 archivalGroupExists, storageMapForExport, request.Deposit.ArchivalGroup, request.Deposit.VersionExported);
 
+            logger.LogInformation("create metadata folders boolean: {createMetadataFolders}", createMetadataFolders);
+
             var filesLocation = await storage.GetWorkingFilesLocation(
                 mintedId, request.Deposit.Template, callerIdentity, createMetadataFolders);
             if (filesLocation.Failure)

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/CreateDepositBase.cs
@@ -172,17 +172,32 @@ public class CreateDepositBase(
 
             var wrapperResult = await metsParser.GetMetsFileWrapper(createdDeposit.Files!);
 
+            var editable = wrapperResult?.Value?.Editable;
+            logger.LogInformation("METS is editable: {editable}", editable);
+
             // Only ensure the metadata/ad-hoc folders when there is a METS file we created and can edit.
             // For template=None or third-party METS there is nothing to write to, and HandleCreateFolder
             // would fail internally (GetFullMets returns NotFound / BadRequest).
             if (wrapperResult.Value is { Editable: true } metsWrapper)
             {
-                if (metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) == null)
+                logger.LogInformation("Create folders");
+
+                var metadataFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.Metadata) != null;
+
+                logger.LogInformation("Metadata folder exists: {metadataFolderExists}", metadataFolderExists);
+
+                if (!metadataFolderExists)
                     await CreateFolderInMets(FolderNames.Metadata, FolderNames.Metadata, createdDeposit);
 
-                if (metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) == null)
+                var metadataAdhocFolderExists = metsWrapper.PhysicalStructure!.FindDirectory(FolderNames.MetadataAdHoc) != null;
+
+                logger.LogInformation("Metadata adhoc folder exists: {metadataAdHocFolderExists}", metadataAdhocFolderExists);
+
+                if (!metadataAdhocFolderExists)
                     await CreateFolderInMets(FolderNames.MetadataAdHoc, FolderNames.AdHoc, createdDeposit);
             }
+
+
 
             if (!request.Export)
             {

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposit.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposit.cs
@@ -20,8 +20,8 @@ public class GetDepositHandler(
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
-    WorkspaceManagerFactory workspaceManagerFactory) : 
-        GetDepositBase(logger, dbContext, storageApiClient, resourceMutator, workspaceManagerFactory), 
+    WorkspaceManagerFactory workspaceManagerFactory) :
+        GetDepositBase(logger, dbContext, storageApiClient, resourceMutator, workspaceManagerFactory, metsParser),
         IRequestHandler<GetDeposit, Result<Deposit?>>
 {
     public async Task<Result<Deposit?>> Handle(GetDeposit request, CancellationToken cancellationToken)

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
@@ -1,6 +1,8 @@
 ﻿using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.PreservationApi;
 using DigitalPreservation.Common.Model.Results;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
 using DigitalPreservation.Workspace;
 using Microsoft.EntityFrameworkCore;
 using Preservation.API.Data;
@@ -14,7 +16,8 @@ public class GetDepositBase(
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
-    WorkspaceManagerFactory workspaceManagerFactory)
+    WorkspaceManagerFactory workspaceManagerFactory,
+    IMetsParser metsParser)
 {
     public async Task<Result<Deposit?>> GetDeposit(string depositId, CancellationToken cancellationToken)
     {
@@ -64,7 +67,8 @@ public class GetDepositBase(
 
                 if (wasExportingAndNowFinished)
                 {
-                    await workspaceManagerFactory.CreateAsync(deposit, refresh: true);
+                    var workspaceManager = await workspaceManagerFactory.CreateAsync(deposit, refresh: true);
+                    await EnsureMetadataFoldersAfterExport(depositId, deposit, workspaceManager);
                 }
                 return Result.Ok(deposit);
             }
@@ -74,6 +78,59 @@ public class GetDepositBase(
         {
             logger.LogError(e, e.Message);
             return Result.Fail<Deposit?>(ErrorCodes.UnknownError, $"Deposit {depositId} error: {e.Message}");
+        }
+    }
+
+    // LPII-133: a deposit created against an existing Archival Group with Export=true gets its METS
+    // asynchronously, via the export - CreateDepositBase's own "add metadata/ad-hoc folders to METS" step
+    // runs before that export completes, so it can't act on a METS that isn't there yet, and
+    // CreateDepositBase deliberately no longer scaffolds those folders in S3 for this case either (see the
+    // comment there - doing so unconditionally is what caused the folders to end up in S3 but never in
+    // METS, the original bug). This reconciles them once the export has actually finished and the deposit's
+    // real METS - and its true Editable/Agent status - is known. Only applies where that METS is ours to
+    // edit; for a third-party METS there's nothing to reconcile, matching CreateDepositBase's own check.
+    private async Task EnsureMetadataFoldersAfterExport(string depositId, Deposit deposit, WorkspaceManager workspaceManager)
+    {
+        var wrapperResult = await metsParser.GetMetsFileWrapper(deposit.Files!);
+        if (wrapperResult is not { Success: true, Value.Editable: true, Value.PhysicalStructure: not null })
+        {
+            return;
+        }
+
+        var physicalStructure = wrapperResult.Value!.PhysicalStructure!;
+        var needsMetadata = physicalStructure.FindDirectory(FolderNames.Metadata) is null;
+        var needsAdHoc = physicalStructure.FindDirectory(FolderNames.MetadataAdHoc) is null;
+        if (!needsMetadata && !needsAdHoc)
+        {
+            return;
+        }
+
+        // Use the ETag from the METS we just fetched, not whatever the deposit entity happened to carry -
+        // CreateFolder writes the S3 folder marker, the deposit file-system cache, and the METS entry
+        // together (unlike calling HandleCreateFolder alone, which is METS-only and would reintroduce the
+        // same kind of S3/METS mismatch this method exists to fix), and the METS write is ETag-guarded.
+        deposit.MetsETag = wrapperResult.Value.ETag;
+
+        if (needsMetadata)
+        {
+            var result = await workspaceManager.CreateFolder(FolderNames.Metadata, null, false, null, refreshDirectory: true);
+            if (result.Failure)
+            {
+                logger.LogWarning(
+                    "Unable to reconcile missing metadata folder for deposit {DepositId} after export: {Message}",
+                    depositId, result.CodeAndMessage());
+            }
+        }
+
+        if (needsAdHoc)
+        {
+            var result = await workspaceManager.CreateFolder(FolderNames.AdHoc, FolderNames.Metadata, false, null, refreshDirectory: true);
+            if (result.Failure)
+            {
+                logger.LogWarning(
+                    "Unable to reconcile missing metadata/ad-hoc folder for deposit {DepositId} after export: {Message}",
+                    depositId, result.CodeAndMessage());
+            }
         }
     }
 }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
@@ -111,6 +111,11 @@ public class GetDepositBase(
         // same kind of S3/METS mismatch this method exists to fix), and the METS write is ETag-guarded.
         deposit.MetsETag = wrapperResult.Value.ETag;
 
+        // callerIdentity: null is intentional on both calls below - this reconciliation is a system action
+        // triggered by an Exporting -> New status transition, not a user-initiated edit, so it should
+        // proceed regardless of who (if anyone) currently holds the deposit's edit lock. CreateFolder's
+        // lock check (GetOtherLockOwner) only blocks when callerIdentity is non-empty, so passing null
+        // deliberately bypasses it.
         if (needsMetadata)
         {
             var result = await workspaceManager.CreateFolder(FolderNames.Metadata, null, false, null, refreshDirectory: true);
@@ -119,6 +124,20 @@ public class GetDepositBase(
                 logger.LogWarning(
                     "Unable to reconcile missing metadata folder for deposit {DepositId} after export: {Message}",
                     depositId, result.CodeAndMessage());
+            }
+        }
+
+        if (needsMetadata && needsAdHoc)
+        {
+            // The metadata write above changed the METS file's own S3 ETag - CreateFolder is ETag-guarded
+            // (it passes deposit.MetsETag through to GetFullMets as eTagToMatch), so reusing the ETag
+            // fetched before that write would make this second call fail its precondition check. Re-fetch
+            // just the ETag (parse: false - we already know Editable and which folders are missing, no
+            // need to re-parse the whole METS) before the ad-hoc write.
+            var refreshedWrapperResult = await metsParser.GetMetsFileWrapper(deposit.Files!, parse: false);
+            if (refreshedWrapperResult is { Success: true, Value: not null })
+            {
+                deposit.MetsETag = refreshedWrapperResult.Value.ETag;
             }
         }
 

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositWithMets.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositWithMets.cs
@@ -20,8 +20,8 @@ public class GetDepositWithMetsHandler(
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
-    WorkspaceManagerFactory workspaceManagerFactory) : 
-        GetDepositBase(logger, dbContext, storageApiClient, resourceMutator, workspaceManagerFactory), 
+    WorkspaceManagerFactory workspaceManagerFactory) :
+        GetDepositBase(logger, dbContext, storageApiClient, resourceMutator, workspaceManagerFactory, metsParser),
         IRequestHandler<GetDepositWithMets, Result<DepositWithMets>>
 {
     public async Task<Result<DepositWithMets>> Handle(GetDepositWithMets request, CancellationToken cancellationToken)

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/Requests/GetDiffImportJob.cs
@@ -172,10 +172,28 @@ public class GetDiffImportJobHandler(
         foreach (var container in sourceContainers)
         {
             var relativeLocalPath = container.Id!.LocalPath.RemoveStart(agLocalPathWithSlash)!.UnEscapePathElementsNoHashes();
-            var metsDirectory = combined.FindDirectory(relativeLocalPath)?.DirectoryInMets; 
-            
+            var combinedDirectory = combined.FindDirectory(relativeLocalPath);
+            var metsDirectory = combinedDirectory?.DirectoryInMets;
+
             if (metsDirectory is null)
             {
+                // LPII-133: a folder can legitimately exist on the deposit's filesystem side with no
+                // corresponding METS entry - e.g. a metadata/ad-hoc scaffold folder on a deposit cloned
+                // from an Archival Group whose own preserved METS predates that folder, or is third-party
+                // and not ours to edit (CreateDepositBase/GetDepositBase deliberately do not force such
+                // folders into a METS we can't/shouldn't write to). If the folder - and everything beneath
+                // it - is empty, there's no preservable payload being silently dropped by leaving it
+                // unlisted in METS, so skip it rather than failing the whole diff. A folder that does
+                // contain real content but is genuinely missing from METS is still a real problem and
+                // continues to fail below - this only relaxes the check for the no-payload case.
+                if (combinedDirectory is null || !HasAnyDescendantFile(combinedDirectory))
+                {
+                    logger.LogInformation(
+                        "Folder {relativeLocalPath} has no corresponding METS entry but is empty; skipping rather than failing the diff",
+                        relativeLocalPath);
+                    continue;
+                }
+
                 var message = $"Could not find folder {relativeLocalPath} in METS file.";
                 logger.LogWarning(message);
                 return Result.FailNotNull<ImportJob>(ErrorCodes.Unprocessable, message);
@@ -248,7 +266,12 @@ public class GetDiffImportJobHandler(
         logger.LogInformation("Diff Import Job created: " + importJob.LogSummary());
         return Result.OkNotNull(importJob);
     }
-    
+
+    private static bool HasAnyDescendantFile(CombinedDirectory directory)
+    {
+        return directory.Files.Count > 0 || directory.Directories.Any(HasAnyDescendantFile);
+    }
+
     
     private void PopulateDiffTasks(
         CombinedDirectory combined,

--- a/src/DigitalPreservation/Storage.API.Tests/S3/StorageTests.cs
+++ b/src/DigitalPreservation/Storage.API.Tests/S3/StorageTests.cs
@@ -143,6 +143,77 @@ public class StorageTests
 
 
     [Fact]
+    public void GetWorkingFilesLocation_SkipsMetadataFolders_WhenCreateMetadataFoldersFalse()
+    {
+        // LPII-133: for a deposit against an existing Archival Group, CreateDepositBase passes
+        // createMetadataFolders=false so the metadata/ad-hoc folders aren't scaffolded in S3 ahead of
+        // the (possibly historic/third-party) METS that arrives later via export.
+        var expectedPath = @"C:\temp\working";
+        A.CallTo(() => options.Value).Returns(new AwsStorageOptions
+        {
+            DefaultWorkingBucket = expectedPath
+        });
+
+        A.CallTo(() => s3Client.GetObjectAsync(
+                A<GetObjectRequest>.Ignored, CancellationToken.None))
+            .Throws(new AmazonS3Exception("Not found")
+            {
+                ErrorCode = "NotFound",
+                StatusCode = HttpStatusCode.NotFound
+            });
+
+        var putRequests = new List<PutObjectRequest>();
+        A.CallTo(() => s3Client.PutObjectAsync(A<PutObjectRequest>.Ignored, CancellationToken.None))
+            .Invokes((PutObjectRequest req, CancellationToken _) => putRequests.Add(req))
+            .Returns(Task.FromResult(new PutObjectResponse
+            {
+                HttpStatusCode = HttpStatusCode.Created,
+            }));
+
+        var idPart = "testId";
+        var resultTask = storage.GetWorkingFilesLocation(idPart, TemplateType.RootLevel, null, createMetadataFolders: false);
+        var result = resultTask.GetAwaiter().GetResult();
+
+        result.Success.Should().BeTrue();
+        putRequests.Should().NotContain(r => r.Key.Contains("metadata"));
+        putRequests.Should().Contain(r => r.Key.EndsWith("objects/"));
+    }
+
+    [Fact]
+    public void GetWorkingFilesLocation_CreatesMetadataFolders_WhenCreateMetadataFoldersTrue()
+    {
+        var expectedPath = @"C:\temp\working";
+        A.CallTo(() => options.Value).Returns(new AwsStorageOptions
+        {
+            DefaultWorkingBucket = expectedPath
+        });
+
+        A.CallTo(() => s3Client.GetObjectAsync(
+                A<GetObjectRequest>.Ignored, CancellationToken.None))
+            .Throws(new AmazonS3Exception("Not found")
+            {
+                ErrorCode = "NotFound",
+                StatusCode = HttpStatusCode.NotFound
+            });
+
+        var putRequests = new List<PutObjectRequest>();
+        A.CallTo(() => s3Client.PutObjectAsync(A<PutObjectRequest>.Ignored, CancellationToken.None))
+            .Invokes((PutObjectRequest req, CancellationToken _) => putRequests.Add(req))
+            .Returns(Task.FromResult(new PutObjectResponse
+            {
+                HttpStatusCode = HttpStatusCode.Created,
+            }));
+
+        var idPart = "testId";
+        var resultTask = storage.GetWorkingFilesLocation(idPart, TemplateType.RootLevel, null, createMetadataFolders: true);
+        var result = resultTask.GetAwaiter().GetResult();
+
+        result.Success.Should().BeTrue();
+        putRequests.Should().Contain(r => r.Key.EndsWith("metadata/"));
+        putRequests.Should().Contain(r => r.Key.EndsWith("metadata/ad-hoc/"));
+    }
+
+    [Fact]
     public async Task GetListing()
     {
         A.CallTo(() => s3Client.ListObjectsV2Async(

--- a/src/DigitalPreservation/Storage.Repository.Common/IStorage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/IStorage.cs
@@ -6,7 +6,7 @@ namespace Storage.Repository.Common;
 
 public interface IStorage
 {
-    Task<Result<Uri>> GetWorkingFilesLocation(string idPart, TemplateType templateType, string? callerIdentity = null);
+    Task<Result<Uri>> GetWorkingFilesLocation(string idPart, TemplateType templateType, string? callerIdentity = null, bool createMetadataFolders = true);
     Task<ConnectivityCheckResult> CanSeeStorage(string source);
     
     /// <summary>

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/StorageImpl/S3MetsStorage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/StorageImpl/S3MetsStorage.cs
@@ -64,10 +64,10 @@ public class S3MetsStorage(
         DigitalPreservation.XmlGen.Mets.Mets? mets = null;
         string? returnedETag;
         var fileLocResult = await metsParser.GetRootAndFile(metsLocation);
-        var (_, file) = fileLocResult.Value;
+        var (root, file) = fileLocResult.Value;
         if (file is null)
         {
-            return Result.FailNotNull<FullMets>(ErrorCodes.NotFound, "No METS file in " + metsLocation);
+            return Result.FailNotNull<FullMets>(ErrorCodes.NotFound, "No METS file in " + metsLocation + " root location: " + root);
         }
 
         var s3Uri = new AmazonS3Uri(file);

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -21,7 +21,7 @@ public class Storage(
 {
     private readonly AwsStorageOptions options = options.Value;
 
-    public async Task<Result<Uri>> GetWorkingFilesLocation(string idPart, TemplateType templateType, string? callerIdentity = null)
+    public async Task<Result<Uri>> GetWorkingFilesLocation(string idPart, TemplateType templateType, string? callerIdentity = null, bool createMetadataFolders = true)
     {
         // This will be able to yield different locations in different buckets for different callers
         // e.g., Goobi
@@ -43,17 +43,23 @@ public class Storage(
             {
                 case TemplateType.RootLevel:
                     await PutDirectory(FolderNames.Objects, key, root);
-                    var metadataDirRoot = await PutDirectory(FolderNames.Metadata, key, root);
-                    await PutDirectory(FolderNames.AdHoc, key + metadataDirRoot.Name + "/", metadataDirRoot);
+                    if (createMetadataFolders)
+                    {
+                        var metadataDirRoot = await PutDirectory(FolderNames.Metadata, key, root);
+                        await PutDirectory(FolderNames.AdHoc, key + metadataDirRoot.Name + "/", metadataDirRoot);
+                    }
                     break;
                 case TemplateType.BagIt:
                 {
                     var dataDir = await PutDirectory(FolderNames.BagItData, key, root);
                     var dataKey = $"{key}{FolderNames.BagItData}/";
                     await PutDirectory(FolderNames.Objects, dataKey, dataDir);
-                    var metadataDir = await PutDirectory(FolderNames.Metadata, dataKey, dataDir);
-                    await PutDirectory(FolderNames.AdHoc, dataKey + metadataDir.Name + "/", metadataDir);
-                        break;
+                    if (createMetadataFolders)
+                    {
+                        var metadataDir = await PutDirectory(FolderNames.Metadata, dataKey, dataDir);
+                        await PutDirectory(FolderNames.AdHoc, dataKey + metadataDir.Name + "/", metadataDir);
+                    }
+                    break;
                 }
             }
             var depositFileSystemKey = key + IStorage.DepositFileSystem;


### PR DESCRIPTION
Ticket: https://digirati.atlassian.net/browse/LPII-133
If the METS in the Archival Group deposit is non-editable then do not add the metadata and/or ad-hoc folder as it will cause an issue with the Import Job. I have noticed the issue with import job occurs if you add a file in objects in S3 and refresh storage on a deposit created from an archival Group with a non-editable METS.