### PR TITLE
Sonar cleanup: fix mechanical analyzer warnings from the #177 merge

### DIFF
--- a/src/DigitalPreservation/Builder/Program.cs
+++ b/src/DigitalPreservation/Builder/Program.cs
@@ -6,7 +6,7 @@ using IIIF.Serialisation;
 
 namespace Builder;
 
-class Program
+static class Program
 {
     static async Task Main(string[] args)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedDirectory.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedDirectory.cs
@@ -55,11 +55,6 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
     {
         return FindDirectoryInternal(path, (directory, part) => directory.LocalPath!.GetSlug() == part);
     }
-    
-    // public CombinedDirectory? FindDirectoryByUriSafeSlugs(string? path)
-    // {
-    //     return FindDirectoryInternal(path, (directory, part) => directory.LocalPath!.GetUriSafeSlug() == part);
-    // }
 
     private CombinedDirectory? FindDirectoryInternal(string? path, Func<CombinedDirectory, string, bool> predicate)
     {
@@ -100,14 +95,6 @@ public class CombinedDirectory(WorkingDirectory? directoryInDeposit, WorkingDire
         var slug = path.GetSlug();
         return parent?.Files.SingleOrDefault(f => f.LocalPath!.GetSlug() == slug);
     }
-    
-    
-    // public CombinedFile? FindFileByUriSafeSlugs(string path)
-    // {
-    //     var parent = FindDirectoryByUriSafeSlugs(path.GetParent());
-    //     var slug = path.GetUriSafeSlug();
-    //     return parent?.Files.SingleOrDefault(f => f.LocalPath!.GetUriSafeSlug() == slug);
-    // }
 
     public bool RemoveFileFromDeposit(string path, string depositPath, bool trueIfNotFound)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Combined/CombinedFile.cs
@@ -59,7 +59,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                     DepositFileFormatMetadata.FormatName, MetsFileFormatMetadata.FormatName));
             }
 
-            if (DepositFileFormatMetadata!.PronomKey != MetsFileFormatMetadata!.PronomKey)
+            if (DepositFileFormatMetadata.PronomKey != MetsFileFormatMetadata.PronomKey)
             {
                 misMatches.Add(new FileMisMatch(nameof(FileFormatMetadata), "PronomKey",
                     DepositFileFormatMetadata.PronomKey, MetsFileFormatMetadata.PronomKey));
@@ -74,7 +74,7 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
                     depositContentTypes, FileInMets.ContentType));
             }
 
-            if (DepositFileFormatMetadata!.Digest != MetsFileFormatMetadata!.Digest)
+            if (DepositFileFormatMetadata.Digest != MetsFileFormatMetadata.Digest)
             {
                 misMatches.Add(new FileMisMatch(nameof(FileFormatMetadata), "Digest", DepositFileFormatMetadata.Digest,
                     MetsFileFormatMetadata.Digest));
@@ -414,7 +414,6 @@ public class CombinedFile(WorkingFile? fileInDeposit, WorkingFile? fileInMets, s
 
         return distinctDigests.Where(digest => digest.HasText())
             .Distinct()
-            .Select(digest => digest!)
             .ToList();
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/FileLink.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/FileLink.cs
@@ -32,7 +32,7 @@ public static class FileLinkRoles
 
     public static string? ToIiifProvides(Uri? uri)
     {
-        return uri == null ? null : ProvidesKeywordFromUri!.GetValueOrDefault(uri, null);
+        return uri == null ? null : ProvidesKeywordFromUri.GetValueOrDefault(uri, null);
     }
     
     static FileLinkRoles()

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/WorkingFile.cs
@@ -130,23 +130,20 @@ public class WorkingFile : WorkingBase
         // them here, we must check them elsewhere.
 
         // (for now - we may have other sources later)
-        if (pronomKeys.Count > 0)
+        if (pronomKeys.Count > 0 && pronomKeys.All(x => x == pronomKeys[0]))
         {
-            if (pronomKeys.All(x => x == pronomKeys.First()))
+            return new FileFormatMetadata
             {
-                return new FileFormatMetadata
-                {
-                    Digest = digests.First(), // check the digests metadata for mismatch
-                    PronomKey = pronomKeys.First(),
-                    ContentType = contentTypes.FirstOrDefault(),
-                    Size = size.First(),
-                    FormatName = formatNames.First(),
-                    OriginalName = originalNames.FirstOrDefault(),
-                    StorageLocation = storageLocations.FirstOrDefault(),
-                    Source = string.Join(',', fileFormatMetadata.Select(m => m.Source)),
-                    Timestamp = fileFormatMetadata.Select(m => m.Timestamp).Max()
-                };
-            }
+                Digest = digests[0], // check the digests metadata for mismatch
+                PronomKey = pronomKeys[0],
+                ContentType = contentTypes.FirstOrDefault(),
+                Size = size[0],
+                FormatName = formatNames[0],
+                OriginalName = originalNames.FirstOrDefault(),
+                StorageLocation = storageLocations.FirstOrDefault(),
+                Source = string.Join(',', fileFormatMetadata.Select(m => m.Source)),
+                Timestamp = fileFormatMetadata.Select(m => m.Timestamp).Max()
+            };
         }
 
         // There is only one, or none
@@ -166,11 +163,11 @@ public class WorkingFile : WorkingBase
         {
             return null;
         }
-        if (digests.All(x => x == digests.First()))
+        if (digests.All(x => x == digests[0]))
         {
             return new DigestMetadata
             {
-                Digest = digests.First(),
+                Digest = digests[0],
                 Source = string.Join(',', digestMetadata.Select(m => m.Source)),
                 Timestamp = digestMetadata.Select(m => m.Timestamp).Max()
             };

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/ViewValues.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/ViewValues.cs
@@ -1,6 +1,6 @@
 ﻿namespace DigitalPreservation.Common.Model;
 
-public class ViewValues
+public static class ViewValues
 {
     public const string Mets = "mets";
     public const string ParsedMets = "parsed-mets";

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsFileWrapper.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsFileWrapper.cs
@@ -25,9 +25,6 @@ public class MetsFileWrapper
 
     public WorkingDirectory? PhysicalStructure { get; set; }
 
-    // A list of all the directories mentioned, with their names
-    // public List<WorkingDirectory> ContainersX { get; set; } = [];
-
     // A list of all the files mentioned, with their names and hashes (digests)
     public List<WorkingFile> Files { get; set; } = [];
     public XDocument? XDocument { get; set; }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -460,7 +460,7 @@ public class MetsParser(
                             }
                             catch (Exception e)
                             {
-                                logger.LogError(e, "Unable to parse storage location {storageUri}", storageUri);
+                                logger.LogError(e, "Unable to parse storage location {StorageUri}", storageUri);
                             }
                         }
 
@@ -1233,7 +1233,7 @@ public class MetsParser(
             file.EffectiveRightsStatement = null;
 
         // RecordInfo: own → exactly-one whole-file logical range (effective) → smLink-associated range → physical parent
-        // Logical inheritance only applies when the range actually has a (non-null) effective RecordInfo;
+        // Logical inheritance only applies when the range actually has a non-null effective RecordInfo -
         // a null from the logical range must not override a real RecordInfo asserted by a physical ancestor.
         if (file.RecordInfo != null)
         {

--- a/src/DigitalPreservation/DigitalPreservation.Mets/PremisManagerExif.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/PremisManagerExif.cs
@@ -80,7 +80,7 @@ public class PremisManagerExif
             parentElement?.AppendChild(element);
     }
 
-    private void SetSignificantPropertiesFromTags(File file, List<ExifTag> tags)
+    private static void SetSignificantPropertiesFromTags(File file, List<ExifTag> tags)
     {
         // ImageSize is ExifTool's composite tag representing the final video frame dimensions.
         // It appears once and takes precedence over the per-track ImageWidth/ImageHeight tags,
@@ -145,7 +145,7 @@ public class PremisManagerExif
 
     // Adds a significantProperty if not already present; if already present from any source,
     // verifies the value matches and throws if not.
-    private void PatchSignificantProperty(File file, string propertyName, string value)
+    private static void PatchSignificantProperty(File file, string propertyName, string value)
     {
         var existing = file.SignificantProperties
             .FirstOrDefault(sp => sp.SignificantPropertiesType?.Value == propertyName);
@@ -217,7 +217,7 @@ public class PremisManagerExif
         return null;
     }
 
-    private XmlSerializerNamespaces GetXmlSerializerNameSpaces()
+    private static XmlSerializerNamespaces GetXmlSerializerNameSpaces()
     {
         var namespaces = new XmlSerializerNamespaces();
         namespaces.Add("premis", "http://www.loc.gov/premis/v3");

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Browse.cshtml.cs
@@ -96,8 +96,8 @@ public class BrowseModel(
             }
         }
         
-        var name = Resource!.Name ?? Resource!.Id!.GetSlug()?.UnEscapeFromUriNoHashes();
-        switch (Resource!.Type)
+        var name = Resource.Name ?? Resource.Id!.GetSlug()?.UnEscapeFromUriNoHashes();
+        switch (Resource.Type)
         {
             case nameof(ArchivalGroup):
                 
@@ -235,11 +235,11 @@ public class BrowseModel(
         while (testPath.HasText() && testPath != "/" && testPath.Contains('/'))
         {
             var cacheKey = CacheKey(testPath);
-            logger.LogInformation("Seeing if there is an Archival Group in the cache for {cacheKey}", cacheKey);
+            logger.LogInformation("Seeing if there is an Archival Group in the cache for {CacheKey}", cacheKey);
             CachedArchivalGroup = memoryCache.TryGetValue(cacheKey, out ArchivalGroup? archivalGroup) ? archivalGroup : null;
             if (CachedArchivalGroup != null)
             {
-                logger.LogInformation("Archival Group was found for {cacheKey}", cacheKey);
+                logger.LogInformation("Archival Group was found for {CacheKey}", cacheKey);
                 break;
             }
             testPath = testPath.GetParent();
@@ -262,13 +262,13 @@ public class BrowseModel(
                 if (preservedResource == null)
                 {
                     // This is going to cause a problem in the rest of the flow
-                    logger.LogWarning("No resource returned for {resourcePath}", resourcePath);
+                    logger.LogWarning("No resource returned for {ResourcePath}", resourcePath);
                     return null;
                 }
                 if (preservedResource is ArchivalGroup group)
                 {
                     // If it is an archival group, hang on to it.
-                    logger.LogInformation("{resourcePath} is an Archival Group", resourcePath);
+                    logger.LogInformation("{ResourcePath} is an Archival Group", resourcePath);
                     archivalGroupToBeCached = group;
                 }
                 else if (preservedResource.PartOf != null)
@@ -278,12 +278,12 @@ public class BrowseModel(
                     archivalGroupToBeCached = result.Value as ArchivalGroup;
                     if (archivalGroupToBeCached != null)
                     {
-                        logger.LogInformation("ArchivalGroup {archivalGroup} recovered from .PartOf for {resourcePath}",
+                        logger.LogInformation("ArchivalGroup {ArchivalGroup} recovered from .PartOf for {ResourcePath}",
                             archivalGroupToBeCached.Id!.AbsolutePath, resourcePath);
                     }
                     else
                     {
-                        logger.LogInformation("No archival group found on path {resourcePath}", resourcePath);
+                        logger.LogInformation("No archival group found on path {ResourcePath}", resourcePath);
                     }
                 }
 
@@ -306,25 +306,25 @@ public class BrowseModel(
 
         if (CachedArchivalGroup.Id!.AbsolutePath.RemoveStart("/") == resourcePath.RemoveStart("/"))
         {
-            logger.LogInformation("{resourcePath} is the archival group itself, returning", resourcePath);
+            logger.LogInformation("{ResourcePath} is the archival group itself, returning", resourcePath);
             return CachedArchivalGroup;
         }
         
         // /repository/folder/folder/ag/folder/folder/file
         var localPath = resourcePath
             .RemoveStart("/")
-            .RemoveStart(CachedArchivalGroup.Id!.AbsolutePath.RemoveStart("/")!)
+            .RemoveStart(CachedArchivalGroup.Id.AbsolutePath.RemoveStart("/")!)
             .RemoveStart("/");
         var resourceInAg = CachedArchivalGroup.FindResource(localPath);
         if (resourceInAg is not null)
         {
-            logger.LogInformation("Found resource of type {type} for {localPath} within ArchivalGroup {archivalGroup}",
-                resourceInAg.Type, localPath, CachedArchivalGroup.Id!.AbsolutePath);
+            logger.LogInformation("Found resource of type {Type} for {LocalPath} within ArchivalGroup {ArchivalGroup}",
+                resourceInAg.Type, localPath, CachedArchivalGroup.Id.AbsolutePath);
         }
         else
         {
-            logger.LogInformation("No resource found at path {localPath} within Archival Group {archivalGroup}",
-                localPath, CachedArchivalGroup.Id!.AbsolutePath);
+            logger.LogInformation("No resource found at path {LocalPath} within Archival Group {ArchivalGroup}",
+                localPath, CachedArchivalGroup.Id.AbsolutePath);
         }
         return resourceInAg;
 
@@ -374,7 +374,7 @@ public class BrowseModel(
         return Redirect(Request.Path);
     }
 
-    private Result ValidateNewContainerSlug(string? path, string slug, string? containerTitle)
+    private static Result ValidateNewContainerSlug(string? path, string slug, string? containerTitle)
     {
         if (PreservedResource.ValidSlug(slug, out var reason))
         {

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml.cs
@@ -141,7 +141,7 @@ public class DepositModel(
             AccessConditions = conditionsResult.Value!;
         var rangeTypesResult = await preservationApiClient.GetRangeTypes(HttpContext.RequestAborted);
         if (rangeTypesResult.Success && rangeTypesResult.Value!.Count > 0)
-            RangeTypes = rangeTypesResult.Value!;
+            RangeTypes = rangeTypesResult.Value;
     }
 
     private async Task<bool> BindDeposit(string id, bool readFromStorage = false, bool writeToStorage = false)
@@ -194,7 +194,7 @@ public class DepositModel(
             return false;
         }
 
-        logger.LogInformation("In Bind deposit for deposit {deposit} Lock date: {lockDate}, Locked by: {lockedBy} ", Deposit?.Id, Deposit?.LockDate, Deposit?.LockedBy);
+        logger.LogInformation("In Bind deposit for deposit {Deposit} Lock date: {LockDate}, Locked by: {LockedBy} ", Deposit?.Id, Deposit?.LockDate, Deposit?.LockedBy);
         return true;
     }
     
@@ -269,7 +269,7 @@ public class DepositModel(
                 TempData[TempDataError] = "Could not read deposit file system.";
                 return Redirect($"/deposits/{id}");
             }
-            var contentRoot = combinedResult.Value!;
+            var contentRoot = combinedResult.Value;
             var wbsToAdd = minimalItems
                 .Select(m => m.ResolveFromContentRoot(contentRoot))
                 .OfType<WorkingBase>()
@@ -515,24 +515,21 @@ public class DepositModel(
         [FromForm] string? agName,
         [FromForm] string? submissionText)
     {
-        if (agPathUnderRoot.HasText())
+        if (agPathUnderRoot.HasText() && agPathUnderRoot.StartsWith("http"))
         {
-            if (agPathUnderRoot.StartsWith("http"))
+            var pathUrl = new Uri(agPathUnderRoot);
+            agPathUnderRoot = pathUrl.AbsolutePath.ToLowerInvariant();
+            if (agPathUnderRoot.StartsWith("/browse/"))
             {
-                var pathUrl = new Uri(agPathUnderRoot);
-                agPathUnderRoot = pathUrl.AbsolutePath.ToLowerInvariant();
-                if (agPathUnderRoot.StartsWith("/browse/"))
-                {
-                    agPathUnderRoot = agPathUnderRoot.Substring("/browse/".Length);
-                }
-                if (agPathUnderRoot.StartsWith("/repository/"))
-                {
-                    agPathUnderRoot = agPathUnderRoot.Substring("/repository/".Length);
-                }
-                if (agPathUnderRoot.StartsWith("/"))
-                {
-                    agPathUnderRoot = agPathUnderRoot.Substring(1);
-                }
+                agPathUnderRoot = agPathUnderRoot.Substring("/browse/".Length);
+            }
+            if (agPathUnderRoot.StartsWith("/repository/"))
+            {
+                agPathUnderRoot = agPathUnderRoot.Substring("/repository/".Length);
+            }
+            if (agPathUnderRoot.StartsWith("/"))
+            {
+                agPathUnderRoot = agPathUnderRoot.Substring(1);
             }
         }
         var getDepositResult = await mediator.Send(new GetDeposit(id));
@@ -637,18 +634,15 @@ public class DepositModel(
 
     public string GetDepositLocation()
     {
-        if (Deposit != null)
+        if (Deposit != null && Deposit.Files?.Scheme == "s3")
         {
-            if (Deposit.Files?.Scheme == "s3")
-            {
-                const string template =
-                    "https://eu-west-1.console.aws.amazon.com/s3/buckets/{bucket}?region=eu-west-1&bucketType=general&prefix={prefix}&showversions=false";
-                var s3Uri = new AmazonS3Uri(Deposit.Files);
-                string href = template
-                    .Replace("{bucket}", s3Uri.Bucket)
-                    .Replace("{prefix}", s3Uri.Key.TrimEnd('/') + "/");
-                return href;
-            }
+            const string template =
+                "https://eu-west-1.console.aws.amazon.com/s3/buckets/{bucket}?region=eu-west-1&bucketType=general&prefix={prefix}&showversions=false";
+            var s3Uri = new AmazonS3Uri(Deposit.Files);
+            string href = template
+                .Replace("{bucket}", s3Uri.Bucket)
+                .Replace("{prefix}", s3Uri.Key.TrimEnd('/') + "/");
+            return href;
         }
 
         return "#";

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Search.cshtml.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Search.cshtml.cs
@@ -15,7 +15,7 @@ public class SearchModel(IMediator mediator) : PageModel
     private const int DefaultPageSize = 20;
 
     [BindProperty(SupportsGet=true)]
-    public SearchCollection? SearchModelData { get; set; } // = new SearchCollection();
+    public SearchCollection? SearchModelData { get; set; }
 
 
     [BindProperty(SupportsGet=true)]

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -114,8 +114,8 @@ try
     if (!app.Environment.IsDevelopment())
     {
         app.UseExceptionHandler("/Error");
-        // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     }
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
     
     app

--- a/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Program.cs
@@ -115,7 +115,6 @@ try
     {
         app.UseExceptionHandler("/Error");
         // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-        //app.UseHsts();
     }
     app.UseHsts();
     
@@ -135,7 +134,7 @@ try
 
 
 
-    app.Run();
+    await app.RunAsync();
 }
 catch (Exception ex)
 {
@@ -144,5 +143,5 @@ catch (Exception ex)
 finally
 {
     Log.Information("Shut down complete");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }

--- a/src/DigitalPreservation/DigitalPreservation.Utils/Checksum.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/Checksum.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace DigitalPreservation.Utils;
 
-public class Checksum
+public static class Checksum
 {
     public static string? HashFromStream(Stream openedStream, HashAlgorithm hashAlgorithm)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Utils/UriX.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/UriX.cs
@@ -66,15 +66,6 @@ public static class UriX
         }
         
         // We need to allow a trailing slash, but not a leading one
-        // if (escapedSlug[^1] == '/')
-        // {
-        //     escapedSlug = escapedSlug[..^1];
-        // }
-        // if (escapedSlug == string.Empty)
-        // {
-        //     throw new Exception("Cannot append empty slug");
-        // }
-
         if (escapedSlug[..^1].Contains('/'))
         {
             // We want to do this to force callers to escape parts, because we DO NOT want to escape '/'
@@ -87,9 +78,6 @@ public static class UriX
             uri = new Uri(s + "/");
         }
         return new Uri(uri, escapedSlug);
-
-        //var newUriString = uri.GetStringTemporaryForTesting().TrimEnd('/') + '/' + slug.TrimStart('/');
-        //return new Uri(newUriString);
     }
     
     public static string EscapeForUri(this string s)
@@ -145,12 +133,6 @@ public static class UriX
     {
         return s.Replace("%23", HashReplacement);
     }
-    
-    //
-    // public static string RestoreHashesInAlreadyEscapedString(this string s)
-    // {
-    //     return s.Replace(HashReplacement, "#");
-    // }
 
     public static bool UnescapedEquals(this Uri? u1, Uri? u2)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/WorkspaceManager.cs
@@ -360,7 +360,7 @@ public class WorkspaceManager(
     }
     
     
-    private WorkingDirectory? RemoveRootMetadata(WorkingDirectory wd)
+    private static WorkingDirectory? RemoveRootMetadata(WorkingDirectory wd)
     {
         wd.Modified = DateTime.MinValue;
         // Also do not compare the object directory
@@ -403,49 +403,43 @@ public class WorkspaceManager(
         var (allCombinedDirectories, allCombinedFiles) = depositCombinedDirectory.Flatten();
         var agFiles = existingArchivalGroup?.StorageMap?.Files;
         var unescapedPathAgFiles = agFiles?.ToDictionary(kvp => kvp.Key.UnEscapePathElementsNoHashes(), kvp => kvp.Value);
-        foreach (var combinedFile in allCombinedFiles)
+        foreach (var localPath in allCombinedFiles.Where(cf => cf.FileInMets is not null).Select(cf => cf.LocalPath))
         {
-            if (combinedFile.FileInMets is not null)
+            // It's in the incoming METS...
+            // Inventory Paths seem only to have %20 encoding?
+            if (unescapedPathAgFiles != null && unescapedPathAgFiles.ContainsKey(localPath!))
             {
-                // It's in the incoming METS...
-                // Inventory Paths seem only to have %20 encoding?
-                if (unescapedPathAgFiles != null && unescapedPathAgFiles.ContainsKey(combinedFile.LocalPath!))
-                {
-                    // ...and also in the ArchivalGroup
-                    continue;
-                }
-
-                if (importJob.BinariesToAdd.Exists(b => b.Id!.LocalPath.EscapePathElementsNoHashes() == agLocalPathWithSlash + combinedFile.LocalPath!.EscapePathElementsNoHashes()))
-                {
-                    // It's being added in this operation
-                    continue;
-                }
-                
-                return Result.Fail(ErrorCodes.Conflict, 
-                    "File " + combinedFile.LocalPath + " is in deposit METS but not in existing Archival Group or Deposit.");
+                // ...and also in the ArchivalGroup
+                continue;
             }
+
+            if (importJob.BinariesToAdd.Exists(b => b.Id!.LocalPath.EscapePathElementsNoHashes() == agLocalPathWithSlash + localPath!.EscapePathElementsNoHashes()))
+            {
+                // It's being added in this operation
+                continue;
+            }
+
+            return Result.Fail(ErrorCodes.Conflict,
+                "File " + localPath + " is in deposit METS but not in existing Archival Group or Deposit.");
         }
-        
-        foreach (var combinedDirectory in allCombinedDirectories)
-        {
-            if (combinedDirectory.DirectoryInMets is not null)
-            {
-                // It's in the incoming METS...
-                if (allExistingContainers.Exists(c => c.Id!.LocalPath == agLocalPathWithSlash + combinedDirectory.LocalPath))
-                {
-                    // ...and also in the ArchivalGroup
-                    continue;
-                }
 
-                if (importJob.ContainersToAdd.Exists(c => c.Id!.LocalPath.EscapePathElementsNoHashes() == agLocalPathWithSlash + combinedDirectory.LocalPath!.EscapePathElementsNoHashes()))
-                {
-                    // It's being added in this operation
-                    continue;
-                }
-                
-                return Result.Fail(ErrorCodes.Conflict, 
-                    "Folder " + combinedDirectory.LocalPath + " is in deposit METS but not in existing Archival Group or Deposit.");
+        foreach (var localPath in allCombinedDirectories.Where(cd => cd.DirectoryInMets is not null).Select(cd => cd.LocalPath))
+        {
+            // It's in the incoming METS...
+            if (allExistingContainers.Exists(c => c.Id!.LocalPath == agLocalPathWithSlash + localPath))
+            {
+                // ...and also in the ArchivalGroup
+                continue;
             }
+
+            if (importJob.ContainersToAdd.Exists(c => c.Id!.LocalPath.EscapePathElementsNoHashes() == agLocalPathWithSlash + localPath!.EscapePathElementsNoHashes()))
+            {
+                // It's being added in this operation
+                continue;
+            }
+
+            return Result.Fail(ErrorCodes.Conflict,
+                "Folder " + localPath + " is in deposit METS but not in existing Archival Group or Deposit.");
         }
         
         return Result.Ok();

--- a/src/DigitalPreservation/Pipeline.API/Program.cs
+++ b/src/DigitalPreservation/Pipeline.API/Program.cs
@@ -146,7 +146,7 @@ try
     app.MapGet("/", () => "Pipeline API: Hello World!");
     app.MapControllers();
     app.UseHealthChecks("/health");
-    app.Run();
+    await app.RunAsync();
 }
 catch (HostAbortedException)
 {
@@ -160,11 +160,12 @@ catch (Exception ex)
 finally
 {
     Log.Information("Shut down complete");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }
 
 
 // required for WebApplicationFactory
 public partial class Program
 {
+    protected Program() { }
 }

--- a/src/DigitalPreservation/Preservation.API.Tests/IIIF/ManifestBuilderTests.cs
+++ b/src/DigitalPreservation/Preservation.API.Tests/IIIF/ManifestBuilderTests.cs
@@ -77,7 +77,7 @@ public class ManifestBuilderTests
         var manifest = BuildDeposit(Wrapper(MakeFile("objects/img.tif", "image/tiff", 2000, 3000)));
         var canvas = SingleCanvas(manifest);
         canvas.Thumbnail.Should().NotBeNullOrEmpty();
-        canvas.Thumbnail!.First().Id.Should().StartWith($"{MediaUrl}imagesvc/objects/img.tif/full/");
+        canvas.Thumbnail![0].Id.Should().StartWith($"{MediaUrl}imagesvc/objects/img.tif/full/");
     }
 
     [Fact]
@@ -207,7 +207,7 @@ public class ManifestBuilderTests
         canvas.Annotations.Should().HaveCount(1);
         var anno = (GeneralAnnotation)canvas.Annotations!.Single().Items!.Single();
         anno.Motivation.Should().Be("supplementing");
-        anno.Body!.First().Id.Should().Be($"{MediaUrl}file/objects/t.txt");
+        anno.Body![0].Id.Should().Be($"{MediaUrl}file/objects/t.txt");
     }
 
     // ─── deposit IIIF: IDs and encoding ──────────────────────────────────────────
@@ -380,6 +380,6 @@ public class ManifestBuilderTests
         var manifest = BuildWithOriginUris(Wrapper(main, adjunct), f => origins[f.LocalPath]);
 
         var anno = (GeneralAnnotation)SingleCanvas(manifest).Annotations!.Single().Items!.Single();
-        anno.Body!.First().Id.Should().Be("https://host/t.txt");
+        anno.Body![0].Id.Should().Be("https://host/t.txt");
     }
 }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/DepositsController.cs
@@ -49,7 +49,7 @@ public class DepositsController(
     public async Task<IActionResult> GetDeposit([FromRoute] string id)
     {
         var result = await mediator.Send(new GetDeposit(id));
-        logger.LogInformation("In Preservation API for deposit {deposit} Lock date: {lockDate}, Locked by: {lockedBy} ", result.Value ?.Id, result.Value?.LockDate, result.Value?.LockedBy);
+        logger.LogInformation("In Preservation API for deposit {Deposit} Lock date: {LockDate}, Locked by: {LockedBy} ", result.Value ?.Id, result.Value?.LockDate, result.Value?.LockedBy);
         return this.StatusResponseFromResult(result);
     }
     
@@ -70,7 +70,7 @@ public class DepositsController(
             })
         {
             Response.Headers.ETag = wrapper.Value.MetsFileWrapper.ETag;
-            return Content(wrapper.Value.MetsFileWrapper.XDocument!.ToString(), "application/xml");
+            return Content(wrapper.Value.MetsFileWrapper.XDocument.ToString(), "application/xml");
         }
         return this.StatusResponseFromResult(wrapper);
     }
@@ -158,13 +158,13 @@ public class DepositsController(
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Could not deserialise POSTed IIIF manifest for deposit {id}", id);
+            logger.LogWarning(ex, "Could not deserialise POSTed IIIF manifest for deposit {Id}", id);
             return BadRequest(new ProblemDetails { Title = "Invalid IIIF Manifest", Detail = ex.Message });
         }
 
         if (manifest is null)
         {
-            logger.LogWarning("POSTed IIIF manifest for deposit {id} deserialised to null", id);
+            logger.LogWarning("POSTed IIIF manifest for deposit {Id} deserialised to null", id);
             return BadRequest(new ProblemDetails { Title = "Invalid IIIF Manifest", Detail = "The request body did not contain a manifest." });
         }
 
@@ -205,7 +205,7 @@ public class DepositsController(
             var eTag = Request.Headers.IfMatch.FirstOrDefault();
             if (!eTag.HasText() || eTag != deposit.MetsETag)
             {
-                logger.LogWarning("Supplied eTag {eTag} does not match deposit eTag {depositETag}", eTag, deposit.MetsETag);
+                logger.LogWarning("Supplied eTag {ETag} does not match deposit eTag {DepositETag}", eTag, deposit.MetsETag);
                 var pd = new ProblemDetails
                 {
                     Title = "Conflict: ETag does not match deposit METS",

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposit.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDeposit.cs
@@ -33,7 +33,7 @@ public class GetDepositHandler(
             var wrapperResult = await MetsParser.GetMetsFileWrapper(getDepositResult.Value!.Files!, false);
             if (wrapperResult.Success)
             {
-                var deposit = getDepositResult.Value!;
+                var deposit = getDepositResult.Value;
                 deposit.MetsETag = wrapperResult.Value?.ETag;
                 return Result.Ok(deposit);
             }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositAsIIIFManifest.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositAsIIIFManifest.cs
@@ -24,7 +24,7 @@ public class GetDepositAsIIIFManifest(string id, string tokenBaseUrl, string pla
 
 public class GetDepositAsIIIFManifestHandler(
     IMetsParser metsParser,
-    ILogger<GetDepositHandler> logger,
+    ILogger<GetDepositAsIIIFManifestHandler> logger,
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
@@ -44,7 +44,7 @@ public class GetDepositAsIIIFManifestHandler(
         {
             return Result.FailNotNull<Manifest>(wrapperResult.ErrorCode!, wrapperResult.ErrorMessage);
         }
-        var deposit = getDepositResult.Value!;
+        var deposit = getDepositResult.Value;
         var wrapper = wrapperResult.Value!;
         var manifest = MakeDepositManifest(deposit, wrapper, request.TokenBaseUrl);
         manifestBuilder.MakeCanvasesAndRanges(manifest, wrapper, request.PlainBaseUrl, request.MediaServerBaseUrl);
@@ -83,7 +83,7 @@ public class GetDepositAsIIIFManifestHandler(
 
 
 
-    private string? GetDateDisplay(DateTime? dt)
+    private static string? GetDateDisplay(DateTime? dt)
     {
         return !dt.HasValue ? " - " : dt?.ToLocalTime().ToString("s").Replace("T", " ");
     }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositBase.cs
@@ -12,7 +12,7 @@ using Storage.Client;
 namespace Preservation.API.Features.Deposits.Requests;
 
 public class GetDepositBase(
-    ILogger<GetDepositHandler> logger,
+    ILogger<GetDepositBase> logger,
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
@@ -100,7 +100,7 @@ public class GetDepositBase(
             return;
         }
 
-        var physicalStructure = wrapperResult.Value!.PhysicalStructure!;
+        var physicalStructure = wrapperResult.Value.PhysicalStructure;
         var needsMetadata = physicalStructure.FindDirectory(FolderNames.Metadata) is null;
         var needsAdHoc = physicalStructure.FindDirectory(FolderNames.MetadataAdHoc) is null;
         if (!needsMetadata && !needsAdHoc)

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositWithMets.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/GetDepositWithMets.cs
@@ -16,7 +16,7 @@ public class GetDepositWithMets(string id, bool parse = true) : IRequest<Result<
 
 public class GetDepositWithMetsHandler(
     IMetsParser metsParser,
-    ILogger<GetDepositHandler> logger,
+    ILogger<GetDepositWithMetsHandler> logger,
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,
@@ -32,11 +32,11 @@ public class GetDepositWithMetsHandler(
             var wrapperResult = await MetsParser.GetMetsFileWrapper(getDepositResult.Value!.Files!, request.Parse);
             if (wrapperResult.Success)
             {
-                var deposit = getDepositResult.Value!;
+                var deposit = getDepositResult.Value;
                 deposit.MetsETag = wrapperResult.Value?.ETag;
                 return Result.OkNotNull(new DepositWithMets
                 {
-                    Deposit = getDepositResult.Value!,
+                    Deposit = getDepositResult.Value,
                     MetsFileWrapper = wrapperResult.Value!
                 });
             }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/UpdateLogicalStructMapsFromManifest.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/UpdateLogicalStructMapsFromManifest.cs
@@ -27,7 +27,7 @@ public class UpdateLogicalStructMapsFromManifest(
 
 public class UpdateLogicalStructMapsFromManifestHandler(
     IMetsParser metsParser,
-    ILogger<GetDepositHandler> logger,
+    ILogger<UpdateLogicalStructMapsFromManifestHandler> logger,
     PreservationContext dbContext,
     IStorageApiClient storageApiClient,
     ResourceMutator resourceMutator,

--- a/src/DigitalPreservation/Preservation.API/Features/Iiif/Requests/GetArchivalGroupAsIIIFManifest.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Iiif/Requests/GetArchivalGroupAsIIIFManifest.cs
@@ -82,12 +82,12 @@ public class GetArchivalGroupAsIIIFManifestHandler(
         var agUriPrefix = archivalGroup.Id!.ToString().TrimEnd('/') + "/";
         var (_, allBinaries) = archivalGroup.Flatten();
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var binary in allBinaries)
+        foreach (var id in allBinaries.Select(binary => binary.Id))
         {
-            if (binary.Id is null) continue;
-            var relative = binary.Id.ToString().RemoveStart(agUriPrefix);
+            if (id is null) continue;
+            var relative = id.ToString().RemoveStart(agUriPrefix);
             if (relative is null) continue;
-            result[Uri.UnescapeDataString(relative)] = binary.Id.ToString();
+            result[Uri.UnescapeDataString(relative)] = id.ToString();
         }
         return result;
     }

--- a/src/DigitalPreservation/Preservation.API/Features/ImportJobs/ImportJobsController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/ImportJobs/ImportJobsController.cs
@@ -39,11 +39,11 @@ public class ImportJobsController(
         if (result is { Success: true, Value: not null })
         {
             result.Value.OriginalId = GetDiffUri(depositId);
-            logger.LogInformation($"Controller returning import job: {result.Value.LogSummary()}");
+            logger.LogInformation("Controller returning import job: {ImportJobSummary}", result.Value.LogSummary());
         }
         else
         {
-            logger.LogError("Failed to get diff import job: " + result.CodeAndMessage());
+            logger.LogError("Failed to get diff import job: {ErrorDetail}", result.CodeAndMessage());
         }
         return this.StatusResponseFromResult(result);
     }
@@ -77,11 +77,11 @@ public class ImportJobsController(
     public async Task<IActionResult> ExecuteImportJob([FromRoute] string depositId, [FromBody] ImportJob importJob,
         CancellationToken cancellationToken)
     {
-        logger.LogInformation("Import Jobs Controller: Executing Import Job " + importJob.LogSummary());
+        logger.LogInformation("Import Jobs Controller: Executing Import Job {ImportJobSummary}", importJob.LogSummary());
         var depositResult = await mediator.Send(new GetDeposit(depositId), cancellationToken);
         if (depositResult.Failure)
         {
-            logger.LogError("Unable to fetch deposit " + depositId);
+            logger.LogError("Unable to fetch deposit {DepositId}", depositId);
             return this.StatusResponseFromResult(depositResult);
         }
 
@@ -95,12 +95,12 @@ public class ImportJobsController(
             var diffImportJobResult = await mediator.Send(new GetDiffImportJob(deposit, User), cancellationToken);
             if (diffImportJobResult is { Success: true, Value: not null })
             {
-                importJob = diffImportJobResult.Value!;
+                importJob = diffImportJobResult.Value;
                 importJob.OriginalId = GetDiffUri(depositId);
             }
             else
             {
-                logger.LogError("Unable to fetch diff import job for deposit " + diffImportJobResult.CodeAndMessage());
+                logger.LogError("Unable to fetch diff import job for deposit {ErrorDetail}", diffImportJobResult.CodeAndMessage());
                 return this.StatusResponseFromResult(diffImportJobResult);
             }
         }
@@ -121,15 +121,14 @@ public class ImportJobsController(
             return this.StatusResponseFromResult(checkDeposit);
         }
 
-        foreach (var binary in importJob.BinariesToAdd.Union(importJob.BinariesToPatch))
+        var invalidBinary = importJob.BinariesToAdd.Union(importJob.BinariesToPatch)
+            .FirstOrDefault(binary => !deposit.Files!.IsBaseOf(binary.Origin!));
+        if (invalidBinary != null)
         {
-            if (!deposit.Files!.IsBaseOf(binary.Origin!))
-            {
-                var message = $"Binary origin {binary.Origin} is not a child of deposit file location {deposit.Files}.";
-                logger.LogWarning(message);
-                checkDeposit = Result.FailNotNull<ImportJobResult>(ErrorCodes.BadRequest, message);
-                return this.StatusResponseFromResult(checkDeposit);
-            }
+            var message = $"Binary origin {invalidBinary.Origin} is not a child of deposit file location {deposit.Files}.";
+            logger.LogWarning(message);
+            checkDeposit = Result.FailNotNull<ImportJobResult>(ErrorCodes.BadRequest, message);
+            return this.StatusResponseFromResult(checkDeposit);
         }
 
         var executeImportJobResult = await mediator.Send(new ExecuteImportJob(importJob, User), cancellationToken);
@@ -168,51 +167,49 @@ public class ImportJobsController(
     
     private async Task<Result?> ValidateDeposit(Deposit existingDeposit, int maxCompleted)
     {
-        logger.LogInformation("Validating deposit " + existingDeposit.Id + " with maxCompleted " + maxCompleted);
+        logger.LogInformation("Validating deposit {DepositId} with maxCompleted {MaxCompleted}", existingDeposit.Id, maxCompleted);
         if (existingDeposit.Status == DepositStates.Exporting)
         {
-            logger.LogWarning("Invalid: Deposit is being exported - " + existingDeposit.Id);
+            logger.LogWarning("Invalid: Deposit is being exported - {DepositId}", existingDeposit.Id);
             return Result.Fail(ErrorCodes.BadRequest, "Deposit is being exported");
         }
         if (existingDeposit.ArchivalGroup == null)
         {
-            logger.LogWarning("Invalid: Deposit has no Archival Group - " + existingDeposit.Id);
+            logger.LogWarning("Invalid: Deposit has no Archival Group - {DepositId}", existingDeposit.Id);
             return Result.Fail(ErrorCodes.BadRequest, "Deposit requires Archival Group");
         }
 
         var existingImportJobResultsResult = await mediator.Send(new GetImportJobResultsForDeposit(existingDeposit.Id!.GetSlug()!));
         if (existingImportJobResultsResult.Failure || existingImportJobResultsResult.Value == null)
         {
-            logger.LogError("Cannot check for existing import job results - " + existingDeposit.Id + " - " + existingImportJobResultsResult.CodeAndMessage());
+            logger.LogError("Cannot check for existing import job results - {DepositId} - {ErrorDetail}", existingDeposit.Id, existingImportJobResultsResult.CodeAndMessage());
             return Result.Fail(ErrorCodes.UnknownError, "Could not look for existing import jobs");
         }
         var notErrors = existingImportJobResultsResult.Value.Count(ijr => ijr.Status != ImportJobStates.CompletedWithErrors);
         if (notErrors > maxCompleted)
         {
-            logger.LogWarning("Invalid: there are " + notErrors + " existing non-error import jobs for " + existingDeposit.Id);
+            logger.LogWarning("Invalid: there are {NotErrors} existing non-error import jobs for {DepositId}", notErrors, existingDeposit.Id);
             return Result.Fail(ErrorCodes.Conflict, "There are existing import jobs for this deposit");
         }
-        logger.LogInformation("Deposit " + existingDeposit.Id + " is considered valid");
+        logger.LogInformation("Deposit {DepositId} is considered valid", existingDeposit.Id);
         return null;
     }
     
-    private bool IsPostedDiffReference(ImportJob importJob, PathString path)
+    private static bool IsPostedDiffReference(ImportJob importJob, PathString path)
     {
         // This is when the API caller posts a reference to the diff import job rather than an _actual_ job
         // means we have to build the diff now.
-        if(importJob.Id!.ToString().EndsWith(path + "/diff"))
+        // We may want to be more flexible that this, e.g., allowing the DigitalObject to be set as part of the immediate diff execution
+        if(importJob.Id!.ToString().EndsWith(path + "/diff")
+           && importJob.ContainersToAdd.Count == 0
+           && importJob.ContainersToDelete.Count == 0
+           && importJob.BinariesToAdd.Count == 0
+           && importJob.BinariesToDelete.Count == 0
+           && importJob.BinariesToPatch.Count == 0
+           && importJob.ContainersToRename.Count == 0
+           && importJob.BinariesToRename.Count == 0)
         {
-            // We may want to be more flexible that this, e.g., allowing the DigitalObject to be set as part of the immediate diff execution
-            if(   importJob.ContainersToAdd.Count == 0
-               && importJob.ContainersToDelete.Count == 0
-               && importJob.BinariesToAdd.Count == 0
-               && importJob.BinariesToDelete.Count == 0
-               && importJob.BinariesToPatch.Count == 0
-               && importJob.ContainersToRename.Count == 0
-               && importJob.BinariesToRename.Count == 0)
-            {
-                return true;
-            }
+            return true;
         }
         return false;
     }

--- a/src/DigitalPreservation/Preservation.API/Features/MediaServer/MediaController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/MediaServer/MediaController.cs
@@ -127,13 +127,9 @@ public class MediaController(
     private static bool ValidateLocalPath(string localPath)
     {
         if (string.IsNullOrEmpty(localPath)) return false;
-        foreach (var segment in localPath.Split('/'))
-        {
-            if (string.IsNullOrEmpty(segment) || segment == ".." || segment == "."
-                || segment.Contains('\\') || segment.Contains('\0'))
-                return false;
-        }
-        return true;
+        return !localPath.Split('/').Any(segment =>
+            string.IsNullOrEmpty(segment) || segment == ".." || segment == "."
+            || segment.Contains('\\') || segment.Contains('\0'));
     }
 
     private static string FileETag(string localPath, long? size) =>
@@ -182,7 +178,7 @@ public class MediaController(
             return new NotFoundResult();
         if (item.Size.HasValue)
             httpContext.Response.ContentLength = item.Size.Value;
-        return new FileStreamResult(fullStreamResult.Value.Item1!, contentType);
+        return new FileStreamResult(fullStreamResult.Value.Item1, contentType);
     }
 
     private static IActionResult ServePlaceholder(string localPath)
@@ -203,7 +199,7 @@ public class MediaController(
         var w = parts[0].Length > 0 && int.TryParse(parts[0], out var pw) ? pw : 0;
         var h = parts.Length > 1 && parts[1].Length > 0 && int.TryParse(parts[1], out var ph) ? ph : 0;
 
-        using var image = await Image.LoadAsync(streamResult.Value.Item1!);
+        using var image = await Image.LoadAsync(streamResult.Value.Item1);
         image.Mutate(x => x.Resize(new ResizeOptions
         {
             Size = new SixLabors.ImageSharp.Size(w, h),

--- a/src/DigitalPreservation/Preservation.API/IIIF/ManifestBuilder.cs
+++ b/src/DigitalPreservation/Preservation.API/IIIF/ManifestBuilder.cs
@@ -30,12 +30,12 @@ public class ManifestBuilder
         var linkTargets = new Dictionary<string, List<WorkingFile>>();
         foreach (var file in wrapper.Files)
         {
-            foreach (var fileLink in file.Links)
+            foreach (var to in file.Links.Select(fileLink => fileLink.To))
             {
-                if (!linkTargets.TryGetValue(fileLink.To, out var from))
+                if (!linkTargets.TryGetValue(to, out var from))
                 {
                     from = [];
-                    linkTargets[fileLink.To] = from;
+                    linkTargets[to] = from;
                 }
                 from.Add(file);
             }
@@ -232,7 +232,7 @@ public class ManifestBuilder
         manifest.EnsurePresentation3Context();
     }
 
-    private string GetDcType(string? targetContentType)
+    private static string GetDcType(string? targetContentType)
     {
         if (targetContentType.IsNullOrWhiteSpace())
         {

--- a/src/DigitalPreservation/Preservation.API/IIIF/ManifestParser.cs
+++ b/src/DigitalPreservation/Preservation.API/IIIF/ManifestParser.cs
@@ -18,12 +18,12 @@ public static class ManifestParser
     {
         var canvasBaseUrl = $"{iiifBaseUrl}canvases/";
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var item in manifest.Items ?? [])
+        foreach (var id in (manifest.Items ?? []).Select(item => item.Id))
         {
-            if (item.Id?.StartsWith(canvasBaseUrl) == true)
+            if (id?.StartsWith(canvasBaseUrl) == true)
             {
-                var localPath = item.Id[canvasBaseUrl.Length..].UnEscapePathElements();
-                result[item.Id] = localPath;
+                var localPath = id[canvasBaseUrl.Length..].UnEscapePathElements();
+                result[id] = localPath;
             }
         }
         return result;

--- a/src/DigitalPreservation/Preservation.API/Program.cs
+++ b/src/DigitalPreservation/Preservation.API/Program.cs
@@ -222,7 +222,7 @@ try
     app.MapGet("/test", (IConfiguration configuration) => $"Config value 'TestVal': {configuration["TestVal"]} ");
     app.MapControllers();
     app.UseHealthChecks("/health");
-    app.Run();
+    await app.RunAsync();
 }
 catch (HostAbortedException)
 {
@@ -236,8 +236,11 @@ catch (Exception ex)
 finally
 {
     Log.Information("Shut down complete");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }
 
 // required for WebApplicationFactory
-public partial class Program { }
+public partial class Program
+{
+    protected Program() { }
+}

--- a/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/IPreservationApiClient.cs
@@ -56,7 +56,7 @@ public interface IPreservationApiClient
     
     Task<Result<(string, string)>> GetMetsWithETag(string depositId, CancellationToken cancellationToken);
     Task<Result<string>> GetParsedDepositMets(string depositId, CancellationToken cancellationToken);
-    Task<Result<string>> GetIIIF(string depositId, CancellationToken none);
+    Task<Result<string>> GetIIIF(string depositId, CancellationToken cancellationToken);
     
     Task<Result<ArchivalGroup?>> TestArchivalGroupPath(string archivalGroupPathUnderRoot);
     Task<(Stream?, string?)> GetContentStream(string repositoryPath, CancellationToken cancellationToken);

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -434,10 +434,10 @@ public class PreservationApiClient(
         return await ProxyStringFromPreservationApi(cancellationToken, relPath);
     }    
     
-    public async Task<Result<string>> GetIIIF(string depositId, CancellationToken none)
+    public async Task<Result<string>> GetIIIF(string depositId, CancellationToken cancellationToken)
     {
         var relPath = $"/deposits/{depositId}/iiif";
-        return await ProxyStringFromPreservationApi(none, relPath);
+        return await ProxyStringFromPreservationApi(cancellationToken, relPath);
     }
 
     private async Task<Result<string>> ProxyStringFromPreservationApi(CancellationToken cancellationToken, string relPath)

--- a/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
+++ b/src/DigitalPreservation/Preservation.Client/PreservationApiClient.cs
@@ -26,7 +26,7 @@ public class PreservationApiClient(
     private readonly HttpClient preservationHttpClient = httpClient;
 
 
-    public async Task<Result<SearchCollection?>> Search(string text, int? page, int? pageSize, SearchType type, int otherPage, CancellationToken cancellationToken = default)
+    public async Task<Result<SearchCollection?>> Search(string text, int? page = 0, int? pageSize = 50, SearchType type = SearchType.All, int otherPage = 0, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -197,7 +197,7 @@ public class PreservationApiClient(
         TemplateType templateType,
         bool export,
         string? exportVersion,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         Uri postTarget;
         var deposit = new Deposit
@@ -268,7 +268,7 @@ public class PreservationApiClient(
         catch (Exception e)
         {
             var errorCode = ErrorCodes.GetErrorCode(responseStatusCode);
-            logger.LogError(e, "status code was {status}, error was {message}", responseStatusCode, e.Message);
+            logger.LogError(e, "status code was {Status}, error was {Message}", responseStatusCode, e.Message);
             return Result.FailNotNull<DepositQueryPage>(errorCode, e.Message);
         }
     }
@@ -391,7 +391,7 @@ public class PreservationApiClient(
                 var deposit = await response.Content.ReadFromJsonAsync<Deposit>(cancellationToken: cancellationToken);
                 if (deposit is not null)
                 {
-                    logger.LogInformation("In preservation API client for deposit {deposit} Lock date: {lockDate}, Locked by: {lockedBy} ", deposit.Id, deposit?.LockDate, deposit?.LockedBy);
+                    logger.LogInformation("In preservation API client for deposit {Deposit} Lock date: {LockDate}, Locked by: {LockedBy} ", deposit.Id, deposit?.LockDate, deposit?.LockedBy);
                     return Result.Ok(deposit);
                 }
                 return Result.Fail<Deposit>(ErrorCodes.NotFound, "No resource at " + uri);
@@ -434,10 +434,10 @@ public class PreservationApiClient(
         return await ProxyStringFromPreservationApi(cancellationToken, relPath);
     }    
     
-    public async Task<Result<string>> GetIIIF(string depositId, CancellationToken cancellationToken)
+    public async Task<Result<string>> GetIIIF(string depositId, CancellationToken none)
     {
         var relPath = $"/deposits/{depositId}/iiif";
-        return await ProxyStringFromPreservationApi(cancellationToken, relPath);
+        return await ProxyStringFromPreservationApi(none, relPath);
     }
 
     private async Task<Result<string>> ProxyStringFromPreservationApi(CancellationToken cancellationToken, string relPath)
@@ -580,11 +580,11 @@ public class PreservationApiClient(
         }
     }
 
-    public async Task<Result<ProcessPipelineResult>> GetPipelineJobResult(string depositId, string pipelineJobId, CancellationToken cancellationToken)
+    public async Task<Result<ProcessPipelineResult>> GetPipelineJobResult(string depositId, string pipelineJobResultId, CancellationToken cancellationToken)
     {
         try
         {
-            var uri = new Uri($"/deposits/{depositId}/pipelinerunjobs/{pipelineJobId}", UriKind.Relative);
+            var uri = new Uri($"/deposits/{depositId}/pipelinerunjobs/{pipelineJobResultId}", UriKind.Relative);
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await preservationHttpClient.SendAsync(req, cancellationToken);
             if (response.IsSuccessStatusCode)

--- a/src/DigitalPreservation/Registrant/Program.cs
+++ b/src/DigitalPreservation/Registrant/Program.cs
@@ -9,7 +9,7 @@ using Storage.Client;
 
 namespace Registrant;
 
-class Program
+static class Program
 {
     static async Task Main(string[] args)
     {
@@ -44,7 +44,6 @@ class Program
             dlcsOptions,
             GetHttpClient(dlcsOptions.Value.ApiEntryPoint!, dlcsUser, dlcsPassword));
 
-        //var validatedSpace = requestedSpace;
         var validatedSpace = await EnsureSpace(dlcs, requestedSpace);
         if (validatedSpace <= 0)
         {
@@ -86,7 +85,7 @@ class Program
         }
 
         var hydraCollection = new HydraImageCollection { Members = imagesToRegister.ToArray() };
-        var batch = await dlcs.RegisterImages(hydraCollection);
+        await dlcs.RegisterImages(hydraCollection);
 
         Console.WriteLine("Hydra images registered");
     }

--- a/src/DigitalPreservation/Storage.API.Importer/Program.cs
+++ b/src/DigitalPreservation/Storage.API.Importer/Program.cs
@@ -69,7 +69,7 @@ try
     
     var app = builder.Build();
     app.UseHealthChecks("/health");
-    app.Run();
+    await app.RunAsync();
 }
 
 catch (HostAbortedException)
@@ -84,5 +84,5 @@ catch (Exception ex)
 finally
 {
     Log.Information("Shut down complete");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }

--- a/src/DigitalPreservation/Storage.API/Features/Binaries/ContentController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Binaries/ContentController.cs
@@ -42,7 +42,7 @@ public class ContentController(
         var streamResult = await storage.GetStream(binary.Origin!);
         if (streamResult is { Success: true, Value.ResponseStream: not null })
         {
-            return new FileStreamResult(streamResult.Value.ResponseStream!, binary.ContentType!);
+            return new FileStreamResult(streamResult.Value.ResponseStream, binary.ContentType!);
         }
 
         var pdr = streamResult.ToProblemDetails("Cannot stream content");

--- a/src/DigitalPreservation/Storage.API/Features/Export/ExportController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Export/ExportController.cs
@@ -20,7 +20,7 @@ public class ExportController(
         [FromBody] ExportResource export, 
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Queuing export for {path}", export.ArchivalGroup.GetPathUnderRoot());
+        logger.LogInformation("Queuing export for {Path}", export.ArchivalGroup.GetPathUnderRoot());
         var queueExportResult = await mediator.Send(new QueueExport(export), cancellationToken);
         logger.LogInformation("Returned from QueueExport");
         var createdLocation = queueExportResult.Success ? queueExportResult.Value!.Id : null;

--- a/src/DigitalPreservation/Storage.API/Features/Export/ExportMetsOnlyController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Export/ExportMetsOnlyController.cs
@@ -21,7 +21,7 @@ public class ExportMetsOnlyController(
         [FromBody] ExportResource export,
         CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Synchronously exporting METS export for {path}", export.ArchivalGroup.GetPathUnderRoot());
+        logger.LogInformation("Synchronously exporting METS export for {Path}", export.ArchivalGroup.GetPathUnderRoot());
         var metsExportResult = await mediator.Send(new ExecuteExport(null, export, true), cancellationToken);
         return this.StatusResponseFromResult(metsExportResult);
     }

--- a/src/DigitalPreservation/Storage.API/Features/Import/ImportController.cs
+++ b/src/DigitalPreservation/Storage.API/Features/Import/ImportController.cs
@@ -46,7 +46,7 @@ public class ImportController(
     [Produces("application/json")]
     public async Task<IActionResult> ExecuteImportJob([FromBody] ImportJob importJob, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("Executing import job {path}", importJob.ArchivalGroup);
+        logger.LogInformation("Executing import job {Path}", importJob.ArchivalGroup);
         var queueImportJobResult = await mediator.Send(new QueueImportJob(importJob), cancellationToken);
         logger.LogInformation("Returned from QueueImportJob");
         return this.StatusResponseFromResult(queueImportJobResult, 201, queueImportJobResult.Value?.Id);

--- a/src/DigitalPreservation/Storage.API/Program.cs
+++ b/src/DigitalPreservation/Storage.API/Program.cs
@@ -196,7 +196,7 @@ try
     app.MapGet("/", () => "Storage: Hello World!");
     app.MapControllers();
     app.UseHealthChecks("/health");
-    app.Run();
+    await app.RunAsync();
 }
 catch (HostAbortedException)
 {
@@ -210,8 +210,11 @@ catch (Exception ex)
 finally
 {
     Log.Information("Shut down complete");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }
 
 // required for WebApplicationFactory
-public partial class Program { }
+public partial class Program
+{
+    protected Program() { }
+}

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -183,7 +183,7 @@ public class Storage(
         return allObjects.Select(s3Object => s3Object.GetS3Uri()).ToList();
     }
 
-    public async Task<Result<WorkingDirectory>> AddToDepositFileSystem(Uri location, WorkingDirectory directoryToAdd, CancellationToken cancellationToken = default)
+    public async Task<Result<WorkingDirectory>> AddToDepositFileSystem(Uri location, WorkingDirectory directoryToAdd, CancellationToken cancellationToken)
     {
         try
         {
@@ -206,7 +206,7 @@ public class Storage(
         }
     }
 
-    public async Task<Result<WorkingDirectory>> AddToDepositFileSystem(Uri location, WorkingFile fileToAdd, CancellationToken cancellationToken = default)
+    public async Task<Result<WorkingDirectory>> AddToDepositFileSystem(Uri location, WorkingFile fileToAdd, CancellationToken cancellationToken)
     {
         try
         {
@@ -243,7 +243,7 @@ public class Storage(
         return saveResult;
     }
 
-    public async Task<Result> DeleteFromDepositFileSystem(Uri location, string path, bool errorIfNotFound, CancellationToken cancellationToken = default)
+    public async Task<Result> DeleteFromDepositFileSystem(Uri location, string path, bool errorIfNotFound, CancellationToken cancellationToken)
     {
         var wdResult = await ReadDepositFileSystem(location, cancellationToken);
         if (wdResult.Success)
@@ -305,13 +305,11 @@ public class Storage(
             var failResult = ResultHelpers.FailFromAwsStatusCode<WorkingDirectory>(
                 resp.HttpStatusCode, "Could not read METS location", gor.GetS3Uri());
             return failResult;
-            //return Result.Generify<WorkingDirectory?>(failResult);
         }
         catch (AmazonS3Exception s3E)
         {
             var exResult = ResultHelpers.FailFromS3Exception<WorkingDirectory>(s3E, "Could not read METS location", gor.GetS3Uri());
             return exResult;
-            //return Result.Generify<WorkingDirectory?>(exResult);
         }
         catch (Exception e)
         {
@@ -322,10 +320,10 @@ public class Storage(
     public async Task<Result<WorkingDirectory?>> GenerateDepositFileSystem(
         Uri location, 
         bool writeToStorage, 
-        Action<WorkingBase>? decorator, 
-        CancellationToken cancellationToken = default)
+        Action<WorkingBase>? decorator,
+        CancellationToken cancellationToken)
     {
-        logger.LogInformation("Generating deposit file system in " + location);
+        logger.LogInformation("Generating deposit file system in {Location}", location);
         try
         {
             var s3Location = new AmazonS3Uri(location);
@@ -382,12 +380,9 @@ public class Storage(
                     // need to get these from METS-like
                     wf.ContentType = metadataResponse.Headers.ContentType;
                     wf.Digest = AwsChecksum.FromBase64ToHex(metadataResponse.ChecksumSHA256);
-                    if (metadata != null)
+                    if (metadata != null && metadata.Keys.Contains(S3Helpers.OriginalNameMetadataResponseKey))
                     {
-                        if (metadata.Keys.Contains(S3Helpers.OriginalNameMetadataResponseKey))
-                        {
-                            wf.Name = WebUtility.UrlDecode(metadata[S3Helpers.OriginalNameMetadataResponseKey]);
-                        }
+                        wf.Name = WebUtility.UrlDecode(metadata[S3Helpers.OriginalNameMetadataResponseKey]);
                     }
 
                     decorator?.Invoke(wf);
@@ -443,7 +438,7 @@ public class Storage(
         }
     }
 
-    private int WorkingBaseComparer(WorkingBase x, WorkingBase y)
+    private static int WorkingBaseComparer(WorkingBase x, WorkingBase y)
     {
         return string.Compare(x.LocalPath, y.LocalPath, StringComparison.InvariantCulture);
     }
@@ -473,11 +468,11 @@ public class Storage(
                     var pResp = await s3Client.PutObjectAsync(pReq);
                     if (pResp.HttpStatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
                     {
-                        logger.LogDebug("S3 check can write to S3 bucket");
+                        logger.LogDebug(s3E, "S3 check can write to S3 bucket");
                         result.Success = true;
                         return result;
                     }
-                    logger.LogWarning("S3 check returned status {status} on PUT", pResp.HttpStatusCode);
+                    logger.LogWarning("S3 check returned status {Status} on PUT", pResp.HttpStatusCode);
                     result.Error = $"S3 check returned status ${pResp.HttpStatusCode} on PUT";
                     return result;
                 }
@@ -503,13 +498,13 @@ public class Storage(
 
     public async Task<Result<BulkDeleteResult>> EmptyStorageLocation(Uri storageLocation, CancellationToken cancellationToken)
     {
-        logger.LogInformation("About to delete contents of {storageLocation}", storageLocation);
+        logger.LogInformation("About to delete contents of {StorageLocation}", storageLocation);
         // TODO: MUST Validate bucket and key of root here -
         //  only a permitted bucket, and only a deposits/ path.
         var s3Uri = new AmazonS3Uri(storageLocation);
         var allObjects = await ListAllS3Objects(s3Uri, cancellationToken);
 
-        logger.LogInformation("{locationCount} objects in location {storageLocation}", allObjects.Count, storageLocation);
+        logger.LogInformation("{LocationCount} objects in location {StorageLocation}", allObjects.Count, storageLocation);
         int count = 0;
         int deleted = 0;
         while (count < allObjects.Count)
@@ -525,15 +520,15 @@ public class Storage(
             {
                 dor.AddKey(s3Obj.Key);
             }
-            logger.LogInformation("Deleting batch of {batchCount} from {storageLocation}", batch.Count, storageLocation);
+            logger.LogInformation("Deleting batch of {BatchCount} from {StorageLocation}", batch.Count, storageLocation);
             var response = await s3Client.DeleteObjectsAsync(dor, cancellationToken);
-            logger.LogInformation("AWS reports {deleteCount} objects deleted from {storageLocation}", response.DeletedObjects.Count, storageLocation);
+            logger.LogInformation("AWS reports {DeleteCount} objects deleted from {StorageLocation}", response.DeletedObjects.Count, storageLocation);
             deleted += response.DeletedObjects.Count;
         }
-        logger.LogInformation("Deletion summary for location {storageLocation}", storageLocation);
-        logger.LogInformation("Objects to delete: {locationCount}", allObjects.Count);
-        logger.LogInformation("Objects processed: {count}", count);
-        logger.LogInformation("Objects deleted: {deleted}", deleted);
+        logger.LogInformation("Deletion summary for location {StorageLocation}", storageLocation);
+        logger.LogInformation("Objects to delete: {LocationCount}", allObjects.Count);
+        logger.LogInformation("Objects processed: {Count}", count);
+        logger.LogInformation("Objects deleted: {Deleted}", deleted);
         var bulkDelete = new BulkDeleteResult
         {
             Location = storageLocation,
@@ -557,8 +552,6 @@ public class Storage(
 
         // This would be an efficient way of doing this - but with this naive implementation
         // we're going to read the object twice
-        // var s3Stream = await s3Client!.GetObjectStreamAsync(s3Uri.Bucket, s3Uri.Key, null);
-        // expected = Checksum.Sha256FromStream(s3Stream);
         // could get a byte array here and then pass it along eventually to MakeBinaryPutOrPost
         // for now just read it twice.
         // Later we'll get the sha256 checksum from metadata

--- a/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Storage.cs
@@ -468,7 +468,7 @@ public class Storage(
                     var pResp = await s3Client.PutObjectAsync(pReq);
                     if (pResp.HttpStatusCode is HttpStatusCode.Created or HttpStatusCode.OK)
                     {
-                        logger.LogDebug(s3E, "S3 check can write to S3 bucket");
+                        logger.LogDebug(s3E, "S3 health check object absent on GET; created it, so S3 check can write to S3 bucket");
                         result.Success = true;
                         return result;
                     }

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseLiddle.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseLiddle.cs
@@ -35,7 +35,7 @@ public class ParseLiddle
         result.Value.Should().NotBeNull();
         result.Value!.Self.Should().NotBeNull();
         result.Value.Self!.Digest.Should().NotBeEmpty();
-        var phys = result.Value!.PhysicalStructure;
+        var phys = result.Value.PhysicalStructure;
         phys!.Files.Should().Contain(f => f.Name == "liddle.mets.xml");
 
         result.Value.Name.Should().Be("Liddle Tapes 1 and 2");
@@ -167,7 +167,7 @@ public class ParseLiddle
 
         // MetsExtensions IDs
         tape1side1.MetsExtensions!.DivId.Should().Be("PHYS_objects/tape1side1.wav");
-        tape1side1.MetsExtensions!.AdmId.Should().Be("ADM_objects/tape1side1.wav");
+        tape1side1.MetsExtensions.AdmId.Should().Be("ADM_objects/tape1side1.wav");
 
         // Logical structMap: 1 structMap, root is a Collection with 4 child Item ranges
         result.Value.LogicalStructures.Should().HaveCount(1);

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseWomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseWomenOfWestminster.cs
@@ -35,7 +35,7 @@ public class ParseWomenOfWestminster
         result.Value.Should().NotBeNull();
         result.Value!.Self.Should().NotBeNull();
         result.Value.Self!.Digest.Should().NotBeEmpty();
-        var phys = result.Value!.PhysicalStructure;
+        var phys = result.Value.PhysicalStructure;
         phys!.Files.Should().Contain(f => f.Name == "wow.mets.xml");
         
         
@@ -205,10 +205,10 @@ public class ParseWomenOfWestminster
         // inherited from div in logical structMap
         ruddAudio.EffectiveRecordInfo.Should().NotBeNull();
         ruddAudio.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
-        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
-        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
-        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
-        ruddAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        ruddAudio.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        ruddAudio.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        ruddAudio.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        ruddAudio.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
         // inherited from physical structMap objects/ div
         ruddAudio.EffectiveAccessRestrictions.Should().HaveCount(1);
         ruddAudio.EffectiveAccessRestrictions[0].Should().Be("Level1");
@@ -218,10 +218,10 @@ public class ParseWomenOfWestminster
         // inherited from div in logical structMap
         ruddTranscript.EffectiveRecordInfo.Should().NotBeNull();
         ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
-        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
-        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
-        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
-        ruddTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
+        ruddTranscript.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        ruddTranscript.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("mg56cva7");
+        ruddTranscript.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        ruddTranscript.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249/1");
         // inherited from physical structMap objects/ div
         ruddTranscript.EffectiveAccessRestrictions.Should().HaveCount(1);
         ruddTranscript.EffectiveAccessRestrictions[0].Should().Be("Level1");
@@ -230,10 +230,10 @@ public class ParseWomenOfWestminster
         // inherited from div in logical structMap
         eagleRedactedAudio.EffectiveRecordInfo.Should().NotBeNull();
         eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
-        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
-        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
-        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
-        eagleRedactedAudio.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        eagleRedactedAudio.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        eagleRedactedAudio.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        eagleRedactedAudio.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        eagleRedactedAudio.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
         // inherited from physical structMap objects/ div
         eagleRedactedAudio.EffectiveAccessRestrictions.Should().HaveCount(1);
         eagleRedactedAudio.EffectiveAccessRestrictions[0].Should().Be("Level1");
@@ -243,10 +243,10 @@ public class ParseWomenOfWestminster
         // inherited from div in logical structMap
         eagleTranscript.EffectiveRecordInfo.Should().NotBeNull();
         eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers.Should().HaveCount(2);
-        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Source.Should().Be("identity-service");
-        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
-        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Source.Should().Be("EMu");
-        eagleTranscript.EffectiveRecordInfo!.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
+        eagleTranscript.EffectiveRecordInfo.RecordIdentifiers[0].Source.Should().Be("identity-service");
+        eagleTranscript.EffectiveRecordInfo.RecordIdentifiers[0].Value.Should().Be("hh43pd32");
+        eagleTranscript.EffectiveRecordInfo.RecordIdentifiers[1].Source.Should().Be("EMu");
+        eagleTranscript.EffectiveRecordInfo.RecordIdentifiers[1].Value.Should().Be("MS 2249/2");
         // inherited from physical structMap objects/ div
         eagleTranscript.EffectiveAccessRestrictions.Should().HaveCount(1);
         eagleTranscript.EffectiveAccessRestrictions[0].Should().Be("Level1");
@@ -268,7 +268,7 @@ public class ParseWomenOfWestminster
         // divIds, other props we might be interested in
         // This needs more work to be consistent.
         eagleAudio.MetsExtensions!.DivId.Should().Be("PHYS_objects/angela-eagle.m4a");
-        eagleAudio.MetsExtensions!.AdmId.Should().Be("ADM_objects/angela-eagle.m4a");
+        eagleAudio.MetsExtensions.AdmId.Should().Be("ADM_objects/angela-eagle.m4a");
 
         // locate files by ID and localpath
         // This is the ID of the file's mets:div in the physical structMap. Do we want to be able to get by mets:file ID property? 

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ThirdPartyMetsParsing.cs
@@ -94,7 +94,7 @@ public class ThirdPartyMetsParsing
         // LOG_0000 (Archive, "Requires registration") claims all 266 pages.
         // 57 child ranges (LOG_0001–LOG_0046, LOG_0048–LOG_0058) each have "Restricted files"
         //   and claim 93 pages total between them.
-        // LOG_0047 has no DMDID (no own access condition) and claims PHYS_0220 and PHYS_0221;
+        // LOG_0047 has no DMDID (no own access condition) and claims PHYS_0220 and PHYS_0221 -
         //   it inherits "Requires registration" from LOG_0000.
         // Deepest-only: 93 pages go to "Restricted files" children, 2 go to LOG_0047, 171 stay in LOG_0000.
         // Net file access counts: 173 "Requires registration", 93 "Restricted files".
@@ -184,7 +184,7 @@ public class ThirdPartyMetsParsing
         result.Value.Should().NotBeNull();
         result.Value!.Self.Should().NotBeNull();
         result.Value.Self!.Digest.Should().NotBeEmpty();
-        var phys = result.Value!.PhysicalStructure;
+        var phys = result.Value.PhysicalStructure;
         phys!.Files.Should().Contain(f => f.Name == "goobi-wc-b29356350.xml");
         
         result.Value.Name.Should().Be("[Report 1960] /");

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/RoundTripping/RoundTripWomenOfWestminster.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/RoundTripping/RoundTripWomenOfWestminster.cs
@@ -279,7 +279,7 @@ public class RoundTripWomenOfWestminster
         var logsm = wrapper.LogicalStructures[0];
         logsm.Type.Should().Be("Collection");
         logsm.Name.Should().Be("Women of Westminster");
-        // Name is the value set in LogicalRange.Name, written as both LABEL and MODS title;
+        // Name is the value set in LogicalRange.Name, written as both LABEL and MODS title -
         // the parser prefers MODS title, so this is "Women of Westminster" (not a sample-file title)
         logsm.Files.Should().HaveCount(0);
         logsm.Ranges.Should().HaveCount(2);

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerDeepStructureTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerDeepStructureTests.cs
@@ -100,7 +100,7 @@ public class MetsManagerDeepStructureTests
         new()
         {
             LocalPath = localPath,
-            Name = localPath.Split('/').Last(),
+            Name = localPath.Split('/')[^1],
             ContentType = "application/pdf",
             Digest = PdfDigest,
             Size = 102400,
@@ -111,7 +111,7 @@ public class MetsManagerDeepStructureTests
         new()
         {
             LocalPath = localPath,
-            Name = localPath.Split('/').Last(),
+            Name = localPath.Split('/')[^1],
             ContentType = "image/tiff",
             Digest = TifDigest,
             Size = 4096000,

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
@@ -756,7 +756,7 @@ public class MetsManagerWithPremis
         // Initially empty
         var wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.AccessRestrictions.Should().BeNull();
-        wrapper.PhysicalStructure!.Directories.Single(d => d.LocalPath == "objects").AccessRestrictions.Should().BeNull();
+        wrapper.PhysicalStructure.Directories.Single(d => d.LocalPath == "objects").AccessRestrictions.Should().BeNull();
 
         // Set two restrictions on objects and write
         metsManager.SetAccessRestrictionsByPath(fullMets, "objects", ["Restricted", "Leeds only"]);
@@ -764,7 +764,7 @@ public class MetsManagerWithPremis
 
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.AccessRestrictions.Should().BeNull();
-        var objectsAccessRestrictions = wrapper.PhysicalStructure!.Directories
+        var objectsAccessRestrictions = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").AccessRestrictions;
         objectsAccessRestrictions.Should().HaveCount(2);
         objectsAccessRestrictions.Should().Contain("Restricted");
@@ -776,7 +776,7 @@ public class MetsManagerWithPremis
         
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.AccessRestrictions.Should().BeNull();
-        objectsAccessRestrictions = wrapper.PhysicalStructure!.Directories
+        objectsAccessRestrictions = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").AccessRestrictions;
         objectsAccessRestrictions.Should().ContainSingle().Which.Should().Be("Open access");
 
@@ -785,7 +785,7 @@ public class MetsManagerWithPremis
         await metsManager.WriteMets(fullMets);
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.AccessRestrictions.Should().BeNull();
-        objectsAccessRestrictions = wrapper.PhysicalStructure!.Directories
+        objectsAccessRestrictions = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").AccessRestrictions;
         objectsAccessRestrictions.Should().BeNull();
     }
@@ -799,7 +799,7 @@ public class MetsManagerWithPremis
         // Initially null
         var wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.RightsStatement.Should().BeNull();
-        wrapper.PhysicalStructure!.Directories.Single(d => d.LocalPath == "objects").RightsStatement.Should().BeNull();
+        wrapper.PhysicalStructure.Directories.Single(d => d.LocalPath == "objects").RightsStatement.Should().BeNull();
     
         // Set a rights URI and write
         var ccBy = new Uri("https://creativecommons.org/licenses/by/4.0/");
@@ -808,7 +808,7 @@ public class MetsManagerWithPremis
         
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.RightsStatement.Should().BeNull();
-        var rightsStatement = wrapper.PhysicalStructure!.Directories
+        var rightsStatement = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").RightsStatement;
         rightsStatement.Should().Be(ccBy);
     
@@ -819,7 +819,7 @@ public class MetsManagerWithPremis
         
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.RightsStatement.Should().BeNull();
-        rightsStatement = wrapper.PhysicalStructure!.Directories
+        rightsStatement = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").RightsStatement;
         rightsStatement.Should().Be(inC);
         
@@ -829,7 +829,7 @@ public class MetsManagerWithPremis
     
         wrapper = (await parser.GetMetsFileWrapper(metsUri)).Value!;
         wrapper.PhysicalStructure!.RightsStatement.Should().BeNull();
-        rightsStatement = wrapper.PhysicalStructure!.Directories
+        rightsStatement = wrapper.PhysicalStructure.Directories
             .Single(d => d.LocalPath == "objects").RightsStatement;
         rightsStatement.Should().BeNull();
     }

--- a/src/DigitalPreservation/XmlGen.Tests/MetsWrapperTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsWrapperTests.cs
@@ -67,7 +67,7 @@ public class MetsWrapperTests
         result.Value.Should().NotBeNull();
         result.Value!.Self.Should().NotBeNull();
         result.Value.Self!.Digest.Should().NotBeEmpty();
-        var phys = result.Value!.PhysicalStructure;
+        var phys = result.Value.PhysicalStructure;
         phys!.Files.Should().Contain(f => f.Name == "EPrints.10315.METS.xml");
 
         result.Value.Name.Should().Be("[Example title]");
@@ -105,7 +105,7 @@ public class MetsWrapperTests
         result.Value.Should().NotBeNull();
         result.Value!.Self.Should().NotBeNull();
         result.Value.Self!.Digest.Should().NotBeEmpty();
-        var phys = result.Value!.PhysicalStructure;
+        var phys = result.Value.PhysicalStructure;
         phys!.Files.Should().Contain(f => f.Name == "archivematica-wc-METS.299eb16f-1e62-4bf6-b259-c82146153711.xml");
 
         result.Value.Name.Should().BeNull(); // No name in Archivematica METS
@@ -146,7 +146,7 @@ public class MetsWrapperTests
 
         // Archivematica PREMIS rightsStatements are administrative, not MODS access conditions —
         // they must not surface as effective access/rights on files; no file links either
-        var allFiles = result.Value.Files.Where(f => f.LocalPath != result.Value.Self!.LocalPath);
+        var allFiles = result.Value.Files.Where(f => f.LocalPath != result.Value.Self.LocalPath);
         allFiles.Should().OnlyContain(f =>
             f.EffectiveAccessRestrictions.Count == 0 &&
             f.EffectiveRightsStatement == null &&

--- a/src/DigitalPreservation/XmlGen.Tests/ModsTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/ModsTests.cs
@@ -34,8 +34,7 @@ public class ModsTests
     public void Build_Premis_Get_XmlElement()
     {
         var mods = ModsManager.CreateRootMods("This is the name of the object");
-        var xmlElement = ModsManager.GetXmlElement(mods);
-        // testOutputHelper.WriteLine(xmlElement?.OuterXml);
+        ModsManager.GetXmlElement(mods);
     }
     
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/Parsing/EffectiveMetadataInheritanceTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Parsing/EffectiveMetadataInheritanceTests.cs
@@ -1223,7 +1223,7 @@ public class EffectiveMetadataInheritanceTests : MetsParserTestBase
     {
         // From WoW and Liddle: logical ranges have no explicit access, and DMD_PHYS_ROOT has
         // only a title (no access conditions). Therefore EffectiveAccessRestrictions = [].
-        // Note: the objects/ access restriction ("Level1") does NOT propagate to logical ranges;
+        // Note: the objects/ access restriction ("Level1") does NOT propagate to logical ranges -
         // only DMD_PHYS_ROOT can supply access/rights to logical ranges.
         var xml = """
             <mets:mets xmlns:mets="http://www.loc.gov/METS/"


### PR DESCRIPTION
## What

PR #177 merged a long-lived experimental branch, which dropped all of its code into main's SonarCloud **new code period** at once (the PR-level analysis itself passed with 0–3 issues — this flood is an accounting effect of the merge, not new defects).

This PR clears the mechanical warnings in the 48 merge-touched files that had them (~170 issues):

- **S8969/S8970** — redundant null-forgiving `!` operators removed
- **S6678 / S2629 / S6667 / S6672** — logging hygiene: PascalCase placeholders, no interpolation in templates, exceptions passed to the logger, correct `ILogger<T>` categories
- **S6966** — service hosts now `await app.RunAsync()` (and `Log.CloseAndFlushAsync()`) instead of the blocking sync forms
- **S125** — commented-out code deleted (genuine explanatory comments false-flagged by trailing semicolons were kept, reworded)
- **S2325 / S6608 / S1006 / S1066 / S1118 / S3267 / S1481 / S927** — assorted mechanical style fixes

## Deliberately not fixed (mark as Accepted in SonarCloud instead)

- **S5332 / S1075** — canonical `http://` rights-statement and CC URIs (identifiers, not endpoints) and S3 path-delimiter constants, concentrated in `RightsStatement.cs`
- **S1135** — TODOs
- Seven **S2325** static suggestions on public API members (`PremisManagerExif`, `WorkspaceManager.ValidateImportJob`) and a Razor page model property, where `static` would change the public surface

## Verification

- Full solution builds with 0 errors, 0 compiler warnings
- SonarAnalyzer.CSharp re-run confirms only the seven documented S2325 skips remain of the targeted rules in these files
- Full test suite: 527 passed, 3 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)