### PR TITLE
Fix/lpii 135/make pipeline more performant

### DIFF
--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -28,14 +28,36 @@ RUN apt-get install golang -y
 RUN go install github.com/richardlehane/siegfried/cmd/sf@v1.11.2
 RUN cp /root/go/bin/sf /bin
 RUN sf -update
-#brunnhilde    
+#brunnhilde
 RUN apt-get install python3-full python3-pip -y
 RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN pip3 install --upgrade brunnhilde
 RUN brunnhilde.py -V
 #clam av
-RUN apt-get install clamav clamav-freshclam -y 
+RUN apt-get install clamav clamav-freshclam clamav-daemon util-linux -y
 RUN freshclam
+
+# Debian's clamav-daemon/clamav-freshclam ship an "Example" line in both config files that blocks
+# either from starting until it's removed.
+RUN sed -i '/^Example/d' /etc/clamav/clamd.conf /etc/clamav/freshclam.conf
+
+# Point clamd at the socket path clamscan-shim.sh expects, and make it connectable by the app's
+# non-root user (setpriv-dropped in pipeline-api-entrypoint.sh) - this socket never leaves the
+# container's own namespace, so a permissive local socket mode is an acceptable tradeoff here.
+# Debian's package already ships a working LocalSocket/LocalSocketMode pair near the top of the
+# file - clamd honors the FIRST occurrence of a directive, so these must replace it in place
+# rather than append a second, conflicting pair that gets silently ignored.
+RUN sed -i 's#^LocalSocket .*#LocalSocket /var/run/clamav/clamd.sock#' /etc/clamav/clamd.conf
+RUN sed -i 's#^LocalSocketMode .*#LocalSocketMode 666#' /etc/clamav/clamd.conf
+
+# Brunnhilde always invokes the literal "clamscan" binary with no way to configure it - shadow the
+# real clamscan with a shim that instead talks to clamd running as a second process in this same
+# container (started by pipeline-api-entrypoint.sh), avoiding the signature-database reload cost
+# clamscan otherwise pays on every single invocation. Falls back to a local scan if clamd isn't
+# up yet/crashed.
+RUN mv /usr/bin/clamscan /usr/bin/clamscan.real
+COPY clamscan-shim.sh /usr/bin/clamscan
+RUN chmod +x /usr/bin/clamscan
 # Exif Tool for metadata extraction
 RUN apt-get install -y exiftool
 
@@ -58,5 +80,9 @@ LABEL org.opencontainers.image.description="UoL DLIP Pipeline API"
 
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER $APP_UID
-ENTRYPOINT ["dotnet", "Pipeline.API.dll"]
+
+# Stays root at container start (not $APP_UID) because the entrypoint needs root to launch clamd -
+# it drops to $APP_UID itself via setpriv before exec'ing the actual .NET process.
+COPY pipeline-api-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -27,7 +27,15 @@ RUN apt-get update -y
 RUN apt-get install golang -y
 RUN go install github.com/richardlehane/siegfried/cmd/sf@v1.11.2
 RUN cp /root/go/bin/sf /bin
+
+# Siegfried resolves its signature file relative to the invoking user's home directory (no shared
+# location, no config to override this from Brunnhilde's own "sf -update"/"sf -version" calls) -
+# the app runs as the non-root $APP_UID at runtime, so downloading signatures as root here would
+# leave them undiscoverable at runtime (Brunnhilde's own pre-flight "sf -version" check would then
+# fail and report "Siegfried is not installed or available on PATH").
+USER $APP_UID
 RUN sf -update
+USER root
 #brunnhilde
 RUN apt-get install python3-full python3-pip -y
 RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED

--- a/clamscan-shim.sh
+++ b/clamscan-shim.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Brunnhilde invokes the literal "clamscan" command with no way to configure it - this shim
+# shadows the real clamscan binary (moved aside to clamscan.real during the image build, see
+# Dockerfile.PipelineApi) and redirects to the clamd daemon running on the EC2 host, reached via
+# the Unix socket bind-mounted into this container at /var/run/clamav/clamd.sock. This avoids
+# clamscan reloading the entire virus signature database from disk on every single pipeline job
+# run.
+#
+# clamdscan does not accept --max-scansize/--max-filesize per invocation the way clamscan does -
+# those limits are configured as MaxScanSize/MaxFileSize in the host's clamd.conf instead, so
+# strip them here rather than letting clamdscan reject the call outright.
+
+set -euo pipefail
+
+SOCKET="${CLAMD_SOCKET:-/var/run/clamav/clamd.sock}"
+
+if [ ! -S "$SOCKET" ]; then
+    echo "clamscan shim: $SOCKET not found, falling back to a local clamscan scan" >&2
+    exec /usr/bin/clamscan.real "$@"
+fi
+
+args=()
+for arg in "$@"; do
+    case "$arg" in
+        --max-scansize=*|--max-filesize=*)
+            continue
+            ;;
+        *)
+            args+=("$arg")
+            ;;
+    esac
+done
+
+# clamdscan has no --socket flag - it reads LocalSocket from a config file via --config-file,
+# so point it at the real clamd.conf (which already has LocalSocket set to $SOCKET) instead.
+#
+# -m/--multiscan tells clamd to scan multiple files in the directory concurrently across
+# MaxThreads worker threads, instead of one file at a time. Measured on a real 2796-file/37GB
+# deposit: 21m21s single-threaded vs 6m53s with multiscan (~3.1x on 4 cores) - the dominant cost
+# for a large deposit is scan throughput across many files, which multiscan directly parallelizes.
+exec clamdscan --config-file=/etc/clamav/clamd.conf --multiscan "${args[@]}"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,7 @@ volumes:
   preservation_postgres_data: {}
   storage_postgres_data: {}
   iiifbuilder_postgres_data: {}
+  clamav_data: {}
 
 services:
   db-preservation:
@@ -36,3 +37,19 @@ services:
     depends_on:
       - db-iiifbuilder
     env_file: src/iiif-builder/.env
+  # Local clamd for testing against Pipeline.API without the reload-on-every-scan cost of a bare
+  # clamscan. Exposed over TCP (3310) rather than the Unix socket the container/ECS setup uses -
+  # see the note in clamd-daemon-ec2-setup.md, this does NOT exercise the exact same code path as
+  # production (clamscan-shim.sh talks to a Unix socket, not TCP).
+  clamav:
+    image: clamav/clamav:stable
+    ports:
+      - "3310:3310"
+    volumes:
+      - clamav_data:/var/lib/clamav
+    healthcheck:
+      test: ["CMD", "clamdcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s

--- a/pipeline-api-entrypoint.sh
+++ b/pipeline-api-entrypoint.sh
@@ -32,4 +32,10 @@ if [ ! -S /var/run/clamav/clamd.sock ]; then
     echo "entrypoint: clamd socket never appeared after 120s - starting the app anyway, clamscan-shim.sh will fall back to a local scan" >&2
 fi
 
-exec setpriv --reuid="$APP_UID" --regid="$APP_UID" --init-groups dotnet Pipeline.API.dll "$@"
+# setpriv changes the process's UID/GID but does NOT reset HOME the way su does - without this,
+# the dotnet process (and everything it spawns, including Brunnhilde/Siegfried/sf) would inherit
+# HOME=/root from this root shell despite running as a non-root UID, causing sf to look for its
+# signature file under /root instead of this user's actual home and fail with "Siegfried is not
+# installed or available on PATH".
+APP_HOME=$(getent passwd "$APP_UID" | cut -d: -f6)
+exec env HOME="$APP_HOME" setpriv --reuid="$APP_UID" --regid="$APP_UID" --init-groups dotnet Pipeline.API.dll "$@"

--- a/pipeline-api-entrypoint.sh
+++ b/pipeline-api-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Starts clamd (and freshclam) inside this same container, then drops privileges to the app's
+# non-root user for the actual .NET process. This container must start as root (see Dockerfile.
+# PipelineApi - the trailing "USER $APP_UID" was removed) because clamd needs root to create its
+# runtime directories and bind its socket; the .NET app itself still ends up running as $APP_UID.
+set -euo pipefail
+
+mkdir -p /var/run/clamav /var/log/clamav
+chown clamav:clamav /var/run/clamav /var/log/clamav
+
+# The image's build-time `RUN freshclam` (Dockerfile.PipelineApi) only captures a point-in-time
+# snapshot that goes stale after the image is built/deployed - pull the latest before clamd starts.
+freshclam || echo "entrypoint: initial freshclam run failed, continuing with the signatures baked into the image"
+
+# Long-running daemon for the lifetime of the container.
+su -s /bin/sh clamav -c "clamd" &
+
+# Keep signatures current for the life of the container (freshclam's own Checks setting in
+# freshclam.conf controls how often it re-polls).
+su -s /bin/sh clamav -c "freshclam -d" &
+
+echo "entrypoint: waiting for clamd socket..."
+for i in $(seq 1 120); do
+    if [ -S /var/run/clamav/clamd.sock ]; then
+        echo "entrypoint: clamd socket ready after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+if [ ! -S /var/run/clamav/clamd.sock ]; then
+    echo "entrypoint: clamd socket never appeared after 120s - starting the app anyway, clamscan-shim.sh will fall back to a local scan" >&2
+fi
+
+exec setpriv --reuid="$APP_UID" --regid="$APP_UID" --init-groups dotnet Pipeline.API.dll "$@"

--- a/src/DigitalPreservation/Pipeline.API/Config/PipelineToolOptions.cs
+++ b/src/DigitalPreservation/Pipeline.API/Config/PipelineToolOptions.cs
@@ -8,6 +8,7 @@ public class PipelineToolOptions
     public string? ObjectsFolder { get; set; }
     public string? ProcessFolder { get; set; }
     public string? ExifToolLocation { get; set; }
+    public string? PathToClamScan { get; set; }
     public int? ReleaseLockAttemptTime { get; set; }
     public string? PipelineMetadataFolders { get; set; }
     public string? ProcessFolderBagit { get; set; }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -36,7 +36,6 @@ public class ProcessPipelineJobHandler(
 {
     private const string BrunnhildeFolderName = "brunnhilde";
     private readonly string[] filesToIgnore = ["tree.txt"];
-    private StreamReader? streamReader;
 
     private int processId;
     private readonly System.Timers.Timer processTimer = new(10000);
@@ -189,7 +188,6 @@ public class ProcessPipelineJobHandler(
         }
         finally
         {
-            streamReader?.Dispose();
             CleanupProcessFolder(request.DepositId);
             if (workspace.IsBagItLayout)
             {
@@ -282,6 +280,17 @@ public class ProcessPipelineJobHandler(
             return await ForceCompleteReturn(cleanupProcessJob, request, workspaceManager.Deposit, cancellationToken);
         }
 
+        // Computed early - this only depends on IsBagItLayout (known before Brunnhilde runs), not on
+        // anything Brunnhilde produces. Doing this now (rather than after Brunnhilde completes) lets us
+        // kick off Exif in parallel with Brunnhilde/ClamAV instead of waiting for it to finish first.
+        var metadataPathForProcessFilesAndDirectories = workspaceManager.IsBagItLayout
+            ? $"{processFolder}{separator}{request.DepositId}{separator}data{separator}metadata" //{separator}{BrunnhildeFolderName}
+            : $"{processFolder}{separator}{request.DepositId}{separator}metadata";
+
+        logger.LogInformation("metadataPathForProcessFilesAndDirectories {metadataPathForProcessFilesAndDirectories}",
+            metadataPathForProcessFilesAndDirectories);
+        logger.LogInformation("depositName {depositId}", request.DepositId);
+
         using var process = new Process();
         process.StartInfo.FileName = pipelineToolOptions.Value.PathToPython;
         process.StartInfo.Arguments = $"  {pipelineToolOptions.Value.PathToBrunnhilde} --hash sha256 {objectPath} {metadataProcessPath}  --overwrite ";
@@ -291,66 +300,63 @@ public class ProcessPipelineJobHandler(
         logger.LogInformation("Brunnhilde process about to be started {date}", DateTime.Now);
         var started = process.Start();
 
-        if (started)
+        // Stream stdout line-by-line instead of buffering the whole thing into one string via
+        // ReadToEndAsync: for a large run (thousands of files) Brunnhilde/Siegfried/ClamAV can produce
+        // many MB of output, and we only ever needed to know whether one marker line was present.
+        var brunnhildeExecutionSuccess = false;
+        process.OutputDataReceived += (_, e) =>
         {
-            logger.LogInformation("Brunnhilde process started {date}", DateTime.Now);
-            processId = process.Id;
-        }
+            if (e.Data == null) return;
+            if (e.Data.Contains("Brunnhilde characterization complete."))
+            {
+                brunnhildeExecutionSuccess = true;
+            }
+            logger.LogDebug("Brunnhilde output: {Line}", e.Data);
+        };
 
-        streamReader = process.StandardOutput;
-
-        processTimer.Elapsed += (_, _) => CheckIfProcessRunning(request, workspaceManager.Deposit, cancellationTokenMonitor);
-
-        processTimer.AutoReset = true;
-        processTimer.Enabled = true;
-        
-        if (streamReader == null)
+        if (!started)
         {
             await tokensCatalog[monitorForceCompleteId].CancelAsync();
-            logger.LogError("Steam reader is null Issue executing Brunnhilde process: process?.StandardOutput is null");
+            logger.LogError("Issue executing Brunnhilde process: process did not start");
 
             logger.LogError("Caught error in PipelineJob handler for job id {jobIdentifier} and deposit {depositId}",
                 request.JobIdentifier, request.DepositId);
 
             await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
 
-            var (forceCompleteStreamReader, cleanupProcessJobStreamReader) = await CheckIfForceComplete(request, workspaceManager.Deposit, cancellationToken);
-            if (forceCompleteStreamReader)
+            var (forceCompleteProcessStart, cleanupProcessJobProcessStart) = await CheckIfForceComplete(request, workspaceManager.Deposit, cancellationToken);
+            if (forceCompleteProcessStart)
             {
-                return await ForceCompleteReturn(cleanupProcessJobStreamReader, request, workspaceManager.Deposit, cancellationToken);
+                return await ForceCompleteReturn(cleanupProcessJobProcessStart, request, workspaceManager.Deposit, cancellationToken);
             }
 
             return new ProcessPipelineResult
             {
                 Status = PipelineJobStates.CompletedWithErrors,
-                Errors = [new Error { Message = $"Pipeline job run {request.JobIdentifier} for {request.DepositId} has issue with Brunnhilde output stream reader being null" }]
+                Errors = [new Error { Message = $"Pipeline job run {request.JobIdentifier} for {request.DepositId} could not start the Brunnhilde process" }]
             };
         }
 
-        logger.LogInformation("_streamReader {streamReader}", streamReader);
+        logger.LogInformation("Brunnhilde process started {date}", DateTime.Now);
+        processId = process.Id;
+        process.BeginOutputReadLine();
 
-        var result = await streamReader.ReadToEndAsync(cancellationTokenBrunnhilde);
+        processTimer.Elapsed += (_, _) => CheckIfProcessRunning(request, workspaceManager.Deposit, cancellationTokenMonitor);
+        processTimer.AutoReset = true;
+        processTimer.Enabled = true;
+
+        // Exif only reads objectPath and writes to its own "exif" subfolder (a sibling of the
+        // "brunnhilde" output folder) - it doesn't touch or depend on anything Brunnhilde produces, so
+        // run it concurrently instead of waiting for Brunnhilde/ClamAV to finish first. Its runtime then
+        // hides almost entirely behind the much longer Brunnhilde/ClamAV run.
+        var exifTask = RunExif(metadataPathForProcessFilesAndDirectories, objectPath);
+
+        logger.LogInformation("Ran exif and now at Brunnhilde process wait for async");
+        await process.WaitForExitAsync(cancellationTokenBrunnhilde);
         processId = 0;
         await tokensCatalog[monitorForceCompleteId].CancelAsync();
 
-        streamReader = null;
-        var brunnhildeExecutionSuccess = result.Contains("Brunnhilde characterization complete.");
         logger.LogInformation("Brunnhilde result success: {brunnhildeExecutionSuccess}", brunnhildeExecutionSuccess);
-
-        // Now our workspaceManager is out of date, because METS has been modified.
-        // So we can't use it again for further *content modifications*.
-        // But we can use it for other properties, e.g. workspaceManager.IsBagItLayout won't have changed.
-
-        var metadataPathForProcessFilesAndDirectories = workspaceManager.IsBagItLayout
-            ? $"{processFolder}{separator}{request.DepositId}{separator}data{separator}metadata" //{separator}{BrunnhildeFolderName}
-            : $"{processFolder}{separator}{request.DepositId}{separator}metadata";
-
-        logger.LogInformation("metadataPathForProcessFiles after brunnhilde process {metadataPathForProcessFiles}",
-            metadataPathForProcessFilesAndDirectories);
-        logger.LogInformation(
-            "metadataPathForProcessDirectories after brunnhilde process {metadataPathForProcessDirectories}",
-            metadataPathForProcessFilesAndDirectories);
-        logger.LogInformation("depositName after brunnhilde process {depositId}", request.DepositId);
 
         if (brunnhildeExecutionSuccess)
         {
@@ -387,6 +393,9 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteOnSuccess)
             {
+                // Exif was started concurrently alongside Brunnhilde and may still be running - join it
+                // before returning so it can't still be writing when the process folder is cleaned up.
+                await exifTask;
                 return await ForceCompleteReturn(cleanupProcessJobOnSuccess, request, workspaceManager.Deposit, cancellationToken);
             }
 
@@ -402,6 +411,7 @@ public class ProcessPipelineJobHandler(
             // At this point we have not modified the METS file, the ETag for this workspace is still valid
             if (forceCompleteAfterDelete)
             {
+                await exifTask;
                 return await ForceCompleteReturn(cleanupProcessJobAfterDelete, request, workspaceManager.Deposit, cancellationToken);
             }
 
@@ -412,7 +422,10 @@ public class ProcessPipelineJobHandler(
             Directory.CreateDirectory($"{metadataPathForProcessFilesAndDirectories}{pipelineToolOptions.Value.DirectorySeparator}virus-definition");
             await File.WriteAllTextAsync(virusDefinitionPath, virusDefinition, CancellationToken.None);
 
-            await RunExif(metadataPathForProcessFilesAndDirectories, objectPath);
+            // Join the Exif task kicked off alongside Brunnhilde earlier - its output needs to be on
+            // disk before we upload the metadata folder below, but it has likely already finished
+            // since it typically runs faster than Brunnhilde/ClamAV.
+            await exifTask;
 
             var (createFolderResultList, uploadFilesResultList, forceCompleteUpload, forceCompleteUploadCleanupProcess) = await UploadFilesToMetadataRecursively(
                 request, metadataPathForProcessFilesAndDirectories, depositPath,
@@ -537,6 +550,11 @@ public class ProcessPipelineJobHandler(
             };
 
         }
+
+        // Brunnhilde failed, but Exif was started concurrently alongside it and may still be running -
+        // join it here (rather than leaving it orphaned) so it can't still be writing to the process
+        // folder when Handle()'s finally block deletes it.
+        await exifTask;
 
         var (forceCompleteOnFailure, cleanupProcessJobOnFailure) = await CheckIfForceComplete(request, workspaceManager.Deposit, cancellationToken);
         // At this point we have not modified the METS file, the ETag for this workspace is still valid
@@ -998,12 +1016,9 @@ public class ProcessPipelineJobHandler(
                     {
                         process.Kill(true);
 
-                        if (streamReader != null)
-                        {
-                            logger.LogInformation("Process killed for job id {jobId}", request.JobIdentifier);
-                            processTimer.Stop();
-                            processTimer.Enabled = false;
-                        }
+                        logger.LogInformation("Process killed for job id {jobId}", request.JobIdentifier);
+                        processTimer.Stop();
+                        processTimer.Enabled = false;
 
                         await tokensCatalog[monitorForceCompleteId].CancelAsync();
                     }
@@ -1065,12 +1080,16 @@ public class ProcessPipelineJobHandler(
     {
         try
         {
+            var clamScanPath = pipelineToolOptions.Value.PathToClamScan.HasText()
+                ? pipelineToolOptions.Value.PathToClamScan
+                : "clamscan";
+
             var process = new Process()
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "clamscan",
-                    Arguments = "clamscan --version",
+                    FileName = clamScanPath,
+                    Arguments = "--version",
                     RedirectStandardOutput = true,
                     UseShellExecute = false,
                     CreateNoWindow = true

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -702,22 +702,6 @@ public class ProcessPipelineJobHandler(
 
             logger.LogInformation($"context {context}");
 
-            // Acquire the WorkspaceManager ONCE with a full refresh here, rather than having each
-            // folder/file operation below re-acquire and refresh its own (each refresh re-lists the
-            // ENTIRE deposit from S3 - expensive for a large deposit, and pointless when creating a
-            // handful of small metadata folders/files). CreateFolder/UploadFileToDeposit both
-            // incrementally update the cached deposit file-system snapshot after each write
-            // (storage.AddToDepositFileSystem), so reusing this one manager with cheap
-            // (non-refreshing) reads for every subsequent operation stays correct.
-            var workspaceManagerResult = await GetWorkspaceManager(request, true);
-            if (workspaceManagerResult.Failure || workspaceManagerResult.Value == null)
-            {
-                await TryReleaseLock(request, deposit, cancellationToken);
-                logger.LogError("Could not acquire WorkspaceManager in UploadFilesToMetadataRecursively() for job {JobIdentifier} deposit {DepositId}: {error}", request.JobIdentifier, request.DepositId, workspaceManagerResult.CodeAndMessage());
-                return (createSubFolderResult: [], uploadFileResult: [], false, false);
-            }
-            var workspaceManager = workspaceManagerResult.Value;
-
             //create Brunnhilde folder first
             var createSubFolderResult = new List<Result<CreateFolderResult>?>();
 
@@ -734,7 +718,7 @@ public class ProcessPipelineJobHandler(
                     return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload);
                 }
 
-                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(workspaceManager, request, dirPath));
+                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath));
             }
 
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
@@ -754,7 +738,7 @@ public class ProcessPipelineJobHandler(
                     return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(workspaceManager, request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
@@ -792,8 +776,12 @@ public class ProcessPipelineJobHandler(
         return (createSubFolderResult: [], uploadFileResult: [], false, false);
     }
 
-    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(WorkspaceManager workspaceManager, ExecutePipelineJob request, string dirPath)
+    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath)
     {
+        // This is a content-changing operation
+        var workspaceResult = await GetWorkspaceManager(request, true);
+        var workspaceManager = workspaceResult.Value!;
+
         var context = new StringBuilder();
         var metadataContext = "metadata";
         context.Append(metadataContext);
@@ -804,11 +792,8 @@ public class ProcessPipelineJobHandler(
 
         logger.LogInformation("BrunnhildeFolderName {BrunnhildeFolderName}", BrunnhildeFolderName);
         logger.LogInformation("di.Name {di.Name} context {context}", di.Name, context);
-        // refreshDirectory: false - the caller already acquired a freshly-refreshed workspaceManager,
-        // and CreateFolder's own S3 write incrementally updates the cached deposit file-system
-        // snapshot afterward, so there's no need to re-list the entire deposit from S3 again here.
         var result = await workspaceManager.CreateFolder(
-            di.Name, context.ToString(), false, request.GetUserName(), false);
+            di.Name, context.ToString(), false, request.GetUserName(), true);
 
         if (!result.Success)
         {
@@ -820,7 +805,7 @@ public class ProcessPipelineJobHandler(
         return result;
     }
 
-    private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(WorkspaceManager workspaceManager, ExecutePipelineJob request, string filePath,
+    private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(ExecutePipelineJob request, string filePath,
         string? sourcePath, Deposit deposit, CancellationToken cancellationToken, bool bagitFile = false)
     {
         var context = new StringBuilder();
@@ -870,7 +855,7 @@ public class ProcessPipelineJobHandler(
             return (null, false, false);
 
         var stream = GetFileStream(filePath);
-        var result = await UploadFileToBucketDeposit(workspaceManager, request, stream, filePath, contextPath, checksum, bagitFile);
+        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, bagitFile);
 
 
         if (!result.Success)
@@ -889,8 +874,9 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(
-        WorkspaceManager workspaceManager, ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
+        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
     {
+        // This is potentially expensive as it needs a NEW WorkspaceManager each time
         // TODO: We need a batch operation on WorkspaceManager to upload a set of small files.
 
         var fi = new FileInfo(filePath);
@@ -902,7 +888,9 @@ public class ProcessPipelineJobHandler(
                 return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError,
                     "Could not find file content type");
 
-            var result = await workspaceManager.UploadSingleSmallFile(
+            var workspaceManagerResult = await GetWorkspaceManager(request, true);
+
+            var result = await workspaceManagerResult.Value!.UploadSingleSmallFile(
                 stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, request.GetUserName(), true, bagitFile); //bagit file
 
             return result;
@@ -1467,18 +1455,6 @@ public class ProcessPipelineJobHandler(
                 return (uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload);
             }
 
-            // Acquire the WorkspaceManager ONCE with a full refresh here, rather than having each
-            // file upload below re-acquire and refresh its own (see UploadFilesToMetadataRecursively
-            // for the same reasoning).
-            var workspaceManagerResult = await GetWorkspaceManager(request, true);
-            if (workspaceManagerResult.Failure || workspaceManagerResult.Value == null)
-            {
-                await TryReleaseLock(request, deposit, cancellationToken);
-                logger.LogError("Could not acquire WorkspaceManager in UploadBagitFilesToRoot() for job {JobIdentifier} deposit {DepositId}: {error}", request.JobIdentifier, request.DepositId, workspaceManagerResult.CodeAndMessage());
-                return (uploadFileResult: [], false, false);
-            }
-            var workspaceManager = workspaceManagerResult.Value;
-
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
 
             foreach (var filePath in Directory.GetFiles($"{processFolderBagitDeposit}", "*.*", SearchOption.TopDirectoryOnly))
@@ -1496,7 +1472,7 @@ public class ProcessPipelineJobHandler(
                     return (uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(workspaceManager, request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -702,6 +702,22 @@ public class ProcessPipelineJobHandler(
 
             logger.LogInformation($"context {context}");
 
+            // Acquire the WorkspaceManager ONCE with a full refresh here, rather than having each
+            // folder/file operation below re-acquire and refresh its own (each refresh re-lists the
+            // ENTIRE deposit from S3 - expensive for a large deposit, and pointless when creating a
+            // handful of small metadata folders/files). CreateFolder/UploadFileToDeposit both
+            // incrementally update the cached deposit file-system snapshot after each write
+            // (storage.AddToDepositFileSystem), so reusing this one manager with cheap
+            // (non-refreshing) reads for every subsequent operation stays correct.
+            var workspaceManagerResult = await GetWorkspaceManager(request, true);
+            if (workspaceManagerResult.Failure || workspaceManagerResult.Value == null)
+            {
+                await TryReleaseLock(request, deposit, cancellationToken);
+                logger.LogError("Could not acquire WorkspaceManager in UploadFilesToMetadataRecursively() for job {JobIdentifier} deposit {DepositId}: {error}", request.JobIdentifier, request.DepositId, workspaceManagerResult.CodeAndMessage());
+                return (createSubFolderResult: [], uploadFileResult: [], false, false);
+            }
+            var workspaceManager = workspaceManagerResult.Value;
+
             //create Brunnhilde folder first
             var createSubFolderResult = new List<Result<CreateFolderResult>?>();
 
@@ -718,7 +734,7 @@ public class ProcessPipelineJobHandler(
                     return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload);
                 }
 
-                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath));
+                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(workspaceManager, request, dirPath));
             }
 
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
@@ -738,7 +754,7 @@ public class ProcessPipelineJobHandler(
                     return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(workspaceManager, request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
@@ -776,12 +792,8 @@ public class ProcessPipelineJobHandler(
         return (createSubFolderResult: [], uploadFileResult: [], false, false);
     }
 
-    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath)
+    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(WorkspaceManager workspaceManager, ExecutePipelineJob request, string dirPath)
     {
-        // This is a content-changing operation
-        var workspaceResult = await GetWorkspaceManager(request, true);
-        var workspaceManager = workspaceResult.Value!;
-
         var context = new StringBuilder();
         var metadataContext = "metadata";
         context.Append(metadataContext);
@@ -792,8 +804,11 @@ public class ProcessPipelineJobHandler(
 
         logger.LogInformation("BrunnhildeFolderName {BrunnhildeFolderName}", BrunnhildeFolderName);
         logger.LogInformation("di.Name {di.Name} context {context}", di.Name, context);
+        // refreshDirectory: false - the caller already acquired a freshly-refreshed workspaceManager,
+        // and CreateFolder's own S3 write incrementally updates the cached deposit file-system
+        // snapshot afterward, so there's no need to re-list the entire deposit from S3 again here.
         var result = await workspaceManager.CreateFolder(
-            di.Name, context.ToString(), false, request.GetUserName(), true);
+            di.Name, context.ToString(), false, request.GetUserName(), false);
 
         if (!result.Success)
         {
@@ -805,7 +820,7 @@ public class ProcessPipelineJobHandler(
         return result;
     }
 
-    private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(ExecutePipelineJob request, string filePath,
+    private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(WorkspaceManager workspaceManager, ExecutePipelineJob request, string filePath,
         string? sourcePath, Deposit deposit, CancellationToken cancellationToken, bool bagitFile = false)
     {
         var context = new StringBuilder();
@@ -855,7 +870,7 @@ public class ProcessPipelineJobHandler(
             return (null, false, false);
 
         var stream = GetFileStream(filePath);
-        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, bagitFile);
+        var result = await UploadFileToBucketDeposit(workspaceManager, request, stream, filePath, contextPath, checksum, bagitFile);
 
 
         if (!result.Success)
@@ -874,9 +889,8 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(
-        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
+        WorkspaceManager workspaceManager, ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
     {
-        // This is potentially expensive as it needs a NEW WorkspaceManager each time
         // TODO: We need a batch operation on WorkspaceManager to upload a set of small files.
 
         var fi = new FileInfo(filePath);
@@ -888,9 +902,7 @@ public class ProcessPipelineJobHandler(
                 return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError,
                     "Could not find file content type");
 
-            var workspaceManagerResult = await GetWorkspaceManager(request, true);
-
-            var result = await workspaceManagerResult.Value!.UploadSingleSmallFile(
+            var result = await workspaceManager.UploadSingleSmallFile(
                 stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, request.GetUserName(), true, bagitFile); //bagit file
 
             return result;
@@ -1455,6 +1467,18 @@ public class ProcessPipelineJobHandler(
                 return (uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload);
             }
 
+            // Acquire the WorkspaceManager ONCE with a full refresh here, rather than having each
+            // file upload below re-acquire and refresh its own (see UploadFilesToMetadataRecursively
+            // for the same reasoning).
+            var workspaceManagerResult = await GetWorkspaceManager(request, true);
+            if (workspaceManagerResult.Failure || workspaceManagerResult.Value == null)
+            {
+                await TryReleaseLock(request, deposit, cancellationToken);
+                logger.LogError("Could not acquire WorkspaceManager in UploadBagitFilesToRoot() for job {JobIdentifier} deposit {DepositId}: {error}", request.JobIdentifier, request.DepositId, workspaceManagerResult.CodeAndMessage());
+                return (uploadFileResult: [], false, false);
+            }
+            var workspaceManager = workspaceManagerResult.Value;
+
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
 
             foreach (var filePath in Directory.GetFiles($"{processFolderBagitDeposit}", "*.*", SearchOption.TopDirectoryOnly))
@@ -1472,7 +1496,7 @@ public class ProcessPipelineJobHandler(
                     return (uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(workspaceManager, request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);

--- a/src/DigitalPreservation/Pipeline.API/appsettings.json
+++ b/src/DigitalPreservation/Pipeline.API/appsettings.json
@@ -32,6 +32,7 @@
     "ObjectsFolder": "objects",
     "ProcessFolder": "/usr/process-brunnhilde",
     "ExifToolLocation": "exiftool",
+    "PathToClamScan": "clamscan",
     "ReleaseLockAttemptTime": 10,
     "PipelineMetadataFolders": "metadata/brunnhilde,metadata/exif,metadata/virus-definition",
     "ProcessFolderBagit": "/usr/process-bagit",


### PR DESCRIPTION
Ticket: https://digirati.atlassian.net/browse/LPII-135
got the large deposit https://preservation-dev.library.leeds.ac.uk/deposits/mqcqu2gca4cb processing the pipeline in 35 minutes.

The fix included running Clam Av in a multi-threaded way using the multiscan switch - the virus scanning was the bottleneck.

<img width="972" height="405" alt="image" src="https://github.com/user-attachments/assets/e8809e8d-4fc5-47ee-9909-bdec13a30826" />
