### PR TITLE
Fix/lpii 135/failing clam av concurrent threads

### DIFF
--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -43,6 +43,15 @@ RUN apt-get install python3-full python3-pip -y
 RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN pip3 install --upgrade brunnhilde
 RUN brunnhilde.py -V
+
+# No locale is configured in this image, so Python's default text encoding for stdout/stderr and
+# for any open() call without an explicit encoding falls back to a restrictive non-UTF-8 codec.
+# A deposit file with a non-ASCII character in its name or embedded metadata (e.g. "o" with a
+# macron) then crashes/hangs Brunnhilde mid-run with "'charmap' codec can't encode character ..."
+# - and since Pipeline.API processes SQS jobs one at a time, a hang here wedges every subsequent
+# job at "waiting" indefinitely. PYTHONUTF8=1 forces UTF-8 everywhere for every Python process in
+# this image (Brunnhilde and bagit.py both), not just the narrower PYTHONIOENCODING stdout fix.
+ENV PYTHONUTF8=1
 #clam av
 RUN apt-get install clamav clamav-freshclam clamav-daemon util-linux -y
 RUN freshclam

--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -15,6 +15,16 @@ RUN dotnet publish "Pipeline.API.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 
+# This container has no hard memory limit set in its ECS task definition (only a 1536 MiB soft
+# memory_reservation) - deliberately, so two tasks (old + new) can overlap on this single-instance
+# EC2 cluster during a rolling deployment without exceeding the host's ~3839 MiB. Without a cgroup
+# hard limit for .NET's container detection to size against, the default GC heuristics treat
+# memory as effectively unlimited and hold onto committed memory as a high-water mark rather than
+# returning it to the OS between pipeline jobs - measured climbing past 2.4GB and staying there
+# across separate job runs on the same host (LPII-135). GCConserveMemory trades some GC throughput
+# for actively releasing memory back to the OS on collection instead, independent of any hard limit.
+ENV DOTNET_GCConserveMemory=9
+
 #run as root user
 RUN mkdir /usr/process-brunnhilde
 RUN chmod 777 /usr/process-brunnhilde

--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -60,6 +60,21 @@ RUN sed -i '/^Example/d' /etc/clamav/clamd.conf /etc/clamav/freshclam.conf
 RUN sed -i 's#^LocalSocket .*#LocalSocket /var/run/clamav/clamd.sock#' /etc/clamav/clamd.conf
 RUN sed -i 's#^LocalSocketMode .*#LocalSocketMode 666#' /etc/clamav/clamd.conf
 
+# Debian's packaged default (MaxConnectionQueueLength 15) is far below upstream ClamAV's own
+# default of 200, and gets overwhelmed by bursts of concurrent pipeline jobs each opening two
+# connections to clamd (Brunnhilde's own scan, plus the separate per-object-file scan during METS
+# building) in quick succession, causing "Could not connect to clamd ... Connection refused".
+# The directive may or may not already exist commented out depending on the packaged version, and
+# (as above) clamd only honors the first occurrence, so match either form and replace in place.
+RUN sed -i 's/^#\?MaxConnectionQueueLength.*/MaxConnectionQueueLength 200/' /etc/clamav/clamd.conf
+
+# Raising the queue alone isn't sufficient under real concurrent bursts - verified locally by firing
+# 30 simultaneous "clamscan --multiscan" calls through this same shim/clamd setup: with Debian's
+# packaged default (MaxThreads 12), roughly half failed with "Not enough threads for multiscan.
+# Increase MaxThreads. ERROR" (a distinct failure from the connection-refused one above, surfaced
+# only once the queue fix let more connections through to actually reach clamd's thread pool).
+RUN sed -i 's/^#\?MaxThreads.*/MaxThreads 50/' /etc/clamav/clamd.conf
+
 # Brunnhilde always invokes the literal "clamscan" binary with no way to configure it - shadow the
 # real clamscan with a shim that instead talks to clamd running as a second process in this same
 # container (started by pipeline-api-entrypoint.sh), avoiding the signature-database reload cost

--- a/Dockerfile.PipelineApi
+++ b/Dockerfile.PipelineApi
@@ -23,7 +23,21 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 # returning it to the OS between pipeline jobs - measured climbing past 2.4GB and staying there
 # across separate job runs on the same host (LPII-135). GCConserveMemory trades some GC throughput
 # for actively releasing memory back to the OS on collection instead, independent of any hard limit.
-ENV DOTNET_GCConserveMemory=9
+#
+# GCConserveMemory=9 (max) was tried first and made things worse in a different way: under real
+# memory pressure while processing a large deposit, it caused a full blocking GC pause long enough
+# to freeze the whole process - including the /health endpoint - for over two minutes, which is what
+# actually tripped the ALB's Target.Timeout and got the task replaced, not a slow creep to failure.
+# 5 is a lighter touch - still biases the GC toward returning memory instead of growing the heap,
+# without pushing as hard for the most aggressive (and slowest/most blocking) compaction behaviour.
+#
+# Server GC (the container default) also uses one heap per logical CPU and is tuned for throughput
+# via longer, less frequent collections - the wrong trade-off for a container that only gets 1 vCPU
+# worth of allocation (cpu=1024 of the host's 2048 units) and has to keep answering health checks
+# throughout. Workstation GC's background/concurrent collection favours shorter, more frequent
+# pauses instead, which suits a single-core-ish container much better.
+ENV DOTNET_GCConserveMemory=5
+ENV DOTNET_gcServer=0
 
 #run as root user
 RUN mkdir /usr/process-brunnhilde

--- a/pipeline-api-entrypoint.sh
+++ b/pipeline-api-entrypoint.sh
@@ -20,10 +20,17 @@ freshclam || echo "entrypoint: initial freshclam run failed, continuing with the
 # supervise it in its own loop (backgrounded before the exec) instead of a bare fire-and-forget start.
 supervise_clamd() {
     while true; do
+        # --foreground: Debian's packaged clamd defaults to daemonizing (double-fork, parent exits
+        # once it has spawned a detached background child) unless told otherwise, which this loop
+        # would mistake for a crash - "restarting" every cycle while the previous, still-running
+        # detached clamd keeps the socket bound, causing every retry to immediately fail with
+        # "Socket file ... is in use by another process". Foreground keeps it attached so the loop
+        # can track its real exit instead of colliding with itself.
+        #
         # `|| true`: this script runs under `set -e`, and a bare failing command here (rather than
         # one in an if/while-condition or already part of a `||`) would kill this loop on clamd's
         # first crash instead of restarting it.
-        su -s /bin/sh clamav -c "clamd" || true
+        su -s /bin/sh clamav -c "clamd --foreground" || true
         echo "entrypoint: clamd exited - restarting in 2s" >&2
         sleep 2
     done
@@ -34,7 +41,12 @@ supervise_clamd &
 # freshclam.conf controls how often it re-polls). Supervised for the same reason as clamd above.
 supervise_freshclam() {
     while true; do
-        su -s /bin/sh clamav -c "freshclam -d" || true
+        # -d/--daemon self-daemonizes (double-fork: the parent exits immediately once it has spawned
+        # a detached background child), which this loop would otherwise mistake for a crash on every
+        # single cycle - restarting every ~2s forever and piling up orphaned freshclam daemons that
+        # never get cleaned up (and end up contending with clamd for its own socket/lock). -F/
+        # --foreground keeps freshclam attached to this process so the loop can track its real exit.
+        su -s /bin/sh clamav -c "freshclam -d -F" || true
         echo "entrypoint: freshclam exited - restarting in 2s" >&2
         sleep 2
     done

--- a/pipeline-api-entrypoint.sh
+++ b/pipeline-api-entrypoint.sh
@@ -12,12 +12,34 @@ chown clamav:clamav /var/run/clamav /var/log/clamav
 # snapshot that goes stale after the image is built/deployed - pull the latest before clamd starts.
 freshclam || echo "entrypoint: initial freshclam run failed, continuing with the signatures baked into the image"
 
-# Long-running daemon for the lifetime of the container.
-su -s /bin/sh clamav -c "clamd" &
+# Long-running daemon for the lifetime of the container. clamd has no built-in restart-on-crash
+# behaviour, and if it dies (e.g. killed under host memory pressure - see LPII-135) clamscan-shim.sh
+# doesn't fail the scan, it just logs "Could not connect to clamd ... Connection refused" and reports
+# "Infected files: 0" - a false clean result, not an actual scan. Since this entrypoint script exec's
+# into dotnet as its last step, there's no shell left to notice or restart a background `&` job, so
+# supervise it in its own loop (backgrounded before the exec) instead of a bare fire-and-forget start.
+supervise_clamd() {
+    while true; do
+        # `|| true`: this script runs under `set -e`, and a bare failing command here (rather than
+        # one in an if/while-condition or already part of a `||`) would kill this loop on clamd's
+        # first crash instead of restarting it.
+        su -s /bin/sh clamav -c "clamd" || true
+        echo "entrypoint: clamd exited - restarting in 2s" >&2
+        sleep 2
+    done
+}
+supervise_clamd &
 
 # Keep signatures current for the life of the container (freshclam's own Checks setting in
-# freshclam.conf controls how often it re-polls).
-su -s /bin/sh clamav -c "freshclam -d" &
+# freshclam.conf controls how often it re-polls). Supervised for the same reason as clamd above.
+supervise_freshclam() {
+    while true; do
+        su -s /bin/sh clamav -c "freshclam -d" || true
+        echo "entrypoint: freshclam exited - restarting in 2s" >&2
+        sleep 2
+    done
+}
+supervise_freshclam &
 
 echo "entrypoint: waiting for clamd socket..."
 for i in $(seq 1 120); do

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -7,18 +7,11 @@ using DigitalPreservation.XmlGen.Mets;
 using DigitalPreservation.XmlGen.Premis.V3;
 using System.Xml;
 using DigitalPreservation.XmlGen.Extensions;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DigitalPreservation.Mets;
 
-public class MetadataManager(
-    PremisManager premisManager,
-    PremisManagerExif premisManagerExif,
-    PremisEventManagerVirus premisEventManagerVirus,
-    ILogger<MetadataManager>? logger = null)
+public class MetadataManager(PremisManager premisManager, PremisManagerExif premisManagerExif, PremisEventManagerVirus premisEventManagerVirus)
 {
-    private readonly ILogger<MetadataManager> logger = logger ?? NullLogger<MetadataManager>.Instance;
     private sealed class ProcessingContext
     {
         public required string FileAdmId { get; set; }
@@ -141,25 +134,12 @@ public class MetadataManager(
             premisType = premisManager.Create(premisFile);
         }
 
-        // TEMPORARY diagnostic logging for LPII-135 significantProperties/ImageWidth mismatch
-        // investigation - remove once root cause is confirmed.
-        var diagExifWidth = patchPremisExif?.Tags?.FirstOrDefault(t =>
-            string.Equals(t.TagName, "ImageWidth", StringComparison.OrdinalIgnoreCase))?.TagValue;
-        logger.LogInformation(
-            "ImageWidth diagnostic: operationPath={OperationPath} workingFileLocalPath={WorkingFileLocalPath} hadExistingPremis={HadExistingPremis} exifSource={ExifSource} exifImageWidth={ExifImageWidth}",
-            operationPath, workingFile.LocalPath, ctx.PremisIncExifXml is not null, patchPremisExif?.Source, diagExifWidth);
-
         if (patchPremisExif is not null)
-            premisManagerExif.Patch(premisType, patchPremisExif);
+            premisManagerExif.Patch(premisType, patchPremisExif, operationPath);
 
         var patchExtent = workingFile.GetExtentMetadata();
-
-        logger.LogInformation(
-            "ImageWidth diagnostic: operationPath={OperationPath} extentSource={ExtentSource} extentPixelWidth={ExtentPixelWidth}",
-            operationPath, patchExtent?.Source, patchExtent?.PixelWidth);
-
         if (patchExtent is not null)
-            premisManagerExif.PatchExtent(premisType, patchExtent);
+            premisManagerExif.PatchExtent(premisType, patchExtent, operationPath);
 
         var premisXml = premisManager.GetXmlElement(premisType, true);
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -7,11 +7,18 @@ using DigitalPreservation.XmlGen.Mets;
 using DigitalPreservation.XmlGen.Premis.V3;
 using System.Xml;
 using DigitalPreservation.XmlGen.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DigitalPreservation.Mets;
 
-public class MetadataManager(PremisManager premisManager, PremisManagerExif premisManagerExif, PremisEventManagerVirus premisEventManagerVirus)
+public class MetadataManager(
+    PremisManager premisManager,
+    PremisManagerExif premisManagerExif,
+    PremisEventManagerVirus premisEventManagerVirus,
+    ILogger<MetadataManager>? logger = null)
 {
+    private readonly ILogger<MetadataManager> logger = logger ?? NullLogger<MetadataManager>.Instance;
     private sealed class ProcessingContext
     {
         public required string FileAdmId { get; set; }
@@ -134,10 +141,23 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
             premisType = premisManager.Create(premisFile);
         }
 
+        // TEMPORARY diagnostic logging for LPII-135 significantProperties/ImageWidth mismatch
+        // investigation - remove once root cause is confirmed.
+        var diagExifWidth = patchPremisExif?.Tags?.FirstOrDefault(t =>
+            string.Equals(t.TagName, "ImageWidth", StringComparison.OrdinalIgnoreCase))?.TagValue;
+        logger.LogInformation(
+            "ImageWidth diagnostic: operationPath={OperationPath} workingFileLocalPath={WorkingFileLocalPath} hadExistingPremis={HadExistingPremis} exifSource={ExifSource} exifImageWidth={ExifImageWidth}",
+            operationPath, workingFile.LocalPath, ctx.PremisIncExifXml is not null, patchPremisExif?.Source, diagExifWidth);
+
         if (patchPremisExif is not null)
             premisManagerExif.Patch(premisType, patchPremisExif);
 
         var patchExtent = workingFile.GetExtentMetadata();
+
+        logger.LogInformation(
+            "ImageWidth diagnostic: operationPath={OperationPath} extentSource={ExtentSource} extentPixelWidth={ExtentPixelWidth}",
+            operationPath, patchExtent?.Source, patchExtent?.PixelWidth);
+
         if (patchExtent is not null)
             premisManagerExif.PatchExtent(premisType, patchExtent);
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/PremisManagerExif.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/PremisManagerExif.cs
@@ -1,5 +1,6 @@
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Premis.V3;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -32,7 +33,7 @@ public class PremisManagerExif
         return premis;
     }
 
-    public void Patch(PremisComplexType premis, ExifMetadata? exifMetadata)
+    public void Patch(PremisComplexType premis, ExifMetadata? exifMetadata, string? fileIdentifier = null)
     {
         if (premis.Object.FirstOrDefault(po => po is File) is not File file)
         {
@@ -69,7 +70,7 @@ public class PremisManagerExif
         objectCharacteristics.ObjectCharacteristicsExtension.Add(parentExtension);
 
         if (exifMetadata.Tags is not null)
-            SetSignificantPropertiesFromTags(file, exifMetadata.Tags);
+            SetSignificantPropertiesFromTags(file, exifMetadata.Tags, fileIdentifier);
     }
 
     private static void ProcessExifMetadataItem(XmlDocument document, XmlElement? parentElement, ExifTag? tag)
@@ -80,7 +81,7 @@ public class PremisManagerExif
             parentElement?.AppendChild(element);
     }
 
-    private static void SetSignificantPropertiesFromTags(File file, List<ExifTag> tags)
+    private static void SetSignificantPropertiesFromTags(File file, List<ExifTag> tags, string? fileIdentifier = null)
     {
         // ImageSize is ExifTool's composite tag representing the final video frame dimensions.
         // It appears once and takes precedence over the per-track ImageWidth/ImageHeight tags,
@@ -92,8 +93,8 @@ public class PremisManagerExif
             var parts = sizeVal.Split('x');
             if (parts.Length == 2)
             {
-                PatchSignificantProperty(file, "ImageWidth", parts[0]);
-                PatchSignificantProperty(file, "ImageHeight", parts[1]);
+                PatchSignificantProperty(file, "ImageWidth", parts[0], fileIdentifier);
+                PatchSignificantProperty(file, "ImageHeight", parts[1], fileIdentifier);
             }
         }
         else
@@ -102,15 +103,15 @@ public class PremisManagerExif
             // once. Fall back to the first ImageWidth/ImageHeight if those aren't present.
             var w = FirstTag(tags, "sourceimagewidth")?.TagValue ?? FirstTag(tags, "imagewidth")?.TagValue;
             var h = FirstTag(tags, "sourceimageheight")?.TagValue ?? FirstTag(tags, "imageheight")?.TagValue;
-            if (w is not null) PatchSignificantProperty(file, "ImageWidth", w);
-            if (h is not null) PatchSignificantProperty(file, "ImageHeight", h);
+            if (w is not null) PatchSignificantProperty(file, "ImageWidth", w, fileIdentifier);
+            if (h is not null) PatchSignificantProperty(file, "ImageHeight", h, fileIdentifier);
         }
 
         if (FirstTag(tags, "duration")?.TagValue is { } duration)
-            PatchSignificantProperty(file, "Duration", duration);
+            PatchSignificantProperty(file, "Duration", duration, fileIdentifier);
 
         if (FirstTag(tags, "avgbitrate")?.TagValue is { } bitrate)
-            PatchSignificantProperty(file, "Bitrate", bitrate);
+            PatchSignificantProperty(file, "Bitrate", bitrate, fileIdentifier);
     }
 
     private static ExifTag? FirstTag(List<ExifTag> tags, string normalizedName) =>
@@ -122,7 +123,7 @@ public class PremisManagerExif
     // Merges extent values into premis:significantProperties, checking for conflicts with any
     // properties already present (from Exif or any other source). Throws MetadataException if
     // a property has already been written with a different value.
-    public void PatchExtent(PremisComplexType premis, ExtentMetadata extentMetadata)
+    public void PatchExtent(PremisComplexType premis, ExtentMetadata extentMetadata, string? fileIdentifier = null)
     {
         if (premis.Object.FirstOrDefault(po => po is File) is not File file)
         {
@@ -132,20 +133,22 @@ public class PremisManagerExif
 
         if (extentMetadata.Duration.HasValue)
             PatchSignificantProperty(file, "Duration",
-                extentMetadata.Duration.Value.ToString("G", CultureInfo.InvariantCulture));
+                extentMetadata.Duration.Value.ToString("G", CultureInfo.InvariantCulture), fileIdentifier);
 
         if (extentMetadata.PixelWidth.HasValue)
             PatchSignificantProperty(file, "ImageWidth",
-                extentMetadata.PixelWidth.Value.ToString(CultureInfo.InvariantCulture));
+                extentMetadata.PixelWidth.Value.ToString(CultureInfo.InvariantCulture), fileIdentifier);
 
         if (extentMetadata.PixelHeight.HasValue)
             PatchSignificantProperty(file, "ImageHeight",
-                extentMetadata.PixelHeight.Value.ToString(CultureInfo.InvariantCulture));
+                extentMetadata.PixelHeight.Value.ToString(CultureInfo.InvariantCulture), fileIdentifier);
     }
 
     // Adds a significantProperty if not already present; if already present from any source,
-    // verifies the value matches and throws if not.
-    private static void PatchSignificantProperty(File file, string propertyName, string value)
+    // verifies the value matches and throws if not. fileIdentifier is included in the exception
+    // message purely for diagnosability - without it, tracking down which file in a large deposit
+    // triggered a conflict requires adding temporary logging and reading a full stack trace (see LPII-135).
+    private static void PatchSignificantProperty(File file, string propertyName, string value, string? fileIdentifier = null)
     {
         var existing = file.SignificantProperties
             .FirstOrDefault(sp => sp.SignificantPropertiesType?.Value == propertyName);
@@ -154,8 +157,11 @@ public class PremisManagerExif
         {
             var existingValue = existing.SignificantPropertiesValue.FirstOrDefault();
             if (existingValue != value)
+            {
+                var fileContext = fileIdentifier.HasText() ? $" for file '{fileIdentifier}'" : string.Empty;
                 throw new MetadataException(
-                    $"Conflicting values for significantProperties/{propertyName}: '{existingValue}' vs '{value}'");
+                    $"Conflicting values for significantProperties/{propertyName}{fileContext}: '{existingValue}' vs '{value}'");
+            }
             return;
         }
 

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -531,7 +531,12 @@ public class MetadataReader : IMetadataReader
 
             foreach (var str in exifResultList)
             {
-                if (str.Contains("========") || str.Contains("directories scanned"))
+                // ExifTool always emits the file-boundary marker as the first characters of the
+                // line ("======== <path>") - matching with StartsWith (rather than Contains)
+                // avoids treating an embedded metadata value that merely contains "========"
+                // (e.g. inside a raw ICC profile dump) as a spurious new-file boundary, which
+                // would otherwise split or merge real files' fields into the wrong file's block.
+                if (str.StartsWith("========") || str.Contains("directories scanned"))
                 {
                     if (i > 0)
                     {
@@ -561,7 +566,12 @@ public class MetadataReader : IMetadataReader
                     sbRawOutput.Append(str);
                     sbRawOutput.Append("\\n");
 
+                    // Not every line is a "Field : Value" pair - stray warnings or crashed-tool
+                    // text can end up mixed into the combined stdout for the whole batch. Skip
+                    // anything without a colon rather than throwing: one malformed line used to
+                    // abort parsing for every file in the deposit via the catch-all below.
                     var metadataPair = str.Split(":", 2);
+                    if (metadataPair.Length < 2) continue;
 
                     var rgx = new Regex("[^a-zA-Z0-9]");
                     var key = rgx.Replace(metadataPair[0].Trim(), "");

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -531,57 +531,20 @@ public class MetadataReader : IMetadataReader
 
             foreach (var str in exifResultList)
             {
-                // ExifTool always emits the file-boundary marker as the first characters of the
-                // line ("======== <path>") - matching with StartsWith (rather than Contains)
-                // avoids treating an embedded metadata value that merely contains "========"
-                // (e.g. inside a raw ICC profile dump) as a spurious new-file boundary, which
-                // would otherwise split or merge real files' fields into the wrong file's block.
-                if (str.StartsWith("========", StringComparison.Ordinal) || str.Contains("directories scanned"))
+                if (!IsFileBoundaryLine(str))
                 {
-                    if (i > 0)
-                    {
-                        exifModel.ExifMetadata = new List<ExifTag>(exifMetadataForFile);
-                        exifModel.ExifMetadata.Add(new ExifTag
-                        {
-                            TagName = "RawOutput",
-                            TagValue = sbRawOutput.ToString()
-                        });
-
-                        exifMetadataForFile.Clear();
-                        sbRawOutput.Clear();
-                        result.Add(exifModel);
-
-                        if (str.Contains("directories scanned"))
-                            break;
-
-                    }
-
-                    var fileName = str.Replace("========", string.Empty).Trim();
-                    exifModel = new ExifModel { Filepath = fileName };
-
-                    i++;
+                    AppendExifFieldLine(str, sbRawOutput, exifMetadataForFile);
+                    continue;
                 }
-                else
+
+                if (i > 0)
                 {
-                    sbRawOutput.Append(str);
-                    sbRawOutput.Append("\\n");
-
-                    // Not every line is a "Field : Value" pair - stray warnings or crashed-tool
-                    // text can end up mixed into the combined stdout for the whole batch. Skip
-                    // anything without a colon rather than throwing: one malformed line used to
-                    // abort parsing for every file in the deposit via the catch-all below.
-                    var metadataPair = str.Split(":", 2);
-                    if (metadataPair.Length < 2) continue;
-
-                    var rgx = new Regex("[^a-zA-Z0-9]");
-                    var key = rgx.Replace(metadataPair[0].Trim(), "");
-
-                    exifMetadataForFile.Add(new ExifTag
-                    {
-                        TagName = key,
-                        TagValue = metadataPair[1].Trim()
-                    });
+                    FinalizeCurrentFile(exifModel, exifMetadataForFile, sbRawOutput, result);
+                    if (str.Contains("directories scanned")) break;
                 }
+
+                exifModel = new ExifModel { Filepath = str.Replace("========", string.Empty).Trim() };
+                i++;
             }
 
             return result;
@@ -590,7 +553,49 @@ public class MetadataReader : IMetadataReader
         {
             return [];
         }
+    }
 
+    // ExifTool always emits the file-boundary marker as the first characters of the
+    // line ("======== <path>") - matching with StartsWith (rather than Contains)
+    // avoids treating an embedded metadata value that merely contains "========"
+    // (e.g. inside a raw ICC profile dump) as a spurious new-file boundary, which
+    // would otherwise split or merge real files' fields into the wrong file's block.
+    private static bool IsFileBoundaryLine(string str) =>
+        str.StartsWith("========", StringComparison.Ordinal) || str.Contains("directories scanned");
+
+    private static void FinalizeCurrentFile(ExifModel exifModel, List<ExifTag> exifMetadataForFile,
+        StringBuilder sbRawOutput, List<ExifModel> result)
+    {
+        exifModel.ExifMetadata = new List<ExifTag>(exifMetadataForFile)
+        {
+            new() { TagName = "RawOutput", TagValue = sbRawOutput.ToString() }
+        };
+
+        exifMetadataForFile.Clear();
+        sbRawOutput.Clear();
+        result.Add(exifModel);
+    }
+
+    private static void AppendExifFieldLine(string str, StringBuilder sbRawOutput, List<ExifTag> exifMetadataForFile)
+    {
+        sbRawOutput.Append(str);
+        sbRawOutput.Append("\\n");
+
+        // Not every line is a "Field : Value" pair - stray warnings or crashed-tool
+        // text can end up mixed into the combined stdout for the whole batch. Skip
+        // anything without a colon rather than throwing: one malformed line used to
+        // abort parsing for every file in the deposit via the catch-all below.
+        var metadataPair = str.Split(":", 2);
+        if (metadataPair.Length < 2) return;
+
+        var rgx = new Regex("[^a-zA-Z0-9]");
+        var key = rgx.Replace(metadataPair[0].Trim(), "");
+
+        exifMetadataForFile.Add(new ExifTag
+        {
+            TagName = key,
+            TagValue = metadataPair[1].Trim()
+        });
     }
 
     public static void SetMetadataHtml(List<Metadata>? metadataList, ExifModel? exifMetadata, DateTime timestamp)

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/MetadataReader.cs
@@ -536,7 +536,7 @@ public class MetadataReader : IMetadataReader
                 // avoids treating an embedded metadata value that merely contains "========"
                 // (e.g. inside a raw ICC profile dump) as a spurious new-file boundary, which
                 // would otherwise split or merge real files' fields into the wrong file's block.
-                if (str.StartsWith("========") || str.Contains("directories scanned"))
+                if (str.StartsWith("========", StringComparison.Ordinal) || str.Contains("directories scanned"))
                 {
                     if (i > 0)
                     {

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -415,7 +415,7 @@ public class ProcessPipelineJobHandler(
                 return await ForceCompleteReturn(cleanupProcessJobAfterDelete, request, workspaceManager.Deposit, cancellationToken);
             }
 
-            var virusDefinition = GetVirusDefinition();
+            var virusDefinition = await GetVirusDefinition();
             //add virus definition file to metadata folder
             var virusDefinitionPath = $"{metadataPathForProcessFilesAndDirectories}{pipelineToolOptions.Value.DirectorySeparator}virus-definition{pipelineToolOptions.Value.DirectorySeparator}virus-definition.txt";
 
@@ -1079,7 +1079,7 @@ public class ProcessPipelineJobHandler(
         };
     }
 
-    private string GetVirusDefinition()
+    private async Task<string> GetVirusDefinition()
     {
         try
         {
@@ -1099,8 +1099,14 @@ public class ProcessPipelineJobHandler(
                 }
             };
             process.Start();
-            string result = process.StandardOutput.ReadToEnd();
-            process.WaitForExit();
+            // clamd can be mid-scan and holding every MaxThreads worker when this "--version" call
+            // comes in (it queues behind the scan on the same clamd thread pool via clamscan-shim.sh),
+            // so this can block for as long as a large deposit's scan takes. A synchronous
+            // ReadToEnd()/WaitForExit() here would tie up a real .NET thread-pool thread for that
+            // whole time, which starves the process (including unrelated HttpClient calls and the
+            // ASP.NET Core health check) - see LPII-135.
+            string result = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
             return result;
         }
         catch

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Options;
 using Pipeline.API.Config;
 using Preservation.Client;
 using System.Diagnostics;
-using System.Runtime;
 using System.Text;
 using Checksum = DigitalPreservation.Utils.Checksum;
 
@@ -217,7 +216,8 @@ public class ProcessPipelineJobHandler(
             // indefinitely, and MemoryUtilized just reflects whatever's currently committed rather
             // than what's actually still live. Force a full, compacting pass now instead of waiting
             // for enough allocation pressure from a future job to trigger one naturally.
-            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            // (GCCollectionMode.Aggressive already forces a blocking, compacting collection of the
+            // LOH, so no separate GCSettings.LargeObjectHeapCompactionMode is needed here.)
             GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
             GC.WaitForPendingFinalizers();
             GC.Collect();
@@ -318,16 +318,9 @@ public class ProcessPipelineJobHandler(
             metadataPathForProcessFilesAndDirectories);
         logger.LogInformation("depositName {depositId}", request.DepositId);
 
-        // BagIt deposits get a SHA256 for every object file independently from bagit.py
-        // (BagitScript includes --sha256), so asking Siegfried to also hash every byte of every
-        // file via --hash is pure duplicated I/O with no gain in digest coverage - it only costs
-        // Brunnhilde's own duplicate-file report. For non-BagIt (RootLevel) deposits, Siegfried's
-        // hash is the only digest source recorded, so it can't be dropped there.
-        var hashArg = workspaceManager.IsBagItLayout ? string.Empty : "--hash sha256 ";
-
         using var process = new Process();
         process.StartInfo.FileName = pipelineToolOptions.Value.PathToPython;
-        process.StartInfo.Arguments = $"  {pipelineToolOptions.Value.PathToBrunnhilde} {hashArg}{objectPath} {metadataProcessPath}  --overwrite ";
+        process.StartInfo.Arguments = $"  {pipelineToolOptions.Value.PathToBrunnhilde} --hash sha256 {objectPath} {metadataProcessPath}  --overwrite ";
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.RedirectStandardOutput = true;
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -218,9 +218,9 @@ public class ProcessPipelineJobHandler(
             // for enough allocation pressure from a future job to trigger one naturally.
             // (GCCollectionMode.Aggressive already forces a blocking, compacting collection of the
             // LOH, so no separate GCSettings.LargeObjectHeapCompactionMode is needed here.)
-            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true); // NOSONAR: S1215 - deliberate one-off collection at a known job-boundary idle point, not a routine call; see comment above
             GC.WaitForPendingFinalizers();
-            GC.Collect();
+            GC.Collect(); // NOSONAR: S1215 - second pass to collect finalizable objects freed above; same justification as the call two lines up
         }
     }
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using Pipeline.API.Config;
 using Preservation.Client;
 using System.Diagnostics;
+using System.Runtime;
 using System.Text;
 using Checksum = DigitalPreservation.Utils.Checksum;
 
@@ -204,6 +205,22 @@ public class ProcessPipelineJobHandler(
             // path from this handler actually releases it.
             processTimer.Stop();
             processTimer.Enabled = false;
+
+            // This handler processes one job at a time with a clear idle boundary after each one
+            // (SqsPipelineQueue just polls every 10s until the next job), unlike a normal request-
+            // handling API where forcing collections mid-stream would be harmful. That idle period
+            // turns out not to reliably trigger cleanup on its own - GC isn't time-based, it's
+            // allocation-pressure-based, and routine SQS polling/health checks generate far too
+            // little garbage to cross the threshold for a full collection. So the large object graphs
+            // built while processing this job (the deposit's CombinedDirectory tree, rebuilt many
+            // times over per LPII-135, plus Brunnhilde/exif output buffers) can sit uncollected
+            // indefinitely, and MemoryUtilized just reflects whatever's currently committed rather
+            // than what's actually still live. Force a full, compacting pass now instead of waiting
+            // for enough allocation pressure from a future job to trigger one naturally.
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            GC.Collect(2, GCCollectionMode.Aggressive, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
     }
 

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -194,6 +194,16 @@ public class ProcessPipelineJobHandler(
                 CleanupBagitProcessFolder(request.DepositId);
             }
             await tokensCatalog[monitorForceCompleteId].CancelAsync();
+
+            // processTimer.AutoReset is true, so cancelling the monitor token above is not enough to
+            // stop it - CheckIfProcessRunning never inspects that token, and on the normal success path
+            // it also short-circuits on processId == 0 before ever reaching a Stop() call. Left running,
+            // the timer's Elapsed closure keeps this whole handler instance (and everything it
+            // references) alive indefinitely and keeps firing CheckIfForceComplete's HTTP call every 10s
+            // forever - one leaked timer per completed job. Stop it here unconditionally so every exit
+            // path from this handler actually releases it.
+            processTimer.Stop();
+            processTimer.Enabled = false;
         }
     }
 
@@ -1094,7 +1104,7 @@ public class ProcessPipelineJobHandler(
                 ? pipelineToolOptions.Value.PathToClamScan
                 : "clamscan";
 
-            var process = new Process()
+            using var process = new Process()
             {
                 StartInfo = new ProcessStartInfo
                 {
@@ -1132,7 +1142,7 @@ public class ProcessPipelineJobHandler(
 
         try
         {
-            var process = new Process()
+            using var process = new Process()
             {
                 StartInfo = new ProcessStartInfo
                 {

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -444,7 +444,7 @@ public class ProcessPipelineJobHandler(
             // since it typically runs faster than Brunnhilde/ClamAV.
             await exifTask;
 
-            var (createFolderResultList, uploadFilesResultList, forceCompleteUpload, forceCompleteUploadCleanupProcess) = await UploadFilesToMetadataRecursively(
+            var (createFolderResultList, uploadFilesResultList, forceCompleteUpload, forceCompleteUploadCleanupProcess, metadataWorkspaceManager) = await UploadFilesToMetadataRecursively(
                 request, metadataPathForProcessFilesAndDirectories, depositPath,
                 workspaceManager.Deposit, cancellationToken);
 
@@ -485,7 +485,7 @@ public class ProcessPipelineJobHandler(
 
             if (workspaceManager.IsBagItLayout)
             {
-                var (uploadBagitFilesResultList, forceBagitCompleteUpload, forceBagitCompleteUploadCleanupProcess) = await UploadBagitFilesToRoot(request, workspaceManager.Deposit, cancellationToken);
+                var (uploadBagitFilesResultList, forceBagitCompleteUpload, forceBagitCompleteUploadCleanupProcess) = await UploadBagitFilesToRoot(request, workspaceManager.Deposit, cancellationToken, metadataWorkspaceManager!);
 
                 if (uploadBagitFilesResultList.Count == 0)
                 {
@@ -530,7 +530,7 @@ public class ProcessPipelineJobHandler(
                 logger.LogInformation("Job {JobIdentifier} and deposit {DepositId} pipeline run metadataCreated status logged",
                     request.JobIdentifier, request.DepositId);
 
-            var metsResult = await AddObjectsToMets(request, depositPath);
+            var metsResult = await AddObjectsToMets(request, depositPath, metadataWorkspaceManager!);
 
             if (metsResult.Failure)
                 logger.LogInformation("Issue adding objects to METS in pipeline run: {error}", metsResult.ErrorMessage);
@@ -722,10 +722,11 @@ public class ProcessPipelineJobHandler(
 
     private async Task<(
         List<Result<CreateFolderResult>?> createSubFolderResult,
-        List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess)> UploadFilesToMetadataRecursively(
+        List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess,
+        WorkspaceManager? workspaceManager)> UploadFilesToMetadataRecursively(
             ExecutePipelineJob request,
             string sourcePathForFilesAndDirectories, string depositPath,
-            Deposit deposit, CancellationToken cancellationToken) //string sourcePathForFiles, 
+            Deposit deposit, CancellationToken cancellationToken) //string sourcePathForFiles,
     {
         try
         {
@@ -736,8 +737,20 @@ public class ProcessPipelineJobHandler(
             {
                 await TryReleaseLock(request, deposit, cancellationToken);
                 logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                return (createSubFolderResult: [], uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload);
+                return (createSubFolderResult: [], uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload, null);
             }
+
+            // Fetched once here (with a genuine refresh, to pick up everything Brunnhilde/Exif just
+            // wrote) and threaded through every per-folder/per-file operation below instead of each
+            // one independently re-fetching+refreshing its own copy - CreateFolder/UploadSingleSmallFile
+            // incrementally keep the deposit's cached file-system snapshot accurate as each item is
+            // created (Storage.AddToDepositFileSystem), so a single initial refresh is sufficient for
+            // the whole batch. Previously every single folder and file call re-triggered a full,
+            // sequential, one-object-at-a-time S3 scan of the ENTIRE deposit - for a large deposit
+            // (thousands of files) that's ~40s per call, repeated 20+ times for one job's metadata
+            // upload alone (LPII-135).
+            var workspaceResult = await GetWorkspaceManager(request, true, cancellationToken);
+            var workspaceManager = workspaceResult.Value!;
 
             var context = new StringBuilder();
             context.Append("metadata");
@@ -758,10 +771,10 @@ public class ProcessPipelineJobHandler(
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload);
+                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload, workspaceManager);
                 }
 
-                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath));
+                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath, workspaceManager));
             }
 
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
@@ -779,15 +792,15 @@ public class ProcessPipelineJobHandler(
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
+                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload, workspaceManager);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken, workspaceManager);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess);
+                    return (createSubFolderResult: [], uploadFileResult: [], uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess, workspaceManager);
                 }
 
                 uploadFileResult.Add(uploadFileToS3Result);
@@ -806,7 +819,7 @@ public class ProcessPipelineJobHandler(
 
             if (createSubFolderResult.Any() && uploadFileResult.Any())
             {
-                return (createSubFolderResult, uploadFileResult, false, false);
+                return (createSubFolderResult, uploadFileResult, false, false, workspaceManager);
             }
 
         }
@@ -814,18 +827,14 @@ public class ProcessPipelineJobHandler(
         {
             await TryReleaseLock(request, deposit, cancellationToken);
             logger.LogError(ex, " Caught error in copy files recursively from {sourcePathForFilesAndDirectories} to {depositPath}", sourcePathForFilesAndDirectories, depositPath);
-            return (createSubFolderResult: [], uploadFileResult: [], false, false);
+            return (createSubFolderResult: [], uploadFileResult: [], false, false, null);
         }
 
-        return (createSubFolderResult: [], uploadFileResult: [], false, false);
+        return (createSubFolderResult: [], uploadFileResult: [], false, false, null);
     }
 
-    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath)
+    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath, WorkspaceManager workspaceManager)
     {
-        // This is a content-changing operation
-        var workspaceResult = await GetWorkspaceManager(request, true);
-        var workspaceManager = workspaceResult.Value!;
-
         var context = new StringBuilder();
         var metadataContext = "metadata";
         context.Append(metadataContext);
@@ -836,8 +845,12 @@ public class ProcessPipelineJobHandler(
 
         logger.LogInformation("BrunnhildeFolderName {BrunnhildeFolderName}", BrunnhildeFolderName);
         logger.LogInformation("di.Name {di.Name} context {context}", di.Name, context);
+        // refreshDirectory: false - safe because CreateFolder (Storage.AddToDepositFileSystem)
+        // incrementally updates the deposit's cached file-system snapshot after every creation, so the
+        // next lookup (e.g. for a nested folder created later in the same batch) still sees it via a
+        // cheap cached read instead of forcing another full S3 scan.
         var result = await workspaceManager.CreateFolder(
-            di.Name, context.ToString(), false, request.GetUserName(), true);
+            di.Name, context.ToString(), false, request.GetUserName(), false);
 
         if (!result.Success)
         {
@@ -850,7 +863,7 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(ExecutePipelineJob request, string filePath,
-        string? sourcePath, Deposit deposit, CancellationToken cancellationToken, bool bagitFile = false)
+        string? sourcePath, Deposit deposit, CancellationToken cancellationToken, WorkspaceManager workspaceManager, bool bagitFile = false)
     {
         var context = new StringBuilder();
         var metadataContext =  bagitFile ? string.Empty : "metadata";
@@ -899,7 +912,7 @@ public class ProcessPipelineJobHandler(
             return (null, false, false);
 
         var stream = GetFileStream(filePath);
-        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, bagitFile);
+        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, workspaceManager, bagitFile);
 
 
         if (!result.Success)
@@ -918,11 +931,8 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(
-        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
+        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, WorkspaceManager workspaceManager, bool bagitFile = false)
     {
-        // This is potentially expensive as it needs a NEW WorkspaceManager each time
-        // TODO: We need a batch operation on WorkspaceManager to upload a set of small files.
-
         var fi = new FileInfo(filePath);
         try
         {
@@ -932,9 +942,7 @@ public class ProcessPipelineJobHandler(
                 return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError,
                     "Could not find file content type");
 
-            var workspaceManagerResult = await GetWorkspaceManager(request, true);
-
-            var result = await workspaceManagerResult.Value!.UploadSingleSmallFile(
+            var result = await workspaceManager.UploadSingleSmallFile(
                 stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, request.GetUserName(), true, bagitFile); //bagit file
 
             return result;
@@ -962,10 +970,8 @@ public class ProcessPipelineJobHandler(
     /// </summary>
     /// <param name="request"></param>
     /// <param name="depositPath"></param>
-    private async Task<Result<ItemsAffected>> AddObjectsToMets(ExecutePipelineJob request, string depositPath)
+    private async Task<Result<ItemsAffected>> AddObjectsToMets(ExecutePipelineJob request, string depositPath, WorkspaceManager workspaceManager)
     {
-        var workspaceManagerResult = await GetWorkspaceManager(request, true);
-        var workspaceManager = workspaceManagerResult.Value!;
         var (_, _, objectPath, _) = GetFilePaths(workspaceManager);
         var minimalItems = new List<MinimalItem>();
 
@@ -1505,7 +1511,7 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<(List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess)> UploadBagitFilesToRoot(
-        ExecutePipelineJob request, Deposit deposit, CancellationToken cancellationToken)
+        ExecutePipelineJob request, Deposit deposit, CancellationToken cancellationToken, WorkspaceManager workspaceManager)
     {
         var separator = pipelineToolOptions.Value.DirectorySeparator;
         var processFolderBagitDeposit = $"{pipelineToolOptions.Value.ProcessFolderBagit}{separator}{request.DepositId}";
@@ -1538,7 +1544,7 @@ public class ProcessPipelineJobHandler(
                     return (uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, workspaceManager, true);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -536,16 +536,17 @@ public class ProcessPipelineJobHandler(
                 logger.LogInformation("Issue adding objects to METS in pipeline run: {error}", metsResult.ErrorMessage);
 
             var start = DateTime.Now;
+            var lockReleased = false;
 
             while (true)
             {
                 var releaseLockResult = await TryReleaseLock(request, workspaceManager.Deposit, cancellationToken);
-                var exit = (DateTime.Now - start).Seconds > pipelineToolOptions.Value.ReleaseLockAttemptTime;
 
                 if (releaseLockResult.Success)
                 {
+                    lockReleased = true;
                     logger.LogInformation($"Successfully released the lock for job {request.JobIdentifier} for deposit {workspaceManager.Deposit.Id}");
-                    
+
                     var response = await preservationApiClient.GetDeposit(request.DepositId, cancellationToken);
                     if (response is { Success: true })
                     {
@@ -555,9 +556,33 @@ public class ProcessPipelineJobHandler(
                     break;
                 }
 
-                if (!exit) continue;
+                // .Seconds is the seconds *component* of the elapsed TimeSpan (0-59), not the total
+                // elapsed seconds - comparing that against ReleaseLockAttemptTime looked like a
+                // timeout check but would under-count (and never trip) once elapsed time passed a
+                // minute boundary. TotalSeconds is the actual elapsed duration.
+                if ((DateTime.Now - start).TotalSeconds <= pipelineToolOptions.Value.ReleaseLockAttemptTime)
+                {
+                    // A tight retry loop with no delay just hammers Preservation API's lock endpoint
+                    // as fast as the network round-trip allows, which doesn't give a transient DB
+                    // blip on that end any time to clear.
+                    await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+                    continue;
+                }
+
                 logger.LogError($"Failure to release the lock for job {request.JobIdentifier} for deposit {workspaceManager.Deposit.Id}.");
                 break;
+            }
+
+            if (!lockReleased)
+            {
+                // Previously this always returned Completed even when every release attempt failed,
+                // silently leaving the deposit locked with nothing in the job's own status to show it -
+                // the deposit would stay locked indefinitely with no indication anything was wrong.
+                return new ProcessPipelineResult
+                {
+                    Status = PipelineJobStates.CompletedWithErrors,
+                    Errors = [new Error { Message = $"Pipeline job run {request.JobIdentifier} for {request.DepositId} completed but could not release the deposit lock" }]
+                };
             }
 
             logger.LogInformation($"Returning a completed status for job {request.JobIdentifier} for deposit {workspaceManager.Deposit.Id}.");

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -291,9 +291,16 @@ public class ProcessPipelineJobHandler(
             metadataPathForProcessFilesAndDirectories);
         logger.LogInformation("depositName {depositId}", request.DepositId);
 
+        // BagIt deposits get a SHA256 for every object file independently from bagit.py
+        // (BagitScript includes --sha256), so asking Siegfried to also hash every byte of every
+        // file via --hash is pure duplicated I/O with no gain in digest coverage - it only costs
+        // Brunnhilde's own duplicate-file report. For non-BagIt (RootLevel) deposits, Siegfried's
+        // hash is the only digest source recorded, so it can't be dropped there.
+        var hashArg = workspaceManager.IsBagItLayout ? string.Empty : "--hash sha256 ";
+
         using var process = new Process();
         process.StartInfo.FileName = pipelineToolOptions.Value.PathToPython;
-        process.StartInfo.Arguments = $"  {pipelineToolOptions.Value.PathToBrunnhilde} --hash sha256 {objectPath} {metadataProcessPath}  --overwrite ";
+        process.StartInfo.Arguments = $"  {pipelineToolOptions.Value.PathToBrunnhilde} {hashArg}{objectPath} {metadataProcessPath}  --overwrite ";
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.RedirectStandardOutput = true;
 
@@ -1139,17 +1146,32 @@ public class ProcessPipelineJobHandler(
 
             logger.LogInformation("object path for exif command {ObjectPath}", objectPath);
             logger.LogInformation("About to start exif process.");
-            process.Start();
-            var result = await process.StandardOutput.ReadToEndAsync();
 
-            logger.LogInformation("Exif output result {Result}", result);
             var exifPath = $"{processPath}{separator}exif";
-
             logger.LogInformation("Exif output path {OutputPath}", exifPath);
             logger.LogInformation("Exif process path {ProcessPath}", processPath);
-
             Directory.CreateDirectory(exifPath);
-            await File.WriteAllTextAsync($"{exifPath}{separator}exif_output.txt", result, CancellationToken.None);
+
+            process.Start();
+
+            // Stream ExifTool's stdout straight to disk instead of buffering the whole combined
+            // output (tens of MB for a large deposit with thousands of files) into one in-memory
+            // string. The old ReadToEndAsync + logging-the-whole-string + WriteAllTextAsync pattern
+            // held multiple full copies of this text in memory at once and contributed to an OOM
+            // kill (exitCode 137) while processing a real deposit - see LPII-135. CopyToAsync on the
+            // raw BaseStream also avoids the ~2x memory cost of decoding to a .NET (UTF-16) string
+            // first, and the CloudWatch per-event size limit that the old single giant log line risked.
+            var outputFilePath = $"{exifPath}{separator}exif_output.txt";
+            await using (var fileStream = new FileStream(
+                             outputFilePath, FileMode.Create, FileAccess.Write, FileShare.None,
+                             bufferSize: 81920, useAsync: true))
+            {
+                await process.StandardOutput.BaseStream.CopyToAsync(fileStream);
+            }
+
+            var outputLength = new FileInfo(outputFilePath).Length;
+            logger.LogInformation("Exif output written to {OutputPath} ({Length} bytes)", outputFilePath, outputLength);
+
             await process.WaitForExitAsync();
         }
         catch(Exception e)

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/Requests/ExecutePipelineJob.cs
@@ -444,7 +444,7 @@ public class ProcessPipelineJobHandler(
             // since it typically runs faster than Brunnhilde/ClamAV.
             await exifTask;
 
-            var (createFolderResultList, uploadFilesResultList, forceCompleteUpload, forceCompleteUploadCleanupProcess, metadataWorkspaceManager) = await UploadFilesToMetadataRecursively(
+            var (createFolderResultList, uploadFilesResultList, forceCompleteUpload, forceCompleteUploadCleanupProcess) = await UploadFilesToMetadataRecursively(
                 request, metadataPathForProcessFilesAndDirectories, depositPath,
                 workspaceManager.Deposit, cancellationToken);
 
@@ -485,7 +485,7 @@ public class ProcessPipelineJobHandler(
 
             if (workspaceManager.IsBagItLayout)
             {
-                var (uploadBagitFilesResultList, forceBagitCompleteUpload, forceBagitCompleteUploadCleanupProcess) = await UploadBagitFilesToRoot(request, workspaceManager.Deposit, cancellationToken, metadataWorkspaceManager!);
+                var (uploadBagitFilesResultList, forceBagitCompleteUpload, forceBagitCompleteUploadCleanupProcess) = await UploadBagitFilesToRoot(request, workspaceManager.Deposit, cancellationToken);
 
                 if (uploadBagitFilesResultList.Count == 0)
                 {
@@ -530,7 +530,7 @@ public class ProcessPipelineJobHandler(
                 logger.LogInformation("Job {JobIdentifier} and deposit {DepositId} pipeline run metadataCreated status logged",
                     request.JobIdentifier, request.DepositId);
 
-            var metsResult = await AddObjectsToMets(request, depositPath, metadataWorkspaceManager!);
+            var metsResult = await AddObjectsToMets(request, depositPath);
 
             if (metsResult.Failure)
                 logger.LogInformation("Issue adding objects to METS in pipeline run: {error}", metsResult.ErrorMessage);
@@ -722,8 +722,7 @@ public class ProcessPipelineJobHandler(
 
     private async Task<(
         List<Result<CreateFolderResult>?> createSubFolderResult,
-        List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess,
-        WorkspaceManager? workspaceManager)> UploadFilesToMetadataRecursively(
+        List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess)> UploadFilesToMetadataRecursively(
             ExecutePipelineJob request,
             string sourcePathForFilesAndDirectories, string depositPath,
             Deposit deposit, CancellationToken cancellationToken) //string sourcePathForFiles,
@@ -737,20 +736,8 @@ public class ProcessPipelineJobHandler(
             {
                 await TryReleaseLock(request, deposit, cancellationToken);
                 logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                return (createSubFolderResult: [], uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload, null);
+                return (createSubFolderResult: [], uploadFileResult: [], forceCompleteBeforeUpload, cleanupProcessBeforeUpload);
             }
-
-            // Fetched once here (with a genuine refresh, to pick up everything Brunnhilde/Exif just
-            // wrote) and threaded through every per-folder/per-file operation below instead of each
-            // one independently re-fetching+refreshing its own copy - CreateFolder/UploadSingleSmallFile
-            // incrementally keep the deposit's cached file-system snapshot accurate as each item is
-            // created (Storage.AddToDepositFileSystem), so a single initial refresh is sufficient for
-            // the whole batch. Previously every single folder and file call re-triggered a full,
-            // sequential, one-object-at-a-time S3 scan of the ENTIRE deposit - for a large deposit
-            // (thousands of files) that's ~40s per call, repeated 20+ times for one job's metadata
-            // upload alone (LPII-135).
-            var workspaceResult = await GetWorkspaceManager(request, true, cancellationToken);
-            var workspaceManager = workspaceResult.Value!;
 
             var context = new StringBuilder();
             context.Append("metadata");
@@ -771,10 +758,10 @@ public class ProcessPipelineJobHandler(
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload, workspaceManager);
+                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteDirectoryUpload, cleanupProcessDirectoryUpload);
                 }
 
-                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath, workspaceManager));
+                createSubFolderResult.Add(await CreateMetadataSubFolderOnS3(request, dirPath));
             }
 
             var uploadFileResult = new List<Result<SingleFileUploadResult>?>();
@@ -792,15 +779,15 @@ public class ProcessPipelineJobHandler(
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload, workspaceManager);
+                    return (createSubFolderResult: [], uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken, workspaceManager);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, sourcePathForFilesAndDirectories, deposit, cancellationToken);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);
                     logger.LogInformation("Exited UploadFilesToMetadataRecursively() method as the pipeline job run has been forced complete {JobIdentifier} for deposit {DepositId}", request.JobIdentifier, request.DepositId);
-                    return (createSubFolderResult: [], uploadFileResult: [], uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess, workspaceManager);
+                    return (createSubFolderResult: [], uploadFileResult: [], uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess);
                 }
 
                 uploadFileResult.Add(uploadFileToS3Result);
@@ -819,7 +806,7 @@ public class ProcessPipelineJobHandler(
 
             if (createSubFolderResult.Any() && uploadFileResult.Any())
             {
-                return (createSubFolderResult, uploadFileResult, false, false, workspaceManager);
+                return (createSubFolderResult, uploadFileResult, false, false);
             }
 
         }
@@ -827,14 +814,25 @@ public class ProcessPipelineJobHandler(
         {
             await TryReleaseLock(request, deposit, cancellationToken);
             logger.LogError(ex, " Caught error in copy files recursively from {sourcePathForFilesAndDirectories} to {depositPath}", sourcePathForFilesAndDirectories, depositPath);
-            return (createSubFolderResult: [], uploadFileResult: [], false, false, null);
+            return (createSubFolderResult: [], uploadFileResult: [], false, false);
         }
 
-        return (createSubFolderResult: [], uploadFileResult: [], false, false, null);
+        return (createSubFolderResult: [], uploadFileResult: [], false, false);
     }
 
-    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath, WorkspaceManager workspaceManager)
+    private async Task<Result<CreateFolderResult>?> CreateMetadataSubFolderOnS3(ExecutePipelineJob request, string dirPath)
     {
+        // refresh: false - a fresh Deposit/METS ETag is still fetched every call (necessary, since
+        // each successful CreateFolder writes to METS and changes its ETag - the next call needs the
+        // new one or its own write fails an optimistic-concurrency precondition check), but this skips
+        // the expensive full S3 file-system walk. CreateFolder (via Storage.AddToDepositFileSystem)
+        // incrementally keeps the deposit's cached file-system snapshot accurate as each item is
+        // created, so GetDeposit + a cheap cached-JSON read is sufficient here - a full walk of the
+        // whole deposit on every single folder/file call was costing ~40s each on a large deposit,
+        // repeated 20+ times for one job's metadata upload alone (LPII-135).
+        var workspaceResult = await GetWorkspaceManager(request, false);
+        var workspaceManager = workspaceResult.Value!;
+
         var context = new StringBuilder();
         var metadataContext = "metadata";
         context.Append(metadataContext);
@@ -845,10 +843,6 @@ public class ProcessPipelineJobHandler(
 
         logger.LogInformation("BrunnhildeFolderName {BrunnhildeFolderName}", BrunnhildeFolderName);
         logger.LogInformation("di.Name {di.Name} context {context}", di.Name, context);
-        // refreshDirectory: false - safe because CreateFolder (Storage.AddToDepositFileSystem)
-        // incrementally updates the deposit's cached file-system snapshot after every creation, so the
-        // next lookup (e.g. for a nested folder created later in the same batch) still sees it via a
-        // cheap cached read instead of forcing another full S3 scan.
         var result = await workspaceManager.CreateFolder(
             di.Name, context.ToString(), false, request.GetUserName(), false);
 
@@ -863,7 +857,7 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<(Result<SingleFileUploadResult>?, bool, bool)> UploadFileToDepositOnS3(ExecutePipelineJob request, string filePath,
-        string? sourcePath, Deposit deposit, CancellationToken cancellationToken, WorkspaceManager workspaceManager, bool bagitFile = false)
+        string? sourcePath, Deposit deposit, CancellationToken cancellationToken, bool bagitFile = false)
     {
         var context = new StringBuilder();
         var metadataContext =  bagitFile ? string.Empty : "metadata";
@@ -912,7 +906,7 @@ public class ProcessPipelineJobHandler(
             return (null, false, false);
 
         var stream = GetFileStream(filePath);
-        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, workspaceManager, bagitFile);
+        var result = await UploadFileToBucketDeposit(request, stream, filePath, contextPath, checksum, bagitFile);
 
 
         if (!result.Success)
@@ -931,8 +925,12 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<Result<SingleFileUploadResult>> UploadFileToBucketDeposit(
-        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, WorkspaceManager workspaceManager, bool bagitFile = false)
+        ExecutePipelineJob request, Stream stream, string filePath, string? contextPath, string checksum, bool bagitFile = false)
     {
+        // refresh: false - see the comment on CreateMetadataSubFolderOnS3's equivalent call: this
+        // still fetches a fresh Deposit/METS ETag (required, since each successful upload writes to
+        // METS and changes its ETag) via a cheap GetDeposit + cached-JSON read, without repeating the
+        // expensive full S3 file-system walk on every single file upload (LPII-135).
         var fi = new FileInfo(filePath);
         try
         {
@@ -942,7 +940,9 @@ public class ProcessPipelineJobHandler(
                 return Result.FailNotNull<SingleFileUploadResult>(ErrorCodes.UnknownError,
                     "Could not find file content type");
 
-            var result = await workspaceManager.UploadSingleSmallFile(
+            var workspaceManagerResult = await GetWorkspaceManager(request, false);
+
+            var result = await workspaceManagerResult.Value!.UploadSingleSmallFile(
                 stream, stream.Length, fi.Name, checksum, fi.Name, contentType, contextPath, request.GetUserName(), true, bagitFile); //bagit file
 
             return result;
@@ -970,8 +970,14 @@ public class ProcessPipelineJobHandler(
     /// </summary>
     /// <param name="request"></param>
     /// <param name="depositPath"></param>
-    private async Task<Result<ItemsAffected>> AddObjectsToMets(ExecutePipelineJob request, string depositPath, WorkspaceManager workspaceManager)
+    private async Task<Result<ItemsAffected>> AddObjectsToMets(ExecutePipelineJob request, string depositPath)
     {
+        // refresh: false here too - a fresh Deposit/METS ETag is needed (the folder/file creation
+        // above has since changed it), but the file-system tree itself gets rebuilt unconditionally
+        // just below via RefreshCombinedDirectory() regardless, so there's no point paying for two
+        // full S3 walks back to back.
+        var workspaceManagerResult = await GetWorkspaceManager(request, false);
+        var workspaceManager = workspaceManagerResult.Value!;
         var (_, _, objectPath, _) = GetFilePaths(workspaceManager);
         var minimalItems = new List<MinimalItem>();
 
@@ -1511,7 +1517,7 @@ public class ProcessPipelineJobHandler(
     }
 
     private async Task<(List<Result<SingleFileUploadResult>?> uploadFileResult, bool forceComplete, bool cleanupProcess)> UploadBagitFilesToRoot(
-        ExecutePipelineJob request, Deposit deposit, CancellationToken cancellationToken, WorkspaceManager workspaceManager)
+        ExecutePipelineJob request, Deposit deposit, CancellationToken cancellationToken)
     {
         var separator = pipelineToolOptions.Value.DirectorySeparator;
         var processFolderBagitDeposit = $"{pipelineToolOptions.Value.ProcessFolderBagit}{separator}{request.DepositId}";
@@ -1544,7 +1550,7 @@ public class ProcessPipelineJobHandler(
                     return (uploadFileResult: [], forceCompleteFileUpload, cleanupProcessFileUpload);
                 }
 
-                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, workspaceManager, true);
+                var (uploadFileToS3Result, uploadFileToS3ForcedComplete, uploadFileToS3CleanupProcess) = await UploadFileToDepositOnS3(request, filePath, processFolderBagitDeposit, deposit, cancellationToken, true);
                 if (uploadFileToS3Result != null && (uploadFileToS3ForcedComplete || uploadFileToS3CleanupProcess || !uploadFileToS3Result.Success))
                 {
                     await TryReleaseLock(request, deposit, cancellationToken);

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/SqsPipelineQueue.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/SqsPipelineQueue.cs
@@ -74,7 +74,10 @@ public class SqsPipelineQueue(
                 if (messageModel != null && !messageModel.DepositName.HasText())
                     return messageModel;
 
-                await DeleteMessage(message, queueUrlValue, linkedToken);
+                // Deliberately not scoped to the 30s dequeue-attempt timeout above: cancelling this
+                // mid-flight would leave the message undeleted, so it reappears after the visibility
+                // timeout and the job runs a second time even though it already returned successfully.
+                await DeleteMessage(message, queueUrlValue, cancellationToken);
                 return messageModel;
 
             }

--- a/src/DigitalPreservation/Pipeline.API/Features/Pipeline/SqsPipelineQueue.cs
+++ b/src/DigitalPreservation/Pipeline.API/Features/Pipeline/SqsPipelineQueue.cs
@@ -45,7 +45,17 @@ public class SqsPipelineQueue(
             var queue = options.Value.PipelineJobQueue;
 
             logger.LogInformation($"About to check queue {queue} for messages");
-            var queueUrlResponse = await sqsClient.GetQueueUrlAsync(queue, cancellationToken);
+
+            // WaitTimeSeconds below is an SQS-side long-poll duration, not a client-side timeout - if
+            // the underlying connection to SQS goes dead without erroring, these calls can hang
+            // indefinitely with no exception, silently wedging this single-threaded consumer loop
+            // forever (seen in practice - see LPII-135). Bound the whole dequeue attempt so a hang
+            // degrades to a retried failure on the next loop iteration instead of a permanent stall.
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            var linkedToken = linkedCts.Token;
+
+            var queueUrlResponse = await sqsClient.GetQueueUrlAsync(queue, linkedToken);
             var queueUrlValue = queueUrlResponse.QueueUrl;
 
             var response = await sqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
@@ -53,7 +63,7 @@ public class SqsPipelineQueue(
                 QueueUrl = queueUrlValue,
                 WaitTimeSeconds = 10,
                 MaxNumberOfMessages = 1
-            }, cancellationToken);
+            }, linkedToken);
 
             foreach (var message in response.Messages!)
             {
@@ -64,7 +74,7 @@ public class SqsPipelineQueue(
                 if (messageModel != null && !messageModel.DepositName.HasText())
                     return messageModel;
 
-                await DeleteMessage(message, queueUrlValue, cancellationToken);
+                await DeleteMessage(message, queueUrlValue, linkedToken);
                 return messageModel;
 
             }

--- a/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/DeleteDepositLock.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/Deposits/Requests/DeleteDepositLock.cs
@@ -30,7 +30,17 @@ public class DeleteDepositLockHandler(
         // unlocking an already unlocked deposit is a no-op
         entity.LockedBy = null;
         entity.LockDate = null;
-        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Issue saving the released lock for deposit {id}", request.Id);
+            return Result.Fail(ErrorCodes.UnknownError, e.Message);
+        }
+
         return Result.Ok();
     }
 }

--- a/src/DigitalPreservation/Preservation.Client/MachineAuthTokenInjector.cs
+++ b/src/DigitalPreservation/Preservation.Client/MachineAuthTokenInjector.cs
@@ -1,0 +1,36 @@
+using System.Net.Http.Headers;
+using DigitalPreservation.Core.Web.Headers;
+using Microsoft.Extensions.Logging;
+
+namespace Preservation.Client;
+
+/// <summary>
+/// Gets a client-credentials Bearer token from <see cref="IAccessTokenProvider"/> and injects it
+/// into calls to Preservation API for machine-to-machine callers. Runs per-request rather than once
+/// at HttpClient construction time, so a client used across a long-running job (an ExecutePipelineJob
+/// handler can live for the job's whole duration) always sends a current token instead of one that
+/// may have expired partway through - see LPII-135.
+/// </summary>
+public class MachineAuthTokenInjector(IAccessTokenProvider tokenProvider, ILogger<MachineAuthTokenInjector> logger) : DelegatingHandler
+{
+    private async Task SetBearerToken(HttpRequestMessage request)
+    {
+        var token = await tokenProvider.GetAccessToken();
+
+        if (token != null)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        else
+        {
+            logger.LogWarning("No access token available to attach to request {Uri}", request.RequestUri);
+        }
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        await SetBearerToken(request);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
+++ b/src/DigitalPreservation/Preservation.Client/ServiceCollectionX.cs
@@ -53,21 +53,18 @@ public static class ServiceCollectionX
         serviceCollection.Configure<PreservationOptions>(configuration.GetSection(PreservationOptions.Preservation));
         serviceCollection
             .AddTransient<TimingHandler>()
-            //.AddTransient<AuthTokenInjector>()
+            .AddTransient<MachineAuthTokenInjector>()
             .AddHttpClient<IPreservationApiClient, PreservationApiClient>((provider, client) =>
             {
-                var tokenProvider = provider.GetRequiredService<IAccessTokenProvider>();
-                var token = tokenProvider.GetAccessToken().Result;
                 var preservationOptions = provider.GetRequiredService<IOptions<PreservationOptions>>().Value;
                 client.BaseAddress = !string.IsNullOrEmpty(clientBaseAddress) ? new Uri(clientBaseAddress) : preservationOptions.Root.ThrowIfNull(nameof(preservationOptions.Root));
                 client.DefaultRequestHeaders.WithRequestedBy(componentName);
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                 client.DefaultRequestHeaders.Add("X-Client-Identity", componentName);
                 client.Timeout = TimeSpan.FromMinutes(preservationOptions.TimeoutMinutes);
             })
             .ConfigureTcpKeepAlive(true, TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(60), 60)
-            .AddHttpMessageHandler<TimingHandler>();
-            //.AddHttpMessageHandler<AuthTokenInjector>();
+            .AddHttpMessageHandler<TimingHandler>()
+            .AddHttpMessageHandler<MachineAuthTokenInjector>();
 
         return serviceCollection;
     }


### PR DESCRIPTION
Ticket: https://digirati.atlassian.net/browse/LPII-135

## Summary

Fixes a cluster of related Pipeline API reliability issues tracked under LPII-135. Individually these looked like separate incidents (ClamAV connection errors, tasks going "unhealthy" and getting replaced mid-run, jobs silently leaving deposits locked), but investigating them turned up several distinct, compounding root causes in how Pipeline API manages threads, memory, external processes, and S3/METS calls during a pipeline run. All were reproduced and fixed against a real large deposit (thousands of files) on dev.

## Changes

**ClamAV / concurrency**
- Reconfigured `clamd` (`MaxConnectionQueueLength`, `MaxThreads`) to handle concurrent scan connections without dropping requests under load.
- `GetVirusDefinition()` made properly async — the previous sync call blocked a ThreadPool thread waiting on `clamd`, starving the rest of the app (including health checks) whenever `clamd` was mid-scan.

**Process reliability**
- `clamd` and `freshclam` are now supervised and auto-restart if they crash. Previously a dead `clamd` didn't fail the scan — `clamscan-shim.sh` just logged "Connection refused" and reported a false clean result. Required a follow-up fix: both processes self-daemonize by default, which the first supervision pass mistook for a crash-loop; now run with `--foreground`.
- `PYTHONUTF8=1` — stops Brunnhilde hanging on non-ASCII filenames, which wedged every subsequent SQS job behind it.
- `SqsPipelineQueue`'s dequeue now has a client-side timeout instead of hanging indefinitely.
- ExifTool output is streamed straight to disk instead of buffered fully in memory — was contributing to OOM kills on large deposits.

**Memory leak**
- A `System.Timers.Timer` (`processTimer`) was never stopped on job completion. It kept the entire job's handler instance alive indefinitely and re-fired a background HTTP call every 10s per completed job — root cause of "every consecutive pipeline run provisions a new ECS task." Now stopped unconditionally in the handler's `finally` block.
- Tuned GC (`DOTNET_GCConserveMemory`, switched to Workstation GC) to release memory back to the OS between jobs instead of retaining it as a high-water mark. An initial max-aggressive setting (`GCConserveMemory=9`) traded the memory creep for a worse failure mode — multi-minute blocking GC pauses that froze the health endpoint — dialed back to a lighter setting that avoids both.

**METS correctness**
- `ParseExifToolOutput` hardened against malformed lines and false file-boundary matches.
- `significantProperties` conflict exceptions now include the file path, making stale-METS conflicts diagnosable instead of an opaque property-name-only error.

**Auth token refresh**
- Pipeline API's Bearer token to Preservation API was attached once, at `HttpClient` construction time, and never refreshed for the life of that client — so any job running long enough to cross the token's actual expiry had every subsequent API call fail with 401 partway through, cascading into failed lock releases and status updates. Replaced with a `DelegatingHandler` (`MachineAuthTokenInjector`) that fetches a current token per request, mirroring the pattern already used correctly for user-delegated auth.

**Deposit lock release**
- A transient DB error releasing a deposit's lock went unhandled and surfaced as a generic failure; the retry loop around it was a tight busy-loop with a broken timeout check (compared `TimeSpan.Seconds`, the 0-59 *component*, instead of `TotalSeconds`); and exhausting all retries still reported the job `Completed` — a deposit could be left locked indefinitely with nothing in the job's own status to show it. Now retries with backoff, times out correctly, and reports `CompletedWithErrors` with an explicit message on genuine failure.

**Redundant S3 API calls**
- Every metadata folder/file created after Brunnhilde ran triggered a fula-time S3 scan of the *entire* deposit (`GenerateDepositFileSystem`) torefresh a `WorkspaceManager` that was then thrown away — ~40s per call on a large deposit, repeated 20-25 times per job just for uploading a handful of report files. Fixed by
fetching the deposit metadata fresh (cheap, needed for METS ETag correctne-triggering the expensive full file-system walk, which`Storage.AddToDepositFileSystem` already keeps incrementally accurate. Confirmed on a real run: 25 scans → 3, upload-phase duration ~16 min → ~4 min.

## Test plan
- [x] `dotnet build` — clean
- [x] Full non-integration/non-manual test suite — 521/521 passing
- [x] Validated against a real large deposit on dev: two consecutive runssh-loop, no memory-driven task replacement, no thread-pool-starvation warnings
- [x] Confirmed the auth-token and lock-release fixes correctly surface as `CompletedWithErrors` instead of silently swallowing it
- [x] Confirmed the S3-refactor doesn't break METS write correctness (initial version did — see fixup commit `22c26e7` — caught via a real run before merge)
- [ ] Recommend monitoring `MemoryUtilized` and ECS task-replacement freqost-merge before promoting to test/prod

**PR description assisted by Claude**