### PR TITLE
Fix NRE in PremisManager.Read for PRONOM-key-only formats

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Mets/PremisManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/PremisManager.cs
@@ -39,7 +39,8 @@ public class PremisManager
 
         if (pronomFormat != null)
         {
-            premisFile.FormatName = pronomFormat.FormatDesignation.FormatName.Value;
+            // A format patched with a PRONOM key only has a registry but no designation
+            premisFile.FormatName = pronomFormat.FormatDesignation?.FormatName?.Value;
         }
         var registry = pronomFormat?.FormatRegistry.FirstOrDefault(fr => fr.FormatRegistryName.Value == Pronom);
         if (registry != null)

--- a/src/DigitalPreservation/XmlGen.Tests/Premis_Test.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Premis_Test.cs
@@ -248,7 +248,28 @@ public class PremisTests(ITestOutputHelper testOutputHelper)
         var s = premisManager.Serialise(premis);
         testOutputHelper.WriteLine(s);
     }
-    
+
+    [Fact]
+    public void Premis_Read_After_PronomKey_Only_Patch()
+    {
+        var start = new FileFormatMetadata
+        {
+            Source = "Tests",
+            Digest = "123456",
+            Size = 654321
+        };
+        var premisManager = new PremisManager();
+        var premis = premisManager.Create(start);
+        start.PronomKey = "fmt/bob";
+        premisManager.Patch(premis, start);
+
+        var read = premisManager.Read(premis);
+        read!.Digest.Should().Be("123456");
+        read.Size.Should().Be(654321);
+        read.PronomKey.Should().Be("fmt/bob");
+        read.FormatName.Should().BeNull("a PRONOM-key-only format has no FormatDesignation to read a name from");
+    }
+
     [Fact]
     public void Premis_Build_up_all()
     {


### PR DESCRIPTION
## What

`PremisManager.Read` threw a `NullReferenceException` when reading PREMIS whose format element has a PRONOM registry key but no `FormatDesignation`.

## Why

`Patch` with a `PronomKey` but no `FormatName` (a legitimate sequence — see `Premis_Digest_and_Size_then_Edit_More`) creates a `FormatComplexType` containing a `FormatRegistry` only. `Read` then dereferenced `pronomFormat.FormatDesignation.FormatName.Value` unconditionally.

This was found during the MetsManager work in March and documented in a test comment rather than fixed (out of scope at the time); this PR is the proper fix.

## How

- `Read` now uses null-conditional access: `FormatDesignation?.FormatName?.Value`, leaving `FormatName` null when there is no designation.
- New regression test `Premis_Read_After_PronomKey_Only_Patch` — verified it fails with the NRE against the previous code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)