### PR TITLE
Decouple METS navigation from ID format via path cache (#188 step 1)

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
@@ -1,8 +1,19 @@
-﻿namespace DigitalPreservation.Mets;
+using DigitalPreservation.XmlGen.Mets;
+
+namespace DigitalPreservation.Mets;
 
 public class FullMets
 {
     public required DigitalPreservation.XmlGen.Mets.Mets Mets { get; set; }
     public required Uri Uri { get; set; }
     public string? ETag { get; set; }
+
+    /// <summary>
+    /// Maps each deposit-relative path (BagIt data/ prefix stripped) to its div in the PHYSICAL
+    /// structMap. Paths are resolved from premis:originalName (directories) and FLocat href
+    /// (files), never from div IDs, so navigation does not depend on the ID format (issue #188).
+    /// Populated by <see cref="MetsCache.Populate"/> on load and maintained by every MetsManager
+    /// mutation. The PHYS_ROOT div is not cached; it is the implicit root of every path.
+    /// </summary>
+    public Dictionary<string, DivType> PhysicalDivsByPath { get; } = new();
 }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
@@ -24,4 +24,11 @@ public class FullMets
     /// conformance check.
     /// </summary>
     public List<string> PathDiagnostics { get; } = new();
+
+    /// <summary>
+    /// True when the last <see cref="MetsCache.Populate"/> found two divs resolving to the
+    /// same path - the specific malformation that requires a cache rebuild after deleting a
+    /// path-owning div.
+    /// </summary>
+    public bool HasDuplicatePaths { get; internal set; }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/FullMets.cs
@@ -16,4 +16,12 @@ public class FullMets
     /// mutation. The PHYS_ROOT div is not cached; it is the implicit root of every path.
     /// </summary>
     public Dictionary<string, DivType> PhysicalDivsByPath { get; } = new();
+
+    /// <summary>
+    /// Diagnostics from the last <see cref="MetsCache.Populate"/>: one entry per div whose path
+    /// could not be resolved or that collided with another div's path. Empty for a well-formed
+    /// managed METS. Used to explain navigation failures, and the seed of a future editability
+    /// conformance check.
+    /// </summary>
+    public List<string> PathDiagnostics { get; } = new();
 }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
@@ -30,9 +30,11 @@ public interface IMetsManager
     // SetAccessRestrictionsByPath(mets, "objects/child-folder", ["Closed"])
     // SetAccessRestrictionsByDivId(mets, "LOG_0003", ["Sundays Only"])
     // SetAccessRestrictionsByDivId(mets, "PHYS_objects/child-folder", ["Closed"])  // equiv to first one
-    // Each returns NotFound when the path/divId does not fully resolve - the write did NOT
-    // happen and the caller must not report success (silently writing to an ancestor div,
-    // or silently doing nothing, are both worse than failing).
+    // Each returns a failure when the write did NOT happen, and the caller must not report
+    // success (silently writing to an ancestor div, or silently doing nothing, are both
+    // worse than failing). ByPath methods return BadRequest for an unresolvable path (same
+    // condition and code as EditMets); ByDivId methods return NotFound for an unknown divId;
+    // both return BadRequest when the div's descriptive metadata cannot be edited as MODS.
     Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo);
     Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo);
     Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
@@ -30,14 +30,17 @@ public interface IMetsManager
     // SetAccessRestrictionsByPath(mets, "objects/child-folder", ["Closed"])
     // SetAccessRestrictionsByDivId(mets, "LOG_0003", ["Sundays Only"])
     // SetAccessRestrictionsByDivId(mets, "PHYS_objects/child-folder", ["Closed"])  // equiv to first one
-    void SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo);
-    void SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo);
-    void SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement);
-    void SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement);
-    void SuppressRightsInheritanceByPath(FullMets mets, string localPath);
-    void SuppressRightsInheritanceByDivId(FullMets mets, string divId);
-    void SetAccessRestrictionsByPath(FullMets mets, string localPath, List<string> accessRestrictions);
-    void SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions);
+    // Each returns NotFound when the path/divId does not fully resolve - the write did NOT
+    // happen and the caller must not report success (silently writing to an ancestor div,
+    // or silently doing nothing, are both worse than failing).
+    Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo);
+    Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo);
+    Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement);
+    Result SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement);
+    Result SuppressRightsInheritanceByPath(FullMets mets, string localPath);
+    Result SuppressRightsInheritanceByDivId(FullMets mets, string divId);
+    Result SetAccessRestrictionsByPath(FullMets mets, string localPath, List<string> accessRestrictions);
+    Result SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions);
 
 
     // There may be more than one so we need to address them better than this, which assumes only one

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
@@ -32,9 +32,9 @@ public interface IMetsManager
     // SetAccessRestrictionsByDivId(mets, "PHYS_objects/child-folder", ["Closed"])  // equiv to first one
     // Each returns a failure when the write did NOT happen, and the caller must not report
     // success (silently writing to an ancestor div, or silently doing nothing, are both
-    // worse than failing). ByPath methods return BadRequest for an unresolvable path (same
-    // condition and code as EditMets); ByDivId methods return NotFound for an unknown divId;
-    // both return BadRequest when the div's descriptive metadata cannot be edited as MODS.
+    // worse than failing). ByPath methods return BadRequest for an unresolvable path (the
+    // same condition and code as EditMets). ByDivId methods return NotFound for an unknown
+    // divId. Both return BadRequest when the descriptive metadata cannot be edited as MODS.
     Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo);
     Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo);
     Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -187,7 +187,7 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
 
         SetFileAndFileGroup(ctx, div, fullMets);
 
-        if (ctx.File?.FLocat[0].Href != operationPath)
+        if (ctx.File == null || MetsCache.NormalisePathKey(ctx.File.FLocat[0].Href) != operationPath)
         {
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
         }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -23,12 +23,15 @@ public static class MetsCache
     /// list means the whole physical structMap is navigable by path. The diagnostics are also
     /// stored on <see cref="FullMets.PathDiagnostics"/> so later failures can explain themselves.
     /// </summary>
+    internal const string DuplicatePathFragment = "both resolve to path";
+
     public static List<string> Populate(FullMets fullMets)
     {
         fullMets.PhysicalDivsByPath.Clear();
         var diagnostics = Build(fullMets.Mets, fullMets.PhysicalDivsByPath);
         fullMets.PathDiagnostics.Clear();
         fullMets.PathDiagnostics.AddRange(diagnostics);
+        fullMets.HasDuplicatePaths = diagnostics.Any(d => d.Contains(DuplicatePathFragment));
         return diagnostics;
     }
 
@@ -79,7 +82,7 @@ public static class MetsCache
             if (key != null && !cache.TryAdd(key, child))
             {
                 diagnostics.Add(
-                    $"Divs '{cache[key].Id}' and '{child.Id}' both resolve to path '{key}'");
+                    $"Divs '{cache[key].Id}' and '{child.Id}' {DuplicatePathFragment} '{key}'");
             }
 
             Walk(child, mets, cache, diagnostics);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -1,0 +1,157 @@
+using System.Xml;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Utils;
+using DigitalPreservation.XmlGen.Mets;
+
+namespace DigitalPreservation.Mets;
+
+/// <summary>
+/// Builds <see cref="FullMets.PhysicalDivsByPath"/>: the mapping from deposit-relative path to
+/// physical structMap div. Paths are resolved from the div's own metadata — premis:originalName
+/// for directories, the referenced FILE's FLocat href for files — never from the div's ID, so
+/// the mapping holds whatever form the IDs take (issue #188).
+/// A METS file whose physical structMap cannot be fully and unambiguously mapped is not fully
+/// navigable by path; the diagnostics returned by <see cref="Populate"/> say why. Those
+/// diagnostics are the seed of a future conformance check for whether a METS file is editable.
+/// </summary>
+public static class MetsCache
+{
+    /// <summary>
+    /// Rebuild the path cache from the current state of the METS. Returns diagnostics for any
+    /// div whose path could not be resolved, or that collided with another div's path; an empty
+    /// list means the whole physical structMap is navigable by path.
+    /// </summary>
+    public static List<string> Populate(FullMets fullMets)
+    {
+        fullMets.PhysicalDivsByPath.Clear();
+        return Build(fullMets.Mets, fullMets.PhysicalDivsByPath);
+    }
+
+    /// <summary>
+    /// Build the path→div mapping into the supplied (empty) dictionary. Used by
+    /// <see cref="Populate"/> and by MetsManager's debug-build cache-consistency assertion.
+    /// </summary>
+    internal static List<string> Build(
+        DigitalPreservation.XmlGen.Mets.Mets mets, Dictionary<string, DivType> cache)
+    {
+        var diagnostics = new List<string>();
+
+        var physRoot = mets.StructMap
+            .SingleOrDefault(sm => sm.Type == Constants.Physical)?.Div;
+        if (physRoot == null)
+        {
+            diagnostics.Add("METS has no PHYSICAL structMap");
+            return diagnostics;
+        }
+
+        Walk(physRoot, mets, cache, diagnostics);
+        return diagnostics;
+    }
+
+    private static void Walk(
+        DivType div,
+        DigitalPreservation.XmlGen.Mets.Mets mets,
+        Dictionary<string, DivType> cache,
+        List<string> diagnostics)
+    {
+        foreach (var child in div.Div)
+        {
+            var key = ResolvePath(child, mets, diagnostics);
+            if (key != null && !cache.TryAdd(key, child))
+            {
+                diagnostics.Add(
+                    $"Divs '{cache[key].Id}' and '{child.Id}' both resolve to path '{key}'");
+            }
+
+            Walk(child, mets, cache, diagnostics);
+        }
+    }
+
+    private static string? ResolvePath(
+        DivType child,
+        DigitalPreservation.XmlGen.Mets.Mets mets,
+        List<string> diagnostics)
+    {
+        string? path = null;
+        switch (child.Type)
+        {
+            case Constants.DirectoryType when child.Admid.Count == 0:
+                diagnostics.Add($"Directory div '{child.Id}' has no ADMID, so no path");
+                break;
+            case Constants.DirectoryType:
+            {
+                // Legacy IDs may contain spaces, which the XML processor splits into multiple
+                // IDREFS tokens; joining reconstructs the single amdSec ID (see MetadataManager).
+                var admId = string.Join(' ', child.Admid);
+                var amdSec = mets.AmdSec.FirstOrDefault(a => a.Id == admId);
+                path = ExtractPremisOriginalName(amdSec);
+                if (path == null)
+                {
+                    diagnostics.Add(
+                        $"Directory div '{child.Id}' has no premis:originalName via ADMID '{admId}'");
+                }
+                break;
+            }
+            case Constants.ItemType when child.Fptr.Count == 0:
+                diagnostics.Add($"Item div '{child.Id}' has no fptr, so no path");
+                break;
+            case Constants.ItemType:
+            {
+                var fileId = child.Fptr[0].Fileid;
+                var file = mets.FileSec?.FileGrp
+                    .SelectMany(fg => fg.File)
+                    .FirstOrDefault(f => f.Id == fileId);
+                path = file?.FLocat.FirstOrDefault()?.Href;
+                if (path == null)
+                {
+                    diagnostics.Add(
+                        $"Item div '{child.Id}' has no FLocat href via FILEID '{fileId}'");
+                }
+                break;
+            }
+            default:
+                diagnostics.Add(
+                    $"Div '{child.Id}' has unrecognised TYPE '{child.Type}', so no path");
+                break;
+        }
+
+        if (path == null)
+        {
+            return null;
+        }
+
+        var normalised = NormalisePathKey(path);
+        if (normalised == null)
+        {
+            diagnostics.Add($"Div '{child.Id}' resolves to empty path '{path}'");
+        }
+        return normalised;
+    }
+
+    /// <summary>
+    /// Normalise a path extracted from METS metadata to the deposit-relative form used
+    /// everywhere else in the system (and by MetsManager's own localPath handling).
+    /// </summary>
+    internal static string? NormalisePathKey(string path)
+    {
+        var normalised = FolderNames.RemovePathPrefix(path.Trim())!
+            .RemoveStart("./")!
+            .TrimEnd('/');
+        return normalised.HasText() ? normalised : null;
+    }
+
+    private static string? ExtractPremisOriginalName(AmdSecType? amdSec)
+    {
+        var premisXml = amdSec?.TechMd.FirstOrDefault()?.MdWrap?.XmlData?.Any?.FirstOrDefault();
+        if (premisXml is not XmlElement element)
+        {
+            return null;
+        }
+
+        var originalName = element
+            .GetElementsByTagName("originalName", XNames.premis.NamespaceName)
+            .OfType<XmlElement>()
+            .FirstOrDefault()?.InnerText;
+        return originalName.HasText() ? originalName : null;
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -92,9 +92,10 @@ public static class MetsCache
     /// <summary>
     /// Resolve a single div to its deposit-relative path from its own metadata, without
     /// reporting diagnostics. Used by MetsManager's navigation fallback when the cache entry
-    /// for a path is missing or ambiguous.
+    /// for a path is missing or ambiguous, and by MetsFromArchivalGroup to match template
+    /// divs by path rather than by reconstructed ID.
     /// </summary>
-    internal static string? TryResolvePath(DivType div, DigitalPreservation.XmlGen.Mets.Mets mets)
+    public static string? TryResolvePath(DivType div, DigitalPreservation.XmlGen.Mets.Mets mets)
         => ResolvePath(div, mets, null);
 
     private static string? ResolvePath(

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -11,20 +11,25 @@ namespace DigitalPreservation.Mets;
 /// for directories, the referenced FILE's FLocat href for files — never from the div's ID, so
 /// the mapping holds whatever form the IDs take (issue #188).
 /// A METS file whose physical structMap cannot be fully and unambiguously mapped is not fully
-/// navigable by path; the diagnostics returned by <see cref="Populate"/> say why. Those
-/// diagnostics are the seed of a future conformance check for whether a METS file is editable.
+/// navigable by path; the diagnostics returned by <see cref="Populate"/> (and kept on
+/// <see cref="FullMets.PathDiagnostics"/>) say why. Those diagnostics are the seed of a future
+/// conformance check for whether a METS file is editable.
 /// </summary>
 public static class MetsCache
 {
     /// <summary>
     /// Rebuild the path cache from the current state of the METS. Returns diagnostics for any
     /// div whose path could not be resolved, or that collided with another div's path; an empty
-    /// list means the whole physical structMap is navigable by path.
+    /// list means the whole physical structMap is navigable by path. The diagnostics are also
+    /// stored on <see cref="FullMets.PathDiagnostics"/> so later failures can explain themselves.
     /// </summary>
     public static List<string> Populate(FullMets fullMets)
     {
         fullMets.PhysicalDivsByPath.Clear();
-        return Build(fullMets.Mets, fullMets.PhysicalDivsByPath);
+        var diagnostics = Build(fullMets.Mets, fullMets.PhysicalDivsByPath);
+        fullMets.PathDiagnostics.Clear();
+        fullMets.PathDiagnostics.AddRange(diagnostics);
+        return diagnostics;
     }
 
     /// <summary>
@@ -36,11 +41,25 @@ public static class MetsCache
     {
         var diagnostics = new List<string>();
 
-        var physRoot = mets.StructMap
-            .SingleOrDefault(sm => sm.Type == Constants.Physical)?.Div;
-        if (physRoot == null)
+        // Tolerate malformed METS: never throw here, this runs on every load. Zero or many
+        // PHYSICAL structMaps are diagnostics, not exceptions; with many, the first is used
+        // (matching the parser's structMap selection order).
+        var physicalStructMaps = mets.StructMap.Where(sm => sm.Type == Constants.Physical).ToList();
+        if (physicalStructMaps.Count == 0)
         {
             diagnostics.Add("METS has no PHYSICAL structMap");
+            return diagnostics;
+        }
+        if (physicalStructMaps.Count > 1)
+        {
+            diagnostics.Add(
+                $"METS has {physicalStructMaps.Count} PHYSICAL structMaps; only the first is navigable");
+        }
+
+        var physRoot = physicalStructMaps[0].Div;
+        if (physRoot == null)
+        {
+            diagnostics.Add("PHYSICAL structMap has no root div");
             return diagnostics;
         }
 
@@ -67,16 +86,24 @@ public static class MetsCache
         }
     }
 
+    /// <summary>
+    /// Resolve a single div to its deposit-relative path from its own metadata, without
+    /// reporting diagnostics. Used by MetsManager's navigation fallback when the cache entry
+    /// for a path is missing or ambiguous.
+    /// </summary>
+    internal static string? TryResolvePath(DivType div, DigitalPreservation.XmlGen.Mets.Mets mets)
+        => ResolvePath(div, mets, null);
+
     private static string? ResolvePath(
         DivType child,
         DigitalPreservation.XmlGen.Mets.Mets mets,
-        List<string> diagnostics)
+        List<string>? diagnostics)
     {
         string? path = null;
         switch (child.Type)
         {
             case Constants.DirectoryType when child.Admid.Count == 0:
-                diagnostics.Add($"Directory div '{child.Id}' has no ADMID, so no path");
+                diagnostics?.Add($"Directory div '{child.Id}' has no ADMID, so no path");
                 break;
             case Constants.DirectoryType:
             {
@@ -87,13 +114,13 @@ public static class MetsCache
                 path = ExtractPremisOriginalName(amdSec);
                 if (path == null)
                 {
-                    diagnostics.Add(
+                    diagnostics?.Add(
                         $"Directory div '{child.Id}' has no premis:originalName via ADMID '{admId}'");
                 }
                 break;
             }
             case Constants.ItemType when child.Fptr.Count == 0:
-                diagnostics.Add($"Item div '{child.Id}' has no fptr, so no path");
+                diagnostics?.Add($"Item div '{child.Id}' has no fptr, so no path");
                 break;
             case Constants.ItemType:
             {
@@ -104,13 +131,13 @@ public static class MetsCache
                 path = file?.FLocat.FirstOrDefault()?.Href;
                 if (path == null)
                 {
-                    diagnostics.Add(
+                    diagnostics?.Add(
                         $"Item div '{child.Id}' has no FLocat href via FILEID '{fileId}'");
                 }
                 break;
             }
             default:
-                diagnostics.Add(
+                diagnostics?.Add(
                     $"Div '{child.Id}' has unrecognised TYPE '{child.Type}', so no path");
                 break;
         }
@@ -123,19 +150,24 @@ public static class MetsCache
         var normalised = NormalisePathKey(path);
         if (normalised == null)
         {
-            diagnostics.Add($"Div '{child.Id}' resolves to empty path '{path}'");
+            diagnostics?.Add($"Div '{child.Id}' resolves to empty path '{path}'");
         }
         return normalised;
     }
 
     /// <summary>
     /// Normalise a path extracted from METS metadata to the deposit-relative form used
-    /// everywhere else in the system (and by MetsManager's own localPath handling).
+    /// everywhere else in the system (and by MetsManager's own localPath handling). Only
+    /// structural variants are normalised (leading ./, BagIt data/ prefix, trailing /);
+    /// the characters of the path itself are never altered.
     /// </summary>
-    internal static string? NormalisePathKey(string path)
+    internal static string? NormalisePathKey(string? path)
     {
-        var normalised = FolderNames.RemovePathPrefix(path.Trim())!
-            .RemoveStart("./")!
+        if (path == null)
+        {
+            return null;
+        }
+        var normalised = FolderNames.RemovePathPrefix(path.RemoveStart("./"))!
             .TrimEnd('/');
         return normalised.HasText() ? normalised : null;
     }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -100,7 +100,9 @@ public class MetsManager(
 
     private Result EditMets(WorkingBase? workingBase, string? deletePath, FullMets fullMets)
     {
-        var localPath = FolderNames.RemovePathPrefix(workingBase?.LocalPath ?? deletePath)!;
+        // Normalise once so ID minting, FLocat writing and cache keys all use the same
+        // canonical deposit-relative form of the path.
+        var localPath = MetsCache.NormalisePathKey(workingBase?.LocalPath ?? deletePath) ?? string.Empty;
         var (contextDiv, parent, foundDepth, totalDepth) = LocateMetsDivByLocalPath(fullMets, localPath);
 
         if (foundDepth == totalDepth)
@@ -127,8 +129,12 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "No working directory or working file supplied to add.");
         }
 
-        return Result.Fail(ErrorCodes.BadRequest,
-            $"Could not edit METS because not all parts of the path '{localPath}' have been added to METS.");
+        var message = $"Could not edit METS because not all parts of the path '{localPath}' have been added to METS.";
+        if (fullMets.PathDiagnostics.Count > 0)
+        {
+            message += " METS path diagnostics: " + string.Join("; ", fullMets.PathDiagnostics);
+        }
+        return Result.Fail(ErrorCodes.BadRequest, message);
     }
 
     private Result UpdateExistingFile(DivType contextDiv, FullMets fullMets, WorkingFile workingFile, string localPath)
@@ -137,7 +143,7 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path does not end on a file");
 
         var (file, _) = SetFileAndFileGroup(contextDiv, fullMets);
-        if (file.FLocat[0].Href != localPath)
+        if (MetsCache.NormalisePathKey(file.FLocat[0].Href) != localPath)
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
 
         PopulateDmdFromResource(fullMets, workingFile, contextDiv);
@@ -161,6 +167,15 @@ public class MetsManager(
         var physId = Constants.PhysIdPrefix + localPath;
         var fileId = Constants.FileIdPrefix + localPath;
 
+        // Reaching an add for a path whose div already exists means that div could not be
+        // resolved by path OR by the legacy ID fallback - adding again would write duplicate
+        // ID attributes into the METS. Refuse rather than corrupt.
+        if (parentDiv.Div.Any(d => d.Id == physId))
+        {
+            return Result.Fail(ErrorCodes.BadRequest,
+                $"METS already contains a div '{physId}' that could not be resolved to path '{localPath}'.");
+        }
+
         var childItemDiv = new DivType
         {
             Type = Constants.ItemType,
@@ -168,14 +183,15 @@ public class MetsManager(
             Id = physId,
             Fptr = { new DivTypeFptr { Fileid = fileId } }
         };
-        parentDiv.Div.Add(childItemDiv);
 
-        PopulateDmdFromResource(fullMets, workingFile, childItemDiv);
+        // Nothing is attached to the METS until the fallible metadata step has succeeded,
+        // so a failed add leaves the document (and the cache) exactly as it was.
         var metadataResult = metadataManager.ProcessAllFileMetadata(fullMets, childItemDiv, workingFile, localPath, true);
         if (metadataResult.Failure)
             return metadataResult;
 
-        // After ProcessAllFileMetadata, so the FILE/FLocat entry the cache mirrors exists
+        PopulateDmdFromResource(fullMets, workingFile, childItemDiv);
+        parentDiv.Div.Add(childItemDiv);
         fullMets.PhysicalDivsByPath[localPath] = childItemDiv;
 
         SortChildDivs(parentDiv);
@@ -187,6 +203,12 @@ public class MetsManager(
         var physId = Constants.PhysIdPrefix + localPath;
         var admId = Constants.AdmIdPrefix + localPath;
         var techId = Constants.TechIdPrefix + localPath;
+
+        if (parentDiv.Div.Any(d => d.Id == physId))
+        {
+            return Result.Fail(ErrorCodes.BadRequest,
+                $"METS already contains a div '{physId}' that could not be resolved to path '{localPath}'.");
+        }
 
         var childDirectoryDiv = new DivType
         {
@@ -328,7 +350,7 @@ public class MetsManager(
         {
             var (file, fileGroup) = SetFileAndFileGroup(div, fullMets);
 
-            if (file.FLocat[0].Href != operationPath)
+            if (MetsCache.NormalisePathKey(file.FLocat[0].Href) != operationPath)
             {
                 return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
             }
@@ -372,9 +394,10 @@ public class MetsManager(
         EnsureCache(fullMets);
         AssertCacheConsistent(fullMets);
 
+        localPath = MetsCache.NormalisePathKey(localPath) ?? string.Empty;
         var elements = localPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        var div = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var div = fullMets.Mets.StructMap.First(sm => sm.Type == Constants.Physical).Div!;
         DivType? parent = null;
         var testPath = string.Empty;
         var counter = 0;
@@ -388,17 +411,17 @@ public class MetsManager(
             testPath += element;
 
             // Navigate by path (premis:originalName / FLocat href, via the cache), not by
-            // reconstructing div IDs from the path - IDs are opaque (issue #188).
-            if (!fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var childDiv))
+            // reconstructing div IDs from the path - IDs are opaque (issue #188). The cached
+            // div is only accepted if it really is a child of the current div; a malformed
+            // source can have two unrelated divs resolving to the same path, and the cache
+            // holds whichever was walked first.
+            if (!fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var childDiv) ||
+                !div.Div.Contains(childDiv))
             {
-                break;
+                childDiv = FindChildDivByPath(div, testPath, fullMets.Mets);
             }
 
-            // Guard against a malformed source in which two unrelated divs resolve to the same
-            // path: only accept the cached div if it really is a child of the current div. The
-            // walk then breaks with foundDepth < totalDepth, producing the same "not all parts
-            // of the path have been added" error as a plain miss.
-            if (!div.Div.Contains(childDiv))
+            if (childDiv is null)
             {
                 break;
             }
@@ -409,6 +432,19 @@ public class MetsManager(
         }
 
         return (div, parent, counter, elements.Length);
+    }
+
+    /// <summary>
+    /// Fallback resolution among the current div's children when the cache has no usable entry
+    /// for a path: first by each child's own path metadata (correct even when an unrelated div
+    /// elsewhere claims the same path), then by the legacy ID convention, which keeps divs with
+    /// broken path metadata navigable exactly as they were before the cache existed. The legacy
+    /// tier can be removed after a bulk ID migration (issue #188 step 3).
+    /// </summary>
+    private static DivType? FindChildDivByPath(DivType parent, string testPath, DigitalPreservation.XmlGen.Mets.Mets mets)
+    {
+        var byMetadata = parent.Div.FirstOrDefault(d => MetsCache.TryResolvePath(d, mets) == testPath);
+        return byMetadata ?? parent.Div.FirstOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}");
     }
 
     /// <summary>
@@ -522,7 +558,9 @@ public class MetsManager(
 
     public void SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo)
     {
-        var (div, _, _, _) = LocateMetsDivByLocalPath(mets, localPath);
+        var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
+        // A partial walk means div is an ANCESTOR of the requested path - never write to it
+        if (foundDepth != totalDepth) return;
         SetRecordInfoForDiv(mets, div, recordInfo);
     }
 
@@ -543,7 +581,8 @@ public class MetsManager(
 
     public void SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement)
     {
-        var (div, _, _, _) = LocateMetsDivByLocalPath(mets, localPath);
+        var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
+        if (foundDepth != totalDepth) return;
         SetRightsStatementForDiv(mets, div, rightsStatement);
     }
 
@@ -559,7 +598,8 @@ public class MetsManager(
     // which removes the element and allows parent rights to flow through.
     public void SuppressRightsInheritanceByPath(FullMets mets, string localPath)
     {
-        var (div, _, _, _) = LocateMetsDivByLocalPath(mets, localPath);
+        var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
+        if (foundDepth != totalDepth) return;
         SuppressRightsInheritanceForDiv(mets, div);
     }
 
@@ -594,7 +634,8 @@ public class MetsManager(
 
     public void SetAccessRestrictionsByPath(FullMets mets, string localPath, List<string> accessRestrictions)
     {
-        var (div, _, _, _) = LocateMetsDivByLocalPath(mets, localPath);
+        var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
+        if (foundDepth != totalDepth) return;
         SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -391,23 +391,31 @@ public class MetsManager(
         }
 
         parent!.Div.Remove(div);
-
-        // Only evict the cache entry if it is actually THIS div's - when the deleted div was
-        // reached via a fallback tier (its own path metadata being broken), the key may map to
-        // a different div that legitimately owns the path.
-        if (fullMets.PhysicalDivsByPath.TryGetValue(operationPath!, out var cachedDiv) &&
-            ReferenceEquals(cachedDiv, div))
-        {
-            fullMets.PhysicalDivsByPath.Remove(operationPath!);
-            if (fullMets.PathDiagnostics.Count > 0)
-            {
-                // A malformed doc may contain another div that claimed the same path (see the
-                // duplicate-path diagnostics) - rebuild so the cache reflects post-delete reality.
-                MetsCache.Populate(fullMets);
-            }
-        }
+        EvictFromPathCache(fullMets, div, operationPath!);
 
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// Only evict the cache entry if it is actually the deleted div's - when the deleted div
+    /// was reached via a fallback tier (its own path metadata being broken), the key may map
+    /// to a different div that legitimately owns the path.
+    /// </summary>
+    private static void EvictFromPathCache(FullMets fullMets, DivType div, string operationPath)
+    {
+        if (!fullMets.PhysicalDivsByPath.TryGetValue(operationPath, out var cachedDiv) ||
+            !ReferenceEquals(cachedDiv, div))
+        {
+            return;
+        }
+
+        fullMets.PhysicalDivsByPath.Remove(operationPath);
+        if (fullMets.PathDiagnostics.Count > 0)
+        {
+            // A malformed doc may contain another div that claimed the same path (see the
+            // duplicate-path diagnostics) - rebuild so the cache reflects post-delete reality.
+            MetsCache.Populate(fullMets);
+        }
     }
 
     private static (FileType file, MetsTypeFileSecFileGrp fileGroup) SetFileAndFileGroup(DivType div, FullMets fullMets)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Xml;
 using DigitalPreservation.Common.Model;
@@ -396,7 +397,7 @@ public class MetsManager(
     /// Legacy IDs containing spaces arrive from the XmlSerializer split into IDREFS tokens;
     /// rejoining reconstructs the single intended ID. Null when there is no reference at all.
     /// </summary>
-    private static string? JoinedIdOrNull(IList<string> tokens) =>
+    private static string? JoinedIdOrNull(Collection<string> tokens) =>
         tokens.Count switch
         {
             0 => null,
@@ -586,14 +587,15 @@ public class MetsManager(
         // Search PHYSICAL structMaps first (there should be one, but a malformed METS may
         // have zero or several - all are searched), then the rest. A structMap element with
         // no root div is skipped rather than dereferenced.
-        foreach (var structMap in fullMets.Mets.StructMap
-                     .OrderByDescending(sm => sm.Type == Constants.Physical))
+        foreach (var rootDiv in fullMets.Mets.StructMap
+                     .OrderByDescending(sm => sm.Type == Constants.Physical)
+                     .Select(structMap => structMap.Div))
         {
-            if (structMap.Div is null)
+            if (rootDiv is null)
             {
                 continue;
             }
-            var found = FindDiv(structMap.Div, divId);
+            var found = FindDiv(rootDiv, divId);
             if (found != null)
             {
                 return found;

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Xml;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Results;
@@ -174,6 +175,9 @@ public class MetsManager(
         if (metadataResult.Failure)
             return metadataResult;
 
+        // After ProcessAllFileMetadata, so the FILE/FLocat entry the cache mirrors exists
+        fullMets.PhysicalDivsByPath[localPath] = childItemDiv;
+
         SortChildDivs(parentDiv);
         return Result.Ok();
     }
@@ -201,6 +205,8 @@ public class MetsManager(
         };
         fullMets.Mets.AmdSec.Add(metadataManager.GetAmdSecType(premisFile, admId, techId));
         PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv);
+
+        fullMets.PhysicalDivsByPath[localPath] = childDirectoryDiv;
 
         SortChildDivs(parentDiv);
         return Result.Ok();
@@ -348,6 +354,7 @@ public class MetsManager(
         }
 
         parent!.Div.Remove(div);
+        fullMets.PhysicalDivsByPath.Remove(operationPath!);
 
         return Result.Ok();
     }
@@ -362,6 +369,9 @@ public class MetsManager(
 
     private static (DivType contextDiv, DivType? parent, int foundDepth, int totalDepth) LocateMetsDivByLocalPath(FullMets fullMets, string localPath)
     {
+        EnsureCache(fullMets);
+        AssertCacheConsistent(fullMets);
+
         var elements = localPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
         var div = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
@@ -376,10 +386,19 @@ public class MetsManager(
                 testPath += "/";
             }
             testPath += element;
-            // This is navigating using our ID convention for directories
-            // If we don't want to do this, we can use the premis:originalName for the directory
-            var childDiv = div.Div.SingleOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}");
-            if (childDiv is null)
+
+            // Navigate by path (premis:originalName / FLocat href, via the cache), not by
+            // reconstructing div IDs from the path - IDs are opaque (issue #188).
+            if (!fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var childDiv))
+            {
+                break;
+            }
+
+            // Guard against a malformed source in which two unrelated divs resolve to the same
+            // path: only accept the cached div if it really is a child of the current div. The
+            // walk then breaks with foundDepth < totalDepth, producing the same "not all parts
+            // of the path have been added" error as a plain miss.
+            if (!div.Div.Contains(childDiv))
             {
                 break;
             }
@@ -390,6 +409,43 @@ public class MetsManager(
         }
 
         return (div, parent, counter, elements.Length);
+    }
+
+    /// <summary>
+    /// The cache is populated when a METS file is loaded from storage, but a FullMets can also
+    /// be constructed directly around an in-memory Mets; a non-empty physical structMap with an
+    /// empty cache means that population hasn't happened yet. (An empty cache is never valid
+    /// for a managed METS - the metadata/objects template directories are always present.)
+    /// </summary>
+    private static void EnsureCache(FullMets fullMets)
+    {
+        if (fullMets.PhysicalDivsByPath.Count == 0)
+        {
+            MetsCache.Populate(fullMets);
+        }
+    }
+
+    /// <summary>
+    /// Debug-build check that the maintained cache matches a fresh rebuild - catches any
+    /// mutation path that forgets to keep <see cref="FullMets.PhysicalDivsByPath"/> up to date.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private static void AssertCacheConsistent(FullMets fullMets)
+    {
+        var rebuilt = new Dictionary<string, DivType>();
+        MetsCache.Build(fullMets.Mets, rebuilt);
+        var cache = fullMets.PhysicalDivsByPath;
+        var consistent = cache.Count == rebuilt.Count &&
+                         cache.All(kvp =>
+                             rebuilt.TryGetValue(kvp.Key, out var div) && ReferenceEquals(div, kvp.Value));
+        if (!consistent)
+        {
+            var maintained = string.Join(", ", cache.Keys.Order());
+            var expected = string.Join(", ", rebuilt.Keys.Order());
+            throw new InvalidOperationException(
+                $"PhysicalDivsByPath cache is stale. Maintained: [{maintained}]; rebuilt: [{expected}]. " +
+                "A mutation path is missing its cache update.");
+        }
     }
 
     private static DivType? LocateMetsDivByDivId(FullMets fullMets, string divId)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -157,7 +157,8 @@ public class MetsManager(
         if (MetsCache.NormalisePathKey(file.FLocat[0].Href) != localPath)
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
 
-        PopulateDmdFromResource(fullMets, workingFile, contextDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, contextDiv);
+        if (dmdResult.Failure) return dmdResult;
         return metadataManager.ProcessAllFileMetadata(fullMets, contextDiv, workingFile, localPath);
     }
 
@@ -169,8 +170,7 @@ public class MetsManager(
         if (workingDirectory.Name.HasText())
             contextDiv.Label = workingDirectory.Name;
 
-        PopulateDmdFromResource(fullMets, workingDirectory, contextDiv);
-        return Result.Ok();
+        return PopulateDmdFromResource(fullMets, workingDirectory, contextDiv);
     }
 
     private Result AddNewFile(DivType parentDiv, FullMets fullMets, WorkingFile workingFile, string localPath)
@@ -201,7 +201,9 @@ public class MetsManager(
         if (metadataResult.Failure)
             return metadataResult;
 
-        PopulateDmdFromResource(fullMets, workingFile, childItemDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, childItemDiv);
+        if (dmdResult.Failure) return dmdResult;
+
         parentDiv.Div.Add(childItemDiv);
         fullMets.PhysicalDivsByPath[localPath] = childItemDiv;
 
@@ -236,7 +238,8 @@ public class MetsManager(
             StorageLocation = null
         };
         var amdSec = metadataManager.GetAmdSecType(premisFile, admId, techId);
-        PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv);
+        if (dmdResult.Failure) return dmdResult;
 
         // Attach div, amdSec and cache entry together, after anything that could throw,
         // so a failure cannot leave the tree and the cache out of step (same principle
@@ -360,6 +363,8 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "Cannot delete a non-empty directory.");
         }
 
+        // Deletion is tolerant of dangling or absent references - a broken reference is
+        // exactly the kind of thing a delete may be cleaning up.
         string? admId;
         if (div is { Type: "Item" })
         {
@@ -370,50 +375,66 @@ public class MetsManager(
                 return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
             }
 
-            admId = file.Admid.Count > 1 ? string.Join(" ", file.Admid) : file.Admid[0];
-
+            admId = JoinedIdOrNull(file.Admid);
             fileGroup.File.Remove(file);
         }
         else
         {
-            admId = div.Admid.Count > 1 ? string.Join(" ", div.Admid) : div.Admid[0];
+            admId = JoinedIdOrNull(div.Admid);
         }
 
-        // for both Files and Directories
-        var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == admId);
-        fullMets.Mets.AmdSec.Remove(amdSec);
-
-        if (div.Dmdid.Count != 0)
-        {
-            var dmdId = div.Dmdid.Count > 1 ? string.Join(" ", div.Dmdid) : div.Dmdid[0];
-            var dmdSec = fullMets.Mets.DmdSec.Single(d => d.Id == dmdId);
-            fullMets.Mets.DmdSec.Remove(dmdSec);
-        }
+        RemoveById(fullMets.Mets.AmdSec, admId, a => a.Id);
+        RemoveById(fullMets.Mets.DmdSec, JoinedIdOrNull(div.Dmdid), d => d.Id);
 
         parent!.Div.Remove(div);
-        EvictFromPathCache(fullMets, div, operationPath!);
+        EvictFromPathCache(fullMets, div);
 
         return Result.Ok();
     }
 
     /// <summary>
-    /// Only evict the cache entry if it is actually the deleted div's - when the deleted div
-    /// was reached via a fallback tier (its own path metadata being broken), the key may map
-    /// to a different div that legitimately owns the path.
+    /// Legacy IDs containing spaces arrive from the XmlSerializer split into IDREFS tokens;
+    /// rejoining reconstructs the single intended ID. Null when there is no reference at all.
     /// </summary>
-    private static void EvictFromPathCache(FullMets fullMets, DivType div, string operationPath)
-    {
-        if (!fullMets.PhysicalDivsByPath.TryGetValue(operationPath, out var cachedDiv) ||
-            !ReferenceEquals(cachedDiv, div))
+    private static string? JoinedIdOrNull(IList<string> tokens) =>
+        tokens.Count switch
         {
-            return;
+            0 => null,
+            1 => tokens[0],
+            _ => string.Join(" ", tokens)
+        };
+
+    private static void RemoveById<T>(ICollection<T> sections, string? id, Func<T, string?> idOf)
+        where T : class
+    {
+        if (id is null) return;
+        var match = sections.FirstOrDefault(s => idOf(s) == id);
+        if (match != null)
+        {
+            sections.Remove(match);
+        }
+    }
+
+    /// <summary>
+    /// Evict every cache entry that points at the deleted div. A div reached via a fallback
+    /// tier may own an entry under a DIFFERENT key than the operation path (its own resolved
+    /// metadata path), so eviction goes by value, not by the operation path.
+    /// </summary>
+    private static void EvictFromPathCache(FullMets fullMets, DivType div)
+    {
+        var keys = fullMets.PhysicalDivsByPath
+            .Where(kvp => ReferenceEquals(kvp.Value, div))
+            .Select(kvp => kvp.Key)
+            .ToList();
+        foreach (var key in keys)
+        {
+            fullMets.PhysicalDivsByPath.Remove(key);
         }
 
-        fullMets.PhysicalDivsByPath.Remove(operationPath);
-        if (fullMets.PathDiagnostics.Count > 0)
+        if (keys.Count > 0 && fullMets.HasDuplicatePaths)
         {
-            // A malformed doc may contain another div that claimed the same path (see the
-            // duplicate-path diagnostics) - rebuild so the cache reflects post-delete reality.
+            // In a duplicate-path document another div may have been claiming one of the
+            // evicted paths - rebuild so the cache reflects post-delete reality.
             MetsCache.Populate(fullMets);
         }
     }
@@ -456,15 +477,19 @@ public class MetsManager(
             testPath += element;
 
             // Navigate by path (premis:originalName / FLocat href, via the cache), not by
-            // reconstructing div IDs from the path - IDs are opaque (issue #188). The cached
-            // div is only accepted if it really is a child of the current div; a malformed
-            // source can have two unrelated divs resolving to the same path, and the cache
-            // holds whichever was walked first.
-            if (!fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var childDiv) ||
-                !div.Div.Contains(childDiv))
+            // reconstructing div IDs from the path - IDs are opaque (issue #188). The cache
+            // fast path is only trusted for a fully clean document: whenever load-time
+            // diagnostics exist (duplicate paths, unresolvable divs) every step resolves
+            // strictly among the current div's children, so an ambiguous path can never be
+            // silently satisfied by whichever div the cache walked first.
+            DivType? childDiv = null;
+            if (fullMets.PathDiagnostics.Count == 0 &&
+                fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var cached) &&
+                div.Div.Contains(cached))
             {
-                childDiv = FindChildDivByPath(div, testPath, fullMets.Mets);
+                childDiv = cached;
             }
+            childDiv ??= FindChildDivByPath(div, testPath, fullMets.Mets);
 
             if (childDiv is null)
             {
@@ -491,9 +516,18 @@ public class MetsManager(
         // In each tier the match must be UNIQUE among the parent's children - if two children
         // claim the same path or the same conventional ID (corrupted METS), guessing one would
         // silently edit the wrong div; returning null instead surfaces the standard
-        // incomplete-path error with the load-time diagnostics attached.
-        var byMetadata = UniqueOrNull(parent.Div.Where(d => MetsCache.TryResolvePath(d, mets) == testPath));
-        return byMetadata ?? UniqueOrNull(parent.Div.Where(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}"));
+        // incomplete-path error with the load-time diagnostics attached. An AMBIGUOUS
+        // metadata tier is terminal: falling through to the legacy-ID tier would resolve by
+        // guesswork exactly the ambiguity this method exists to refuse.
+        var byMetadata = parent.Div
+            .Where(d => MetsCache.TryResolvePath(d, mets) == testPath)
+            .Take(2)
+            .ToList();
+        if (byMetadata.Count > 0)
+        {
+            return byMetadata.Count == 1 ? byMetadata[0] : null;
+        }
+        return UniqueOrNull(parent.Div.Where(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}"));
     }
 
     private static DivType? UniqueOrNull(IEnumerable<DivType> divs)
@@ -549,24 +583,20 @@ public class MetsManager(
 
     private static DivType? LocateMetsDivByDivId(FullMets fullMets, string divId)
     {
-        // Look in the physical structMap first (should be only one; tolerate zero or many
-        // in a malformed METS - same policy as LocateMetsDivByLocalPath and MetsCache)
-        var physDiv = fullMets.Mets.StructMap.FirstOrDefault(sm => sm.Type == Constants.Physical)?.Div;
-        if (physDiv != null)
+        // Search PHYSICAL structMaps first (there should be one, but a malformed METS may
+        // have zero or several - all are searched), then the rest. A structMap element with
+        // no root div is skipped rather than dereferenced.
+        foreach (var structMap in fullMets.Mets.StructMap
+                     .OrderByDescending(sm => sm.Type == Constants.Physical))
         {
-            var foundInPhysical = FindDiv(physDiv, divId);
-            if (foundInPhysical != null)
+            if (structMap.Div is null)
             {
-                return foundInPhysical;
+                continue;
             }
-        }
-
-        foreach (var smType in fullMets.Mets.StructMap.Where(sm => sm.Type != Constants.Physical))
-        {
-            var foundInOther = FindDiv(smType.Div, divId);
-            if (foundInOther != null)
+            var found = FindDiv(structMap.Div, divId);
+            if (found != null)
             {
-                return foundInOther;
+                return found;
             }
         }
 
@@ -602,35 +632,47 @@ public class MetsManager(
     /// <param name="mets"></param>
     /// <param name="resource"></param>
     /// <param name="div"></param>
-    private static void PopulateDmdFromResource(FullMets mets, ResourceBase resource, DivType div)
+    private static Result PopulateDmdFromResource(FullMets mets, ResourceBase resource, DivType div)
     {
         if (resource.AccessRestrictions != null)
         {
             // If it's an empty array rather than null, this will clear the access restrictions
-            SetAccessRestrictionsForDiv(mets, div, resource.AccessRestrictions);
+            var result = SetAccessRestrictionsForDiv(mets, div, resource.AccessRestrictions);
+            if (result.Failure) return result;
         }
 
         if (resource.RightsStatement != null)
         {
             // OK how to clear a Rights statement?
-            SetRightsStatementForDiv(mets, div, resource.RightsStatement);
+            var result = SetRightsStatementForDiv(mets, div, resource.RightsStatement);
+            if (result.Failure) return result;
         }
 
         if (resource.RecordInfo != null)
         {
             // Clear this by passing in a RecordInfo with empty RecordIdentifiers[]
-            SetRecordInfoForDiv(mets, div, resource.RecordInfo);
+            var result = SetRecordInfoForDiv(mets, div, resource.RecordInfo);
+            if (result.Failure) return result;
         }
+
+        return Result.Ok();
     }
+
+    // The failure a Set*ForDiv method returns when the div's descriptive metadata cannot be
+    // materialised as MODS (e.g. an existing dmdSec with a non-MODS wrapper or empty xmlData).
+    // Success may only be reported when the write actually happened.
+    private static Result ModsUnavailable(DivType div) =>
+        Result.Fail(ErrorCodes.BadRequest,
+            $"The descriptive metadata for div '{div.Id}' could not be read or created as MODS.");
 
     public Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
-        // A partial walk means div is an ANCESTOR of the requested path - never write to it
+        // A partial walk means div is an ANCESTOR of the requested path - never write to it.
+        // BadRequest for consistency with EditMets, which reports the same condition.
         if (foundDepth != totalDepth)
-            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
-        SetRecordInfoForDiv(mets, div, recordInfo);
-        return Result.Ok();
+            return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
+        return SetRecordInfoForDiv(mets, div, recordInfo);
     }
 
     public Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo)
@@ -638,26 +680,25 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        SetRecordInfoForDiv(mets, div, recordInfo);
-        return Result.Ok();
+        return SetRecordInfoForDiv(mets, div, recordInfo);
     }
 
-    private static void SetRecordInfoForDiv(FullMets mets, DivType div, RecordInfo recordInfo)
+    private static Result SetRecordInfoForDiv(FullMets mets, DivType div, RecordInfo recordInfo)
     {
         var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
-        if (mods is null) return;
+        if (mods is null) return ModsUnavailable(div);
 
         mods.SetRecordInfo(recordInfo);
         ModsManager.SetModsForDiv(mets.Mets, div, mods);
+        return Result.Ok();
     }
 
     public Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
-            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
-        SetRightsStatementForDiv(mets, div, rightsStatement);
-        return Result.Ok();
+            return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
+        return SetRightsStatementForDiv(mets, div, rightsStatement);
     }
 
     public Result SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement)
@@ -665,8 +706,7 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        SetRightsStatementForDiv(mets, div, rightsStatement);
-        return Result.Ok();
+        return SetRightsStatementForDiv(mets, div, rightsStatement);
     }
 
     // Writes a UseAndReproduction element with a non-URI sentinel value so that the
@@ -677,9 +717,8 @@ public class MetsManager(
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
-            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
-        SuppressRightsInheritanceForDiv(mets, div);
-        return Result.Ok();
+            return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
+        return SuppressRightsInheritanceForDiv(mets, div);
     }
 
     public Result SuppressRightsInheritanceByDivId(FullMets mets, string divId)
@@ -687,23 +726,23 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        SuppressRightsInheritanceForDiv(mets, div);
-        return Result.Ok();
+        return SuppressRightsInheritanceForDiv(mets, div);
     }
 
-    private static void SuppressRightsInheritanceForDiv(FullMets mets, DivType div)
+    private static Result SuppressRightsInheritanceForDiv(FullMets mets, DivType div)
     {
         var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd: true);
-        if (mods is null) return;
+        if (mods is null) return ModsUnavailable(div);
         mods.RemoveAccessConditions(Constants.UseAndReproduction);
         mods.AddAccessCondition(Constants.NullRightsStatement, Constants.UseAndReproduction);
         ModsManager.SetModsForDiv(mets.Mets, div, mods);
+        return Result.Ok();
     }
 
-    private static void SetRightsStatementForDiv(FullMets mets, DivType div, Uri? rightsStatement)
+    private static Result SetRightsStatementForDiv(FullMets mets, DivType div, Uri? rightsStatement)
     {
         var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
-        if (mods is null) return;
+        if (mods is null) return ModsUnavailable(div);
 
         mods.RemoveAccessConditions(Constants.UseAndReproduction);
         if (rightsStatement is not null)
@@ -711,6 +750,7 @@ public class MetsManager(
             mods.AddAccessCondition(rightsStatement.ToString(), Constants.UseAndReproduction);
         }
         ModsManager.SetModsForDiv(mets.Mets, div, mods);
+        return Result.Ok();
     }
 
 
@@ -718,9 +758,8 @@ public class MetsManager(
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
-            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
-        SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
-        return Result.Ok();
+            return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
+        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
     }
 
     public Result SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions)
@@ -728,14 +767,13 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
-        return Result.Ok();
+        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
     }
 
-    private static void SetAccessRestrictionsForDiv(FullMets mets, DivType div, List<string> accessRestrictions)
+    private static Result SetAccessRestrictionsForDiv(FullMets mets, DivType div, List<string> accessRestrictions)
     {
         var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
-        if (mods is null) return;
+        if (mods is null) return ModsUnavailable(div);
 
         mods.RemoveAccessConditions(Constants.RestrictionOnAccess);
         foreach (var accessRestriction in accessRestrictions)
@@ -743,6 +781,7 @@ public class MetsManager(
             mods.AddAccessCondition(accessRestriction, Constants.RestrictionOnAccess);
         }
         ModsManager.SetModsForDiv(mets.Mets, div, mods);
+        return Result.Ok();
     }
 
     public void SetStructMap(FullMets mets, LogicalRange logSm)
@@ -885,13 +924,16 @@ public class MetsManager(
         mets.Mets.StructMap.Remove(existing);
     }
 
+    // FILE_ ids are minted from paths; normalise incoming paths the same way navigation and
+    // ID minting do, so that a path variant the setters accept (./, BagIt data/ prefix)
+    // cannot produce smLinks referencing FILE ids that don't exist.
     public void LinkFile(FullMets mets, string from, string to, Uri role)
     {
         mets.Mets.StructLink ??= new MetsTypeStructLink();
         mets.Mets.StructLink.SmLink.Add(new StructLinkTypeSmLink
         {
-            From = Constants.FileIdPrefix + from,
-            To = Constants.FileIdPrefix + to,
+            From = Constants.FileIdPrefix + MetsCache.NormalisePathKey(from),
+            To = Constants.FileIdPrefix + MetsCache.NormalisePathKey(to),
             Arcrole = role.ToString()
         });
     }
@@ -900,8 +942,8 @@ public class MetsManager(
     {
         if (mets.Mets.StructLink == null) return;
 
-        var fromId = Constants.FileIdPrefix + from;
-        var toId = Constants.FileIdPrefix + to;
+        var fromId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(from);
+        var toId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(to);
         var arcrole = role.ToString();
 
         var link = mets.Mets.StructLink.SmLink
@@ -915,7 +957,7 @@ public class MetsManager(
         // Remove all existing outgoing smLinks from this file
         if (mets.Mets.StructLink != null)
         {
-            var fromId = Constants.FileIdPrefix + localPath;
+            var fromId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(localPath);
             var toRemove = mets.Mets.StructLink.SmLink.Where(sl => sl.From == fromId).ToList();
             foreach (var sl in toRemove)
                 mets.Mets.StructLink.SmLink.Remove(sl);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -541,12 +541,16 @@ public class MetsManager(
 
     private static DivType? LocateMetsDivByDivId(FullMets fullMets, string divId)
     {
-        // look in the physical structMap first, there should be only one
-        var physDiv = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
-        var foundInPhysical = FindDiv(physDiv, divId);
-        if (foundInPhysical != null)
+        // Look in the physical structMap first (should be only one; tolerate zero or many
+        // in a malformed METS - same policy as LocateMetsDivByLocalPath and MetsCache)
+        var physDiv = fullMets.Mets.StructMap.FirstOrDefault(sm => sm.Type == Constants.Physical)?.Div;
+        if (physDiv != null)
         {
-            return foundInPhysical;
+            var foundInPhysical = FindDiv(physDiv, divId);
+            if (foundInPhysical != null)
+            {
+                return foundInPhysical;
+            }
         }
 
         foreach (var smType in fullMets.Mets.StructMap.Where(sm => sm.Type != Constants.Physical))

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -105,6 +105,12 @@ public class MetsManager(
         var localPath = MetsCache.NormalisePathKey(workingBase?.LocalPath ?? deletePath) ?? string.Empty;
         var (contextDiv, parent, foundDepth, totalDepth) = LocateMetsDivByLocalPath(fullMets, localPath);
 
+        if (foundDepth < 0)
+        {
+            // No usable PHYSICAL structMap at all - nothing can be edited
+            return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(fullMets, localPath));
+        }
+
         if (foundDepth == totalDepth)
         {
             if (deletePath is not null)
@@ -129,12 +135,17 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "No working directory or working file supplied to add.");
         }
 
+        return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(fullMets, localPath));
+    }
+
+    private static string DescribePathFailure(FullMets fullMets, string localPath)
+    {
         var message = $"Could not edit METS because not all parts of the path '{localPath}' have been added to METS.";
         if (fullMets.PathDiagnostics.Count > 0)
         {
             message += " METS path diagnostics: " + string.Join("; ", fullMets.PathDiagnostics);
         }
-        return Result.Fail(ErrorCodes.BadRequest, message);
+        return message;
     }
 
     private Result UpdateExistingFile(DivType contextDiv, FullMets fullMets, WorkingFile workingFile, string localPath)
@@ -217,7 +228,6 @@ public class MetsManager(
             Id = physId,
             Admid = { admId }
         };
-        parentDiv.Div.Add(childDirectoryDiv);
 
         var premisFile = new FileFormatMetadata
         {
@@ -225,9 +235,14 @@ public class MetsManager(
             OriginalName = localPath,
             StorageLocation = null
         };
-        fullMets.Mets.AmdSec.Add(metadataManager.GetAmdSecType(premisFile, admId, techId));
+        var amdSec = metadataManager.GetAmdSecType(premisFile, admId, techId);
         PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv);
 
+        // Attach div, amdSec and cache entry together, after anything that could throw,
+        // so a failure cannot leave the tree and the cache out of step (same principle
+        // as AddNewFile).
+        parentDiv.Div.Add(childDirectoryDiv);
+        fullMets.Mets.AmdSec.Add(amdSec);
         fullMets.PhysicalDivsByPath[localPath] = childDirectoryDiv;
 
         SortChildDivs(parentDiv);
@@ -376,7 +391,21 @@ public class MetsManager(
         }
 
         parent!.Div.Remove(div);
-        fullMets.PhysicalDivsByPath.Remove(operationPath!);
+
+        // Only evict the cache entry if it is actually THIS div's - when the deleted div was
+        // reached via a fallback tier (its own path metadata being broken), the key may map to
+        // a different div that legitimately owns the path.
+        if (fullMets.PhysicalDivsByPath.TryGetValue(operationPath!, out var cachedDiv) &&
+            ReferenceEquals(cachedDiv, div))
+        {
+            fullMets.PhysicalDivsByPath.Remove(operationPath!);
+            if (fullMets.PathDiagnostics.Count > 0)
+            {
+                // A malformed doc may contain another div that claimed the same path (see the
+                // duplicate-path diagnostics) - rebuild so the cache reflects post-delete reality.
+                MetsCache.Populate(fullMets);
+            }
+        }
 
         return Result.Ok();
     }
@@ -397,7 +426,15 @@ public class MetsManager(
         localPath = MetsCache.NormalisePathKey(localPath) ?? string.Empty;
         var elements = localPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        var div = fullMets.Mets.StructMap.First(sm => sm.Type == Constants.Physical).Div!;
+        // A malformed METS may have no usable PHYSICAL structMap (MetsCache.Populate will have
+        // recorded a diagnostic); signal that with foundDepth -1 rather than throwing.
+        var physRoot = fullMets.Mets.StructMap.FirstOrDefault(sm => sm.Type == Constants.Physical)?.Div;
+        if (physRoot == null)
+        {
+            return (new DivType(), null, -1, elements.Length);
+        }
+
+        var div = physRoot;
         DivType? parent = null;
         var testPath = string.Empty;
         var counter = 0;
@@ -443,8 +480,26 @@ public class MetsManager(
     /// </summary>
     private static DivType? FindChildDivByPath(DivType parent, string testPath, DigitalPreservation.XmlGen.Mets.Mets mets)
     {
-        var byMetadata = parent.Div.FirstOrDefault(d => MetsCache.TryResolvePath(d, mets) == testPath);
-        return byMetadata ?? parent.Div.FirstOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}");
+        // In each tier the match must be UNIQUE among the parent's children - if two children
+        // claim the same path or the same conventional ID (corrupted METS), guessing one would
+        // silently edit the wrong div; returning null instead surfaces the standard
+        // incomplete-path error with the load-time diagnostics attached.
+        var byMetadata = UniqueOrNull(parent.Div.Where(d => MetsCache.TryResolvePath(d, mets) == testPath));
+        return byMetadata ?? UniqueOrNull(parent.Div.Where(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}"));
+    }
+
+    private static DivType? UniqueOrNull(IEnumerable<DivType> divs)
+    {
+        DivType? found = null;
+        foreach (var div in divs)
+        {
+            if (found != null)
+            {
+                return null;
+            }
+            found = div;
+        }
+        return found;
     }
 
     /// <summary>
@@ -556,18 +611,23 @@ public class MetsManager(
         }
     }
 
-    public void SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo)
+    public Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         // A partial walk means div is an ANCESTOR of the requested path - never write to it
-        if (foundDepth != totalDepth) return;
+        if (foundDepth != totalDepth)
+            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
         SetRecordInfoForDiv(mets, div, recordInfo);
+        return Result.Ok();
     }
 
-    public void SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo)
+    public Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo)
     {
-        var div = LocateMetsDivByDivId(mets, divId)!;
+        var div = LocateMetsDivByDivId(mets, divId);
+        if (div is null)
+            return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
         SetRecordInfoForDiv(mets, div, recordInfo);
+        return Result.Ok();
     }
 
     private static void SetRecordInfoForDiv(FullMets mets, DivType div, RecordInfo recordInfo)
@@ -579,34 +639,44 @@ public class MetsManager(
         ModsManager.SetModsForDiv(mets.Mets, div, mods);
     }
 
-    public void SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement)
+    public Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
-        if (foundDepth != totalDepth) return;
+        if (foundDepth != totalDepth)
+            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
         SetRightsStatementForDiv(mets, div, rightsStatement);
+        return Result.Ok();
     }
 
-    public void SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement)
+    public Result SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement)
     {
-        var div = LocateMetsDivByDivId(mets, divId)!;
+        var div = LocateMetsDivByDivId(mets, divId);
+        if (div is null)
+            return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
         SetRightsStatementForDiv(mets, div, rightsStatement);
+        return Result.Ok();
     }
 
     // Writes a UseAndReproduction element with a non-URI sentinel value so that the
     // parser sees an explicit rights decision and suppresses inheritance, without
     // asserting any particular rights URI. Distinct from SetRightsStatementByPath(null),
     // which removes the element and allows parent rights to flow through.
-    public void SuppressRightsInheritanceByPath(FullMets mets, string localPath)
+    public Result SuppressRightsInheritanceByPath(FullMets mets, string localPath)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
-        if (foundDepth != totalDepth) return;
+        if (foundDepth != totalDepth)
+            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
         SuppressRightsInheritanceForDiv(mets, div);
+        return Result.Ok();
     }
 
-    public void SuppressRightsInheritanceByDivId(FullMets mets, string divId)
+    public Result SuppressRightsInheritanceByDivId(FullMets mets, string divId)
     {
-        var div = LocateMetsDivByDivId(mets, divId)!;
+        var div = LocateMetsDivByDivId(mets, divId);
+        if (div is null)
+            return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
         SuppressRightsInheritanceForDiv(mets, div);
+        return Result.Ok();
     }
 
     private static void SuppressRightsInheritanceForDiv(FullMets mets, DivType div)
@@ -632,17 +702,22 @@ public class MetsManager(
     }
 
 
-    public void SetAccessRestrictionsByPath(FullMets mets, string localPath, List<string> accessRestrictions)
+    public Result SetAccessRestrictionsByPath(FullMets mets, string localPath, List<string> accessRestrictions)
     {
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
-        if (foundDepth != totalDepth) return;
+        if (foundDepth != totalDepth)
+            return Result.Fail(ErrorCodes.NotFound, DescribePathFailure(mets, localPath));
         SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
+        return Result.Ok();
     }
 
-    public void SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions)
+    public Result SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions)
     {
-        var div = LocateMetsDivByDivId(mets, divId)!;
+        var div = LocateMetsDivByDivId(mets, divId);
+        if (div is null)
+            return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
         SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
+        return Result.Ok();
     }
 
     private static void SetAccessRestrictionsForDiv(FullMets mets, DivType div, List<string> accessRestrictions)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -497,14 +497,16 @@ public class MetsParser(
                 }
 
                 // Use pre-built dictionary for O(1) lookup instead of LINQ query
-                // The digiprovMD ID contains a pattern like "digiprovmd_clamav_{admId}"
+                // The digiprovMD ID has the form "digiprovMD_ClamAV_{admId}"
                 var clamavKey = $"{Constants.VirusProvEventPrefix}{admId}";
                 if (!lookupMaps.DigiprovMdMap.TryGetValue(clamavKey, out var digiprovMd))
                 {
-                    var lowerKey = clamavKey.ToLowerInvariant();
-                    // Try case-insensitive search through the pre-built map
+                    // Fall back to a case-insensitive but EXACT match. A substring match here
+                    // cross-talks between files whose IDs are prefixes of each other
+                    // (e.g. "ADM_a" is contained in "ADM_a2"), returning one file's virus-scan
+                    // event for a different file.
                     var matchingKey = lookupMaps.DigiprovMdMap.Keys
-                        .FirstOrDefault(k => k.ToLower().Contains(lowerKey));
+                        .FirstOrDefault(k => string.Equals(k, clamavKey, StringComparison.OrdinalIgnoreCase));
                     if (matchingKey != null)
                     {
                         digiprovMd = lookupMaps.DigiprovMdMap[matchingKey];

--- a/src/DigitalPreservation/DigitalPreservation.Mets/StorageImpl/FileSystemMetsStorage.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/StorageImpl/FileSystemMetsStorage.cs
@@ -73,6 +73,7 @@ public class FileSystemMetsStorage(IMetsParser metsParser) : IMetsStorage
             Uri = file,
             ETag = returnedETag
         };
+        MetsCache.Populate(fullMetal);
         return Result.OkNotNull(fullMetal);
     }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/SetModsInformation.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/SetModsInformation.cs
@@ -42,12 +42,17 @@ public class SetModsInformationHandler(IMetsManager metsManager) : IRequestHandl
         if (metsResult is { Success: true, Value: not null })
         {
             var fullMets = metsResult.Value;
-            metsManager.SetAccessRestrictionsByPath(fullMets, request.LocalPath, request.AccessRestrictions);
-            if (request.SuppressRightsInheritance)
-                metsManager.SuppressRightsInheritanceByPath(fullMets, request.LocalPath);
-            else
-                metsManager.SetRightsStatementByPath(fullMets, request.LocalPath, request.RightsStatement);
-            metsManager.SetRecordInfoByPath(fullMets, request.LocalPath, request.RecordInfo);
+            var setResult = metsManager.SetAccessRestrictionsByPath(fullMets, request.LocalPath, request.AccessRestrictions);
+            if (setResult.Failure) return setResult;
+
+            setResult = request.SuppressRightsInheritance
+                ? metsManager.SuppressRightsInheritanceByPath(fullMets, request.LocalPath)
+                : metsManager.SetRightsStatementByPath(fullMets, request.LocalPath, request.RightsStatement);
+            if (setResult.Failure) return setResult;
+
+            setResult = metsManager.SetRecordInfoByPath(fullMets, request.LocalPath, request.RecordInfo);
+            if (setResult.Failure) return setResult;
+
             if (request.FileLinks != null)
                 metsManager.SetFileLinks(fullMets, request.LocalPath, request.FileLinks);
             var writeMetsResult = await metsManager.WriteMets(fullMets);

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -35,9 +35,7 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
         // navigability check as MetsManager mutations: a structMap this class builds that
         // cannot be resolved by path is a bug, caught in debug builds and tests.
         var pathDiagnostics = MetsCache.Populate(fullMets);
-        System.Diagnostics.Debug.Assert(pathDiagnostics.Count == 0,
-            "MetsFromArchivalGroup produced a structMap that is not fully navigable by path: "
-            + string.Join("; ", pathDiagnostics));
+        AssertNavigable(pathDiagnostics);
 
         var writeResult = await metsManager.WriteMets(fullMets);
         if (writeResult.Success)
@@ -47,6 +45,22 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
         return Result.FailNotNull<MetsFileWrapper>(writeResult.ErrorCode!, writeResult.ErrorMessage);
     }
     
+    /// <summary>
+    /// Debug-build check (explicit throw rather than Debug.Assert, which can take down the
+    /// whole test process in .NET test hosts) that the structMap this class built is fully
+    /// navigable by path.
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    private static void AssertNavigable(List<string> pathDiagnostics)
+    {
+        if (pathDiagnostics.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "MetsFromArchivalGroup produced a structMap that is not fully navigable by path: "
+                + string.Join("; ", pathDiagnostics));
+        }
+    }
+
     /// <summary>
     /// This builds up the METS file from repository resources, not working files
     /// </summary>

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -26,10 +26,20 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
     public async Task<Result<MetsFileWrapper>> CreateStandardMets(Uri metsLocation, ArchivalGroup archivalGroup, string? agNameFromDeposit)
     {
         var (file, mets) = await metsManager.GetStandardMets(metsLocation, agNameFromDeposit);
-        
+
         AddResourceToMets(mets, archivalGroup.Id!, mets.StructMap[0].Div, archivalGroup);
-        
-        var writeResult = await metsManager.WriteMets(new FullMets{ Mets = mets, Uri = file });
+
+        var fullMets = new FullMets { Mets = mets, Uri = file };
+        // This FullMets is write-only (navigation happens on a fresh load, which populates the
+        // cache), but building the cache here puts this construction path under the same
+        // navigability check as MetsManager mutations: a structMap this class builds that
+        // cannot be resolved by path is a bug, caught in debug builds and tests.
+        var pathDiagnostics = MetsCache.Populate(fullMets);
+        System.Diagnostics.Debug.Assert(pathDiagnostics.Count == 0,
+            "MetsFromArchivalGroup produced a structMap that is not fully navigable by path: "
+            + string.Join("; ", pathDiagnostics));
+
+        var writeResult = await metsManager.WriteMets(fullMets);
         if (writeResult.Success)
         {
             return await metsParser.GetMetsFileWrapper(file);

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -31,11 +31,11 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
 
         var fullMets = new FullMets { Mets = mets, Uri = file };
         // This FullMets is write-only (navigation happens on a fresh load, which populates the
-        // cache), but building the cache here puts this construction path under the same
-        // navigability check as MetsManager mutations: a structMap this class builds that
-        // cannot be resolved by path is a bug, caught in debug builds and tests.
-        var pathDiagnostics = MetsCache.Populate(fullMets);
-        AssertNavigable(pathDiagnostics);
+        // cache), so the cache build inside AssertNavigable is debug/test-only: it puts this
+        // construction path under the same navigability check as MetsManager mutations - a
+        // structMap this class builds that cannot be resolved by path is a bug. In Release the
+        // whole call compiles out and no cache walk happens.
+        AssertNavigable(fullMets);
 
         var writeResult = await metsManager.WriteMets(fullMets);
         if (writeResult.Success)
@@ -51,8 +51,9 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
     /// navigable by path.
     /// </summary>
     [System.Diagnostics.Conditional("DEBUG")]
-    private static void AssertNavigable(List<string> pathDiagnostics)
+    private static void AssertNavigable(FullMets fullMets)
     {
+        var pathDiagnostics = MetsCache.Populate(fullMets);
         if (pathDiagnostics.Count > 0)
         {
             throw new InvalidOperationException(
@@ -78,8 +79,11 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
             // The template already contains divs (and amdSecs) for objects/, metadata/ and
             // metadata/ad-hoc/ - reuse any div the parent already has for this path rather
             // than adding a duplicate div and duplicate-ID amdSec (which previously happened
-            // for any Archival Group with a preserved metadata/ folder).
-            var childDirectoryDiv = div.Div.FirstOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{localPath}");
+            // for any Archival Group with a preserved metadata/ folder). Matching is by the
+            // div's resolved path (premis:originalName), not by reconstructing its ID, so it
+            // stays correct when ID minting changes (issue #188 step 2).
+            var childDirectoryDiv = div.Div.FirstOrDefault(
+                d => MetsCache.TryResolvePath(d, mets) == localPath);
 
             if (childDirectoryDiv == null)
             {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -73,16 +73,16 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
         var agLocalPath = archivalGroupUri.LocalPath;
         foreach (var childContainer in container.Containers)
         {
-            DivType? childDirectoryDiv = null;
-            if (container is ArchivalGroup && childContainer.GetSlug() == FolderNames.Objects)
-            {
-                // The objects div should already exist from our template
-                childDirectoryDiv = mets.StructMap[0].Div.Div.Single(d => d.Id == Constants.ObjectsDivId);
-            }
+            var localPath = childContainer.Id!.LocalPath.RemoveStart(agLocalPath).RemoveStart("/");
+
+            // The template already contains divs (and amdSecs) for objects/, metadata/ and
+            // metadata/ad-hoc/ - reuse any div the parent already has for this path rather
+            // than adding a duplicate div and duplicate-ID amdSec (which previously happened
+            // for any Archival Group with a preserved metadata/ folder).
+            var childDirectoryDiv = div.Div.FirstOrDefault(d => d.Id == $"{Constants.PhysIdPrefix}{localPath}");
 
             if (childDirectoryDiv == null)
             {
-                var localPath = childContainer.Id!.LocalPath.RemoveStart(agLocalPath).RemoveStart("/");
                 var admId = Constants.AdmIdPrefix + localPath;
                 var techId = Constants.TechIdPrefix + localPath;
                 childDirectoryDiv = new DivType

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/StorageImpl/S3MetsStorage.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/StorageImpl/S3MetsStorage.cs
@@ -120,6 +120,7 @@ public class S3MetsStorage(
             Uri = file,
             ETag = returnedETag
         };
+        MetsCache.Populate(fullMetal);
         return Result.OkNotNull(fullMetal);
 
     }

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseGoobiRostock2026.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/ParseGoobiRostock2026.cs
@@ -1,0 +1,126 @@
+using System.Xml;
+using System.Xml.Serialization;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace XmlGen.Tests.Experimental.Parsing;
+
+/// <summary>
+/// Samples/goobi-2026.xml is a modern Goobi/MyCoRe METS from Rostock University Library
+/// (DFG-Viewer profile, "Goobi MyCoRe Importer 1.4.4", 2022) - a deliberately different
+/// flavour from the older Wellcome Goobi fixtures. Key differences:
+/// <list type="bullet">
+/// <item>FLocat hrefs are ABSOLUTE web URLs (IIIF Image API endpoints, ALTO download URLs),
+/// not deposit-relative paths - this is a presentation METS whose content lives behind web
+/// services, not a transfer METS travelling with its files;</item>
+/// <item>fileGrp USEs are DFG-Viewer vocabulary (DEFAULT/FULLTEXT/THUMBS/DOWNLOAD/TEASER),
+/// not the OBJECTS/ALTO the Wellcome fixtures use;</item>
+/// <item>no PREMIS anywhere: the single amdSec holds DFG-Viewer dv:rights/dv:links; no
+/// digests, sizes or formats exist for any file;</item>
+/// <item>the physSequence root div carries its own fptrs (DOWNLOAD/TEASER).</item>
+/// </list>
+/// These tests document what our code currently makes of it - including the current
+/// limitation that MetsParser cannot yet extract a physical structure from it.
+/// </summary>
+public class ParseGoobiRostock2026
+{
+    private readonly MetsParser parser;
+
+    public ParseGoobiRostock2026()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        parser = new MetsParser(metsLoader, parserLogger);
+    }
+
+    private static DigitalPreservation.XmlGen.Mets.Mets LoadTyped()
+    {
+        var serializer = new XmlSerializer(typeof(DigitalPreservation.XmlGen.Mets.Mets));
+        using var reader = XmlReader.Create("Samples/goobi-2026.xml");
+        return (DigitalPreservation.XmlGen.Mets.Mets)serializer.Deserialize(reader)!;
+    }
+
+    [Fact]
+    public void Typed_Model_Deserialises_The_Dfg_Viewer_Mets()
+    {
+        var mets = LoadTyped();
+
+        mets.MetsHdr.Agent[0].Name.Should().Be("Rostock University Library");
+        mets.StructMap.Select(sm => sm.Type).Should().BeEquivalentTo("PHYSICAL", "LOGICAL");
+
+        // DFG-Viewer fileGrp vocabulary, not the Wellcome OBJECTS/ALTO
+        mets.FileSec.FileGrp.Select(g => (g.Use, g.File.Count)).Should().BeEquivalentTo(
+        [
+            ("FULLTEXT", 29), ("DEFAULT", 29), ("THUMBS", 29), ("DOWNLOAD", 1), ("TEASER", 1)
+        ]);
+
+        // Every FLocat href is an absolute web URL - nothing is deposit-relative
+        mets.FileSec.FileGrp
+            .SelectMany(g => g.File)
+            .Select(f => f.FLocat[0].Href)
+            .Should().OnlyContain(href => href!.StartsWith("https://"));
+
+        // The physSequence root div carries its own fptrs (DOWNLOAD and TEASER)
+        var physRoot = mets.StructMap.Single(sm => sm.Type == "PHYSICAL").Div;
+        physRoot.Type.Should().Be("physSequence");
+        physRoot.Fptr.Should().HaveCount(2);
+        physRoot.Div.Should().HaveCount(29).And.OnlyContain(d => d.Type == "page");
+
+        // No PREMIS: one amdSec holding DFG-Viewer rights/links only
+        mets.AmdSec.Should().ContainSingle().Which.Id.Should().Be("AMD_DFGVIEWER");
+        mets.AmdSec[0].TechMd.Should().BeEmpty();
+
+        // Logical structure: monograph with GROUPID'd MODS dmdSec
+        var logRoot = mets.StructMap.Single(sm => sm.Type == "LOGICAL").Div;
+        logRoot.Type.Should().Be("monograph");
+        logRoot.Dmdid.Should().ContainSingle().Which.Should().Be("DMDLOG_0000");
+        logRoot.Div.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task MetsParser_Cannot_Yet_Extract_Physical_Structure_From_Absolute_Url_FLocats()
+    {
+        // CURRENT LIMITATION, documented deliberately: the parser derives the directory tree
+        // from FLocat hrefs as deposit-relative paths. This METS's hrefs are absolute IIIF /
+        // download URLs, so file-to-directory assignment fails and the parse returns a clean
+        // failure (not an unhandled exception). Supporting presentation-style METS like this
+        // would need a decision about what "physical structure" even means when the content
+        // is remote - tracked as future parser work, out of scope for issue #188.
+        var goobiMets = new FileInfo("Samples/goobi-2026.xml");
+
+        var result = await parser.GetMetsFileWrapper(new Uri(goobiMets.FullName));
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Path_Cache_Reports_The_Dfg_Viewer_Mets_As_Not_Navigable_By_Path()
+    {
+        // The issue #188 path cache is also the seed of an editability conformance check:
+        // a METS is editable-by-path only when every physical div resolves to a unique
+        // deposit-relative path. This METS is READABLE (typed model above) but none of its
+        // page divs resolve a path - each gets a diagnostic instead. (Third-party METS never
+        // reaches MetsManager anyway - the mets:agent gate - but these diagnostics are what
+        // a future conformance-based editability check would report.)
+        var fullMets = new FullMets
+        {
+            Mets = LoadTyped(),
+            Uri = new Uri("file:///test/goobi-2026.xml")
+        };
+
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        fullMets.PhysicalDivsByPath.Should().BeEmpty();
+        diagnostics.Should().HaveCount(29)
+            .And.OnlyContain(d => d.Contains("unrecognised TYPE 'page'"));
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/Parsing/FileMetadataTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Parsing/FileMetadataTests.cs
@@ -431,4 +431,70 @@ public class FileMetadataTests : MetsParserTestBase
 
         mets.Files[0].Metadata.OfType<ExtentMetadata>().Should().BeEmpty();
     }
+
+    private static string ClamAvDigiprov(string digiprovId) => $"""
+        <mets:amdSec ID="ADM_EXTRA">
+          <mets:digiprovMD ID="{digiprovId}">
+            <mets:mdWrap MDTYPE="PREMIS:EVENT">
+              <mets:xmlData>
+                <premis:event>
+                  <premis:eventDateTime>2026-03-18T12:00:00Z</premis:eventDateTime>
+                  <premis:eventDetailInformation>
+                    <premis:eventDetail>ClamAV 1.4.3/27944</premis:eventDetail>
+                  </premis:eventDetailInformation>
+                  <premis:eventOutcomeInformation>
+                    <premis:eventOutcome>pass</premis:eventOutcome>
+                    <premis:eventOutcomeDetail>
+                      <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>
+                    </premis:eventOutcomeDetail>
+                  </premis:eventOutcomeInformation>
+                </premis:event>
+              </mets:xmlData>
+            </mets:mdWrap>
+          </mets:digiprovMD>
+        </mets:amdSec>
+        """;
+
+    [Fact]
+    public void Virus_event_is_not_borrowed_from_a_file_whose_id_extends_this_files_id()
+    {
+        // Regression test for the digiprovMD lookup: it must be an exact match, not a
+        // substring match. Here the only digiprov entry belongs to a DIFFERENT file
+        // ("objects/a.txt.v2") whose expected key happens to CONTAIN this file's expected
+        // key ("...ADM_objects/a.txt"). A substring match would wrongly return that
+        // other file's virus-scan event for this file.
+        var extraAmdSecs = ClamAvDigiprov("digiprovMD_ClamAV_ADM_objects/a.txt.v2");
+
+        var xml = FullMets("ADM_objects/a.txt", "objects/a.txt", "text/plain", """
+            <premis:fixity>
+              <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+              <premis:messageDigest>plainFile</premis:messageDigest>
+            </premis:fixity>
+            """, extraAmdSecs);
+
+        var mets = Parse(xml);
+
+        mets.Files[0].Metadata.OfType<VirusScanMetadata>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Virus_event_with_case_variant_digiprov_id_is_still_matched()
+    {
+        // Case differences in the digiprovMD ID prefix must not lose the virus event -
+        // the fallback match is case-insensitive, but exact.
+        var extraAmdSecs = ClamAvDigiprov("digiprovmd_clamav_ADM_objects/safe.docx");
+
+        var xml = FullMets("ADM_objects/safe.docx", "objects/safe.docx", "application/msword", """
+            <premis:fixity>
+              <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+              <premis:messageDigest>safeFile</premis:messageDigest>
+            </premis:fixity>
+            """, extraAmdSecs);
+
+        var mets = Parse(xml);
+
+        var virus = mets.Files[0].Metadata.OfType<VirusScanMetadata>().Single();
+        virus.HasVirus.Should().BeFalse();
+        virus.VirusDefinition.Should().Be("ClamAV 1.4.3/27944");
+    }
 }

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -1,3 +1,4 @@
+using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Mets;
@@ -359,15 +360,52 @@ public class PhysicalDivsCacheTests
     }
 
     [Fact]
-    public async Task Setting_Metadata_By_An_Unresolvable_Path_Does_Not_Write_To_An_Ancestor()
+    public async Task Setting_Metadata_By_An_Unresolvable_Path_Fails_And_Does_Not_Write_To_An_Ancestor()
     {
         var fullMets = await CreateAndLoadStandardMets("cache-setbypath-miss.xml");
         var dmdSecCountBefore = fullMets.Mets.DmdSec.Count;
 
-        metsManager.SetAccessRestrictionsByPath(fullMets, "objects/missing/file.txt", ["Closed"]);
+        var result = metsManager.SetAccessRestrictionsByPath(fullMets, "objects/missing/file.txt", ["Closed"]);
 
-        // No dmdSec was created for (and no accessCondition written to) any ancestor div
+        // The caller is TOLD nothing was written (not a silent no-op reporting success)...
+        result.Failure.Should().BeTrue();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        // ...and no dmdSec was created for (and no accessCondition written to) any ancestor div
         fullMets.Mets.DmdSec.Count.Should().Be(dmdSecCountBefore);
+    }
+
+    [Fact]
+    public async Task Editing_A_Mets_With_No_Physical_StructMap_Fails_Cleanly()
+    {
+        var uri = OutputUri("cache-no-physical.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "No Physical METS");
+        mets.StructMap.Clear();
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/f.txt", "f.txt"));
+
+        addFile.Failure.Should().BeTrue();
+        addFile.ErrorMessage.Should().Contain("no PHYSICAL structMap");
+    }
+
+    [Fact]
+    public async Task Two_Children_Sharing_A_Conventional_Id_Fail_Cleanly_Instead_Of_Guessing()
+    {
+        var uri = OutputUri("cache-duplicate-legacy-id.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Duplicate Legacy Id METS");
+
+        // Two sibling divs, both with broken path metadata (no ADMID), sharing the same
+        // conventional PHYS_+path ID - corrupted METS. Guessing one would edit the wrong div.
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        objectsDiv.Div.Add(new DivType { Id = "PHYS_objects/twin", Type = Constants.DirectoryType, Label = "twin one" });
+        objectsDiv.Div.Add(new DivType { Id = "PHYS_objects/twin", Type = Constants.DirectoryType, Label = "twin two" });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/twin/f.txt", "f.txt"));
+
+        addFile.Failure.Should().BeTrue();
+        addFile.ErrorMessage.Should().Contain("not all parts of the path");
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -1,4 +1,5 @@
 using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Mets.StorageImpl;
 using DigitalPreservation.XmlGen.Mets;
@@ -257,9 +258,9 @@ public class PhysicalDivsCacheTests
         var uri = OutputUri("cache-normalisation.xml");
         var (_, mets) = await metsManager.GetStandardMets(uri, "Normalisation METS");
 
-        GetPremisOriginalNameElement(mets, FolderNames.Objects).InnerText = $"data/{FolderNames.Objects}";
+        GetPremisOriginalNameElement(mets, FolderNames.Objects).InnerText = $"./data/{FolderNames.Objects}";
         GetPremisOriginalNameElement(mets, FolderNames.Metadata).InnerText = $"./{FolderNames.Metadata}";
-        GetPremisOriginalNameElement(mets, FolderNames.MetadataAdHoc).InnerText = $"{FolderNames.MetadataAdHoc}/";
+        GetPremisOriginalNameElement(mets, FolderNames.MetadataAdHoc).InnerText = $"data/{FolderNames.MetadataAdHoc}/";
 
         var fullMets = new FullMets { Mets = mets, Uri = uri };
         var diagnostics = MetsCache.Populate(fullMets);
@@ -274,13 +275,14 @@ public class PhysicalDivsCacheTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public async Task Two_Divs_Resolving_To_The_Same_Path_Are_Reported_And_Navigation_Fails_Safely()
+    public async Task Two_Divs_Resolving_To_The_Same_Path_Are_Reported_And_The_Real_Div_Still_Wins()
     {
         var uri = OutputUri("cache-duplicate-path.xml");
         var (_, mets) = await metsManager.GetStandardMets(uri, "Duplicate Path METS");
 
         // An impostor div, nested under metadata/, whose ADMID points at the objects
-        // amdSec - so it resolves to the same path as the real objects div.
+        // amdSec - so it resolves to the same path as the real objects div (and, being
+        // walked first, wins the cache slot).
         var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
         var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
         metadataDiv.Div.Add(new DivType
@@ -296,11 +298,116 @@ public class PhysicalDivsCacheTests
 
         diagnostics.Should().ContainSingle(d => d.Contains($"both resolve to path '{FolderNames.Objects}'"));
 
-        // Navigation into objects/ hits the ambiguity and fails with the standard
-        // incomplete-path error rather than editing the wrong subtree.
+        // Navigation must not be captured by the impostor: the fallback resolves the REAL
+        // objects div (a direct child of the current div) and the edit lands there.
         var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/f.txt", "f.txt"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+
+        var realObjectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        realObjectsDiv.Div.Should().ContainSingle(d => d.Label == "f.txt");
+        metadataDiv.Div.Single(d => d.Label == "impostor").Div.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_Second_Physical_StructMap_Is_A_Diagnostic_Not_An_Exception()
+    {
+        var uri = OutputUri("cache-two-physical.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Two Physical METS");
+        mets.StructMap.Add(new StructMapType
+        {
+            Type = Constants.Physical,
+            Div = new DivType { Id = "PHYS_ROOT_2", Label = "second", Type = Constants.DirectoryType }
+        });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        diagnostics.Should().ContainSingle(d => d.Contains("2 PHYSICAL structMaps"));
+
+        // The first structMap is still fully navigable
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/first.pdf", "first.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+    }
+
+    [Fact]
+    public async Task Failed_File_Add_Leaves_Mets_And_Cache_Untouched_And_Retry_Succeeds()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-failed-add.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var dmdSecCountBefore = fullMets.Mets.DmdSec.Count;
+        var amdSecCountBefore = fullMets.Mets.AmdSec.Count;
+
+        // Conflicting digest metadata makes ProcessAllFileMetadata fail
+        var badFile = SimpleFile("objects/new.tif", "new.tif");
+        badFile.Metadata.Add(new DigestMetadata { Digest = "aaa", Source = "test-a" });
+        badFile.Metadata.Add(new DigestMetadata { Digest = "bbb", Source = "test-b" });
+
+        var failedAdd = metsManager.AddToMets(fullMets, badFile);
+
+        failedAdd.Failure.Should().BeTrue();
+        objectsDiv.Div.Should().BeEmpty("a failed add must not leave a half-added div behind");
+        fullMets.Mets.DmdSec.Count.Should().Be(dmdSecCountBefore);
+        fullMets.Mets.AmdSec.Count.Should().Be(amdSecCountBefore);
+        AssertCacheMatchesRebuild(fullMets);
+
+        // The retry with clean metadata succeeds and produces exactly one div
+        var retry = metsManager.AddToMets(fullMets, SimpleFile("objects/new.tif", "new.tif"));
+        retry.Success.Should().BeTrue(retry.ErrorMessage ?? "");
+        objectsDiv.Div.Should().ContainSingle(d => d.Label == "new.tif");
+        AssertCacheMatchesRebuild(fullMets);
+    }
+
+    [Fact]
+    public async Task Setting_Metadata_By_An_Unresolvable_Path_Does_Not_Write_To_An_Ancestor()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-setbypath-miss.xml");
+        var dmdSecCountBefore = fullMets.Mets.DmdSec.Count;
+
+        metsManager.SetAccessRestrictionsByPath(fullMets, "objects/missing/file.txt", ["Closed"]);
+
+        // No dmdSec was created for (and no accessCondition written to) any ancestor div
+        fullMets.Mets.DmdSec.Count.Should().Be(dmdSecCountBefore);
+    }
+
+    [Fact]
+    public async Task File_With_Data_Prefixed_FLocat_Href_Is_Navigable_And_Deletable()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-data-href.xml");
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/x.pdf", "x.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+
+        // Simulate a legacy variant: the FLocat href carries the BagIt data/ prefix
+        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        fileGroup.File.Single().FLocat[0].Href = "data/objects/x.pdf";
+        MetsCache.Populate(fullMets);
+        fullMets.PhysicalDivsByPath.Should().ContainKey("objects/x.pdf");
+
+        var deleteFile = metsManager.DeleteFromMets(fullMets, "objects/x.pdf");
+
+        deleteFile.Success.Should().BeTrue(deleteFile.ErrorMessage ?? "");
+        AssertCacheMatchesRebuild(fullMets);
+    }
+
+    [Fact]
+    public async Task Navigation_Failure_Reports_Path_Diagnostics_In_The_Error()
+    {
+        var uri = OutputUri("cache-error-diagnostics.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Error Diagnostics METS");
+
+        // Break the objects div beyond all fallbacks: no resolvable path metadata AND a
+        // non-convention ID, so navigation below it cannot succeed.
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        objectsDiv.Id = "PHYS_broken";
+        objectsDiv.Admid.Clear();
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/f.txt", "f.txt"));
+
         addFile.Failure.Should().BeTrue();
-        addFile.ErrorMessage.Should().Contain("not all parts of the path");
+        addFile.ErrorMessage.Should().Contain("METS path diagnostics")
+            .And.Contain("PHYS_broken");
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -1,0 +1,370 @@
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using DigitalPreservation.XmlGen.Mets;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// Tests for FullMets.PhysicalDivsByPath - the path→div cache that decouples MetsManager
+/// navigation from the format of METS ID attributes (issue #188). The cache is populated from
+/// premis:originalName (directories) and FLocat href (files), so these tests deliberately make
+/// no assertions on ID attribute values: they must keep passing unchanged when the ID minting
+/// scheme changes.
+/// </summary>
+public class PhysicalDivsCacheTests
+{
+    private readonly MetsManager metsManager;
+    private readonly FileSystemMetsStorage metsStorage;
+
+    private const string TestDigest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f";
+
+    public PhysicalDivsCacheTests()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        var parser = new MetsParser(metsLoader, parserLogger);
+        metsStorage = new FileSystemMetsStorage(parser);
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManager = new PremisEventManagerVirus();
+        var metadataManager = new MetadataManager(premisManager, premisManagerExif, premisEventManager);
+        metsManager = new MetsManager(parser, metsStorage, metadataManager);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private async Task<FullMets> CreateAndLoadStandardMets(string outputFileName)
+    {
+        var uri = OutputUri(outputFileName);
+        var createResult = await metsManager.CreateStandardMets(uri, "Cache Test METS");
+        createResult.Success.Should().BeTrue(createResult.ErrorMessage ?? "");
+        var loadResult = await metsManager.GetFullMets(uri, createResult.Value!.ETag);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        return loadResult.Value!;
+    }
+
+    private static Uri OutputUri(string outputFileName)
+    {
+        var fi = new FileInfo($"Outputs/{outputFileName}");
+        return new Uri(fi.FullName);
+    }
+
+    private static Uri CopyFixture(string fixtureName, string outputName)
+    {
+        var source = new FileInfo($"Samples/{fixtureName}");
+        var dest = new FileInfo($"Outputs/{outputName}");
+        File.Copy(source.FullName, dest.FullName, overwrite: true);
+        return new Uri(dest.FullName);
+    }
+
+    private static WorkingFile SimpleFile(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            ContentType = "application/pdf",
+            Digest = TestDigest,
+            Size = 54321,
+            Modified = DateTime.UtcNow
+        };
+
+    private static WorkingDirectory SimpleDirectory(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            Modified = DateTime.UtcNow
+        };
+
+    /// <summary>
+    /// The maintained cache must always equal a fresh rebuild from the same Mets object -
+    /// same keys, same div instances, no diagnostics.
+    /// </summary>
+    private static void AssertCacheMatchesRebuild(FullMets fullMets)
+    {
+        var rebuilt = new FullMets { Mets = fullMets.Mets, Uri = fullMets.Uri };
+        var diagnostics = MetsCache.Populate(rebuilt);
+        diagnostics.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath.Keys.Should().BeEquivalentTo(rebuilt.PhysicalDivsByPath.Keys);
+        foreach (var (key, div) in fullMets.PhysicalDivsByPath)
+        {
+            rebuilt.PhysicalDivsByPath[key].Should().BeSameAs(div, $"cache entry '{key}' should be the same div instance a rebuild finds");
+        }
+    }
+
+    private static System.Xml.XmlElement GetPremisOriginalNameElement(
+        DigitalPreservation.XmlGen.Mets.Mets mets, string directoryPath)
+    {
+        var amdSec = mets.AmdSec.Single(a => a.Id == $"{Constants.AdmIdPrefix}{directoryPath}");
+        var premisXml = amdSec.TechMd[0].MdWrap.XmlData.Any[0];
+        var elements = premisXml.GetElementsByTagName("originalName", "http://www.loc.gov/premis/v3");
+        return (System.Xml.XmlElement)elements[0]!;
+    }
+
+    // -----------------------------------------------------------------------
+    // Population on load
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Cache_Is_Populated_When_Mets_Is_Loaded_From_Storage()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-populate-on-load.xml");
+
+        fullMets.PhysicalDivsByPath.Keys.Should().BeEquivalentTo(
+            FolderNames.Objects, FolderNames.Metadata, FolderNames.MetadataAdHoc);
+
+        // Cached divs are the actual structMap div instances, matched by label
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
+        var adHocDiv = metadataDiv.Div.Single();
+
+        fullMets.PhysicalDivsByPath[FolderNames.Objects].Should().BeSameAs(objectsDiv);
+        fullMets.PhysicalDivsByPath[FolderNames.Metadata].Should().BeSameAs(metadataDiv);
+        fullMets.PhysicalDivsByPath[FolderNames.MetadataAdHoc].Should().BeSameAs(adHocDiv);
+    }
+
+    [Fact]
+    public async Task Cache_Contains_Files_And_Nested_Directories_After_Reload()
+    {
+        var uri = OutputUri("cache-full-structure.xml");
+        var createResult = await metsManager.CreateStandardMets(uri, "Cache Structure METS");
+        createResult.Success.Should().BeTrue();
+        var eTag = createResult.Value!.ETag;
+
+        // Build: objects/root file.pdf, objects/sub/, objects/sub/nested.pdf
+        var addFileResult = await metsManager.HandleSingleFileUpload(
+            uri, SimpleFile("objects/root file.pdf", "root file.pdf"), eTag!);
+        addFileResult.Success.Should().BeTrue(addFileResult.ErrorMessage ?? "");
+
+        var loadForETag1 = await metsManager.GetFullMets(uri, null);
+        var addDirResult = await metsManager.HandleCreateFolder(
+            uri, SimpleDirectory("objects/sub", "sub"), loadForETag1.Value!.ETag!);
+        addDirResult.Success.Should().BeTrue(addDirResult.ErrorMessage ?? "");
+
+        var loadForETag2 = await metsManager.GetFullMets(uri, null);
+        var addNestedResult = await metsManager.HandleSingleFileUpload(
+            uri, SimpleFile("objects/sub/nested.pdf", "nested.pdf"), loadForETag2.Value!.ETag!);
+        addNestedResult.Success.Should().BeTrue(addNestedResult.ErrorMessage ?? "");
+
+        var fullMets = (await metsManager.GetFullMets(uri, null)).Value!;
+
+        fullMets.PhysicalDivsByPath.Keys.Should().BeEquivalentTo(
+            FolderNames.Objects, FolderNames.Metadata, FolderNames.MetadataAdHoc,
+            "objects/root file.pdf", "objects/sub", "objects/sub/nested.pdf");
+
+        // A cached file entry points at the div whose fptr resolves, through the fileSec,
+        // to a FLocat href equal to the cache key
+        var nestedDiv = fullMets.PhysicalDivsByPath["objects/sub/nested.pdf"];
+        nestedDiv.Type.Should().Be(Constants.ItemType);
+        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        var nestedFile = fileGroup.File.Single(f => f.Id == nestedDiv.Fptr[0].Fileid);
+        nestedFile.FLocat[0].Href.Should().Be("objects/sub/nested.pdf");
+
+        // And the cached directory div is the parent of the nested file's div
+        fullMets.PhysicalDivsByPath["objects/sub"].Div.Should().Contain(nestedDiv);
+    }
+
+    // -----------------------------------------------------------------------
+    // Maintenance through mutations
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Cache_Is_Maintained_Through_Add_And_Delete_Mutations()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-mutations.xml");
+
+        var addDir = metsManager.AddToMets(fullMets, SimpleDirectory("objects/sub", "sub"));
+        addDir.Success.Should().BeTrue(addDir.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().ContainKey("objects/sub");
+        AssertCacheMatchesRebuild(fullMets);
+
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/sub/file one.pdf", "file one.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().ContainKey("objects/sub/file one.pdf");
+        AssertCacheMatchesRebuild(fullMets);
+
+        var deleteFile = metsManager.DeleteFromMets(fullMets, "objects/sub/file one.pdf");
+        deleteFile.Success.Should().BeTrue(deleteFile.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/sub/file one.pdf");
+        AssertCacheMatchesRebuild(fullMets);
+
+        var deleteDir = metsManager.DeleteFromMets(fullMets, "objects/sub");
+        deleteDir.Success.Should().BeTrue(deleteDir.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/sub");
+        AssertCacheMatchesRebuild(fullMets);
+    }
+
+    [Fact]
+    public async Task Updating_An_Existing_File_Leaves_The_Cache_Consistent()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-update-existing.xml");
+
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/doc.pdf", "doc.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+        var divBeforeUpdate = fullMets.PhysicalDivsByPath["objects/doc.pdf"];
+
+        // Same path again = update, not add; div identity must not change
+        var updateFile = metsManager.AddToMets(fullMets, SimpleFile("objects/doc.pdf", "doc renamed.pdf"));
+        updateFile.Success.Should().BeTrue(updateFile.ErrorMessage ?? "");
+
+        fullMets.PhysicalDivsByPath["objects/doc.pdf"].Should().BeSameAs(divBeforeUpdate);
+        AssertCacheMatchesRebuild(fullMets);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lazy population for directly constructed FullMets
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Navigation_Works_On_A_Directly_Constructed_FullMets()
+    {
+        // A FullMets built around an in-memory Mets (not loaded through IMetsStorage) starts
+        // with an empty cache; the first navigation populates it.
+        var uri = OutputUri("cache-lazy-populate.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Lazy Cache METS");
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        fullMets.PhysicalDivsByPath.Should().BeEmpty();
+
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/lazy.pdf", "lazy.pdf"));
+
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().ContainKey("objects/lazy.pdf");
+        AssertCacheMatchesRebuild(fullMets);
+    }
+
+    // -----------------------------------------------------------------------
+    // Path normalisation
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task OriginalName_Variants_Are_Normalised_To_Deposit_Relative_Paths()
+    {
+        // premis:originalName values from legacy or BagIt sources may carry a data/ prefix,
+        // a leading ./ or a trailing slash; the cache keys are always the plain
+        // deposit-relative path.
+        var uri = OutputUri("cache-normalisation.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Normalisation METS");
+
+        GetPremisOriginalNameElement(mets, FolderNames.Objects).InnerText = $"data/{FolderNames.Objects}";
+        GetPremisOriginalNameElement(mets, FolderNames.Metadata).InnerText = $"./{FolderNames.Metadata}";
+        GetPremisOriginalNameElement(mets, FolderNames.MetadataAdHoc).InnerText = $"{FolderNames.MetadataAdHoc}/";
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        diagnostics.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath.Keys.Should().BeEquivalentTo(
+            FolderNames.Objects, FolderNames.Metadata, FolderNames.MetadataAdHoc);
+    }
+
+    // -----------------------------------------------------------------------
+    // Malformed METS: diagnostics and defensive navigation
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Two_Divs_Resolving_To_The_Same_Path_Are_Reported_And_Navigation_Fails_Safely()
+    {
+        var uri = OutputUri("cache-duplicate-path.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Duplicate Path METS");
+
+        // An impostor div, nested under metadata/, whose ADMID points at the objects
+        // amdSec - so it resolves to the same path as the real objects div.
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
+        metadataDiv.Div.Add(new DivType
+        {
+            Id = "PHYS_impostor",
+            Type = Constants.DirectoryType,
+            Label = "impostor",
+            Admid = { $"{Constants.AdmIdPrefix}{FolderNames.Objects}" }
+        });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        diagnostics.Should().ContainSingle(d => d.Contains($"both resolve to path '{FolderNames.Objects}'"));
+
+        // Navigation into objects/ hits the ambiguity and fails with the standard
+        // incomplete-path error rather than editing the wrong subtree.
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/f.txt", "f.txt"));
+        addFile.Failure.Should().BeTrue();
+        addFile.ErrorMessage.Should().Contain("not all parts of the path");
+    }
+
+    [Fact]
+    public async Task Unresolvable_Divs_Are_Reported_As_Diagnostics_And_Left_Out_Of_The_Cache()
+    {
+        var uri = OutputUri("cache-diagnostics.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Diagnostics METS");
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+
+        physRoot.Div.Add(new DivType { Id = "PHYS_noadm", Type = Constants.DirectoryType, Label = "noadm" });
+        physRoot.Div.Add(new DivType { Id = "PHYS_nofptr", Type = Constants.ItemType, Label = "nofptr" });
+        physRoot.Div.Add(new DivType
+        {
+            Id = "PHYS_dangling",
+            Type = Constants.ItemType,
+            Label = "dangling",
+            Fptr = { new DivTypeFptr { Fileid = "FILE_missing" } }
+        });
+        physRoot.Div.Add(new DivType { Id = "PHYS_odd", Type = "banana", Label = "odd" });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        diagnostics.Should().HaveCount(4);
+        diagnostics.Should().ContainSingle(d => d.Contains("PHYS_noadm") && d.Contains("no ADMID"));
+        diagnostics.Should().ContainSingle(d => d.Contains("PHYS_nofptr") && d.Contains("no fptr"));
+        diagnostics.Should().ContainSingle(d => d.Contains("PHYS_dangling") && d.Contains("FILE_missing"));
+        diagnostics.Should().ContainSingle(d => d.Contains("PHYS_odd") && d.Contains("banana"));
+
+        fullMets.PhysicalDivsByPath.Keys.Should().BeEquivalentTo(
+            FolderNames.Objects, FolderNames.Metadata, FolderNames.MetadataAdHoc);
+    }
+
+    // -----------------------------------------------------------------------
+    // Legacy METS: IDs with spaces (frozen fixture)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Legacy_Mets_With_Spaces_In_Ids_Is_Cached_And_Editable_By_Path()
+    {
+        // The frozen fixture's ID attributes contain spaces, so its ADMID values were split
+        // into multiple IDREFS tokens on deserialization; the cache builder must rejoin them
+        // to find each directory's premis:originalName.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "cache-legacy-spaces.xml");
+        var loadResult = await metsStorage.GetFullMets(metsUri, null);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        var fullMets = loadResult.Value!;
+
+        fullMets.PhysicalDivsByPath.Keys.Should().Contain(
+        [
+            "objects/my file.pdf",
+            "objects/my great file.pdf",
+            "objects/my folder",
+            "objects/my folder/my document.pdf"
+        ]);
+
+        var deleteFile = metsManager.DeleteFromMets(fullMets, "objects/my folder/my document.pdf");
+        deleteFile.Success.Should().BeTrue(deleteFile.ErrorMessage ?? "");
+
+        var deleteDir = metsManager.DeleteFromMets(fullMets, "objects/my folder");
+        deleteDir.Success.Should().BeTrue(deleteDir.ErrorMessage ?? "");
+
+        fullMets.PhysicalDivsByPath.Keys.Should().NotContain(
+            ["objects/my folder", "objects/my folder/my document.pdf"]);
+        AssertCacheMatchesRebuild(fullMets);
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -367,9 +367,10 @@ public class PhysicalDivsCacheTests
 
         var result = metsManager.SetAccessRestrictionsByPath(fullMets, "objects/missing/file.txt", ["Closed"]);
 
-        // The caller is TOLD nothing was written (not a silent no-op reporting success)...
+        // The caller is TOLD nothing was written (not a silent no-op reporting success),
+        // with the same error code EditMets uses for the same condition...
         result.Failure.Should().BeTrue();
-        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        result.ErrorCode.Should().Be(ErrorCodes.BadRequest);
         // ...and no dmdSec was created for (and no accessCondition written to) any ancestor div
         fullMets.Mets.DmdSec.Count.Should().Be(dmdSecCountBefore);
     }
@@ -386,6 +387,137 @@ public class PhysicalDivsCacheTests
 
         addFile.Failure.Should().BeTrue();
         addFile.ErrorMessage.Should().Contain("no PHYSICAL structMap");
+    }
+
+    [Fact]
+    public async Task Two_Siblings_Resolving_The_Same_Path_Make_Edits_Of_That_Path_Fail()
+    {
+        var uri = OutputUri("cache-sibling-duplicate-path.xml");
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Sibling Duplicate METS");
+
+        // Two SIBLING divs under objects/, both resolving the SAME path objects/twin (their
+        // ADMIDs point at one amdSec) - editing that path is ambiguous and must fail rather
+        // than guess either div (even though one of them carries the conventional ID).
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var admId = $"{Constants.AdmIdPrefix}objects/twin";
+        mets.AmdSec.Add(new AmdSecType
+        {
+            Id = admId,
+            TechMd =
+            {
+                mets.AmdSec.Single(a => a.Id == $"{Constants.AdmIdPrefix}{FolderNames.Objects}").TechMd[0]
+            }
+        });
+        GetPremisOriginalNameElement(mets, FolderNames.Objects).InnerText = "objects/twin";
+        objectsDiv.Admid.Clear(); // objects div loses its (now-repointed) metadata; it keeps its conventional ID
+        objectsDiv.Div.Add(new DivType { Id = "PHYS_objects/twin", Type = Constants.DirectoryType, Label = "twin a", Admid = { admId } });
+        objectsDiv.Div.Add(new DivType { Id = "PHYS_twin_b", Type = Constants.DirectoryType, Label = "twin b", Admid = { admId } });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        MetsCache.Populate(fullMets).Should().Contain(d => d.Contains("both resolve to path"));
+
+        var setResult = metsManager.SetAccessRestrictionsByPath(fullMets, "objects/twin", ["Closed"]);
+
+        setResult.Failure.Should().BeTrue();
+        setResult.ErrorMessage.Should().Contain("not all parts of the path");
+    }
+
+    [Fact]
+    public async Task Setting_Metadata_On_A_Div_Whose_DmdSec_Is_Not_Mods_Fails()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-non-mods-dmd.xml");
+
+        // Give the objects div a dmdSec that cannot be materialised as MODS
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        fullMets.Mets.DmdSec.Add(new MdSecType
+        {
+            Id = objectsDiv.Dmdid[0],
+            MdWrap = new MdSecTypeMdWrap
+            {
+                Mdtype = MdSecTypeMdWrapMdtype.Other,
+                XmlData = new MdSecTypeMdWrapXmlData()
+            }
+        });
+
+        var setResult = metsManager.SetAccessRestrictionsByPath(fullMets, FolderNames.Objects, ["Closed"]);
+
+        // The write did not happen and the caller is told so
+        setResult.Failure.Should().BeTrue();
+        setResult.ErrorMessage.Should().Contain("could not be read or created as MODS");
+    }
+
+    [Fact]
+    public async Task Deleting_A_Directory_With_No_Admid_Fails_Cleanly_Or_Succeeds_But_Never_Throws()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-delete-no-admid.xml");
+
+        // A directory div with NO ADMID at all (broken path metadata) - reachable only via
+        // the legacy-ID fallback tier; deletion must not throw on the empty Admid collection
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        objectsDiv.Div.Add(new DivType { Id = "PHYS_objects/ghost", Type = Constants.DirectoryType, Label = "ghost" });
+        MetsCache.Populate(fullMets);
+
+        var deleteResult = metsManager.DeleteFromMets(fullMets, "objects/ghost");
+
+        deleteResult.Success.Should().BeTrue(deleteResult.ErrorMessage ?? "");
+        objectsDiv.Div.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Deleting_A_Div_Cached_Under_A_Different_Path_Leaves_No_Dangling_Entry()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-delete-mismatched-key.xml");
+
+        // A div whose conventional ID says objects/dir but whose metadata resolves a
+        // DIFFERENT path - the cache holds it under the metadata-resolved key
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var addDir = metsManager.AddToMets(fullMets, SimpleDirectory("objects/other", "other"));
+        addDir.Success.Should().BeTrue();
+        var mismatched = fullMets.PhysicalDivsByPath["objects/other"];
+        mismatched.Id = "PHYS_objects/dir";
+        MetsCache.Populate(fullMets);
+
+        // Deleted via the legacy-ID tier under objects/dir; its cache entry lives at objects/other
+        var deleteResult = metsManager.DeleteFromMets(fullMets, "objects/dir");
+
+        deleteResult.Success.Should().BeTrue(deleteResult.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/other");
+        objectsDiv.Div.Should().BeEmpty();
+
+        // And the next mutation on the same FullMets must not trip the consistency assertion
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/after.pdf", "after.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+    }
+
+    [Fact]
+    public async Task Setting_Metadata_By_DivId_Tolerates_An_Empty_Logical_StructMap()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-empty-logical-sm.xml");
+        fullMets.Mets.StructMap.Add(new StructMapType { Type = Constants.Logical });
+
+        var setResult = metsManager.SetAccessRestrictionsByDivId(fullMets, "LOG_does_not_exist", ["Closed"]);
+
+        setResult.Failure.Should().BeTrue();
+        setResult.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task Divs_In_A_Second_Physical_StructMap_Are_Reachable_By_DivId()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-second-physical-byid.xml");
+        fullMets.Mets.StructMap.Add(new StructMapType
+        {
+            Type = Constants.Physical,
+            Div = new DivType { Id = "PHYS_SECOND_ROOT", Label = "second", Type = Constants.DirectoryType }
+        });
+
+        var setResult = metsManager.SetAccessRestrictionsByDivId(fullMets, "PHYS_SECOND_ROOT", ["Closed"]);
+
+        setResult.Success.Should().BeTrue(setResult.ErrorMessage ?? "");
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/Samples/goobi-2026.xml
+++ b/src/DigitalPreservation/XmlGen.Tests/Samples/goobi-2026.xml
@@ -1,0 +1,634 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--XSLT was applied...-->
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:dv="http://dfg-viewer.de/" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="rosdok/ppn100673385X" TYPE="histbest.print.monograph" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/xlink/xlink.xsd http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods.xsd http://www.loc.gov/mix/v20 http://www.loc.gov/standards/mix/mix20/mix20.xsd http://dfg-viewer.de/ http://purl.uni-rostock.de/ub/standards/dfg-viewer.xsd">
+  <mets:metsHdr CREATEDATE="2020-06-12T17:15:57Z" LASTMODDATE="2022-03-06T22:29:14Z" RECORDSTATUS="PRESENTATION_DV">
+    <mets:agent ROLE="CREATOR" TYPE="ORGANIZATION">
+      <mets:name>Rostock University Library</mets:name>
+    </mets:agent>
+    <mets:agent OTHERTYPE="SOFTWARE" ROLE="EDITOR" TYPE="OTHER">
+      <mets:name>UB Rostock: Goobi MyCoRe Importer 1.4.4</mets:name>
+      <mets:note xmlns:ubr="http://ub.uni-rostock.de" ubr:date="2022-03-06T22:29:14.506Z" ubr:type="execution" />
+    </mets:agent>
+  </mets:metsHdr>
+  <mets:dmdSec GROUPID="DMDLOG_0000" ID="DMDLOG_0000">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods>
+          <mods:recordInfo>
+            <mods:recordIdentifier source="DE-28">rosdok/ppn100673385X</mods:recordIdentifier>
+            <mods:recordInfoNote type="k10plus_ppn">100673385X</mods:recordInfoNote>
+            <mods:recordInfoNote type="k10plus_bbg">Oau</mods:recordInfoNote>
+            <mods:descriptionStandard>rda</mods:descriptionStandard>
+            <mods:recordOrigin>Converted from PICA to MODS using Pica2Mods XSLT Transformator 2.2 [SCM: "6f55f39418ac01aa24b956f3d89dc79f69ad6cf8" "v2.2" "2022-02-28T18:58:10+0100"] with mode 'REPRO'.</mods:recordOrigin>
+          </mods:recordInfo>
+          <mods:genre authorityURI="https://rosdok.uni-rostock.de/classifications/doctype" displayLabel="doctype" type="intern" usage="primary" valueURI="https://rosdok.uni-rostock.de/classifications/doctype#histbest.print.monograph">Druck</mods:genre>
+          <mods:genre authorityURI="http://www.mycore.org/classifications/aadgenres" displayLabel="aadgenre" type="aadgenre" valueURI="http://www.mycore.org/classifications/aadgenres#ppn_096631147">Dissertation</mods:genre>
+          <mods:titleInfo usage="primary">
+            <mods:title>Dissertatio Inauguralis Medica De Inversione Uteri</mods:title>
+          </mods:titleInfo>
+          <mods:titleInfo type="alternative">
+            <mods:title>De inversione uteri</mods:title>
+          </mods:titleInfo>
+          <mods:name type="personal">
+            <mods:namePart type="given">Karl Friedrich</mods:namePart>
+            <mods:namePart type="family">Köppen</mods:namePart>
+            <mods:role>
+              <mods:roleTerm authority="GBV" type="text">VerfasserIn</mods:roleTerm>
+              <mods:roleTerm authority="marcrelator" type="code">aut</mods:roleTerm>
+            </mods:role>
+            <mods:nameIdentifier type="gnd">1147717303</mods:nameIdentifier>
+          </mods:name>
+          <mods:name type="corporate">
+            <mods:nameIdentifier type="gnd">6146567-7</mods:nameIdentifier>
+            <mods:namePart>Johann Jakob Adler Erben</mods:namePart>
+            <mods:role>
+              <mods:roleTerm authority="GBV" type="text">DruckerIn</mods:roleTerm>
+              <mods:roleTerm authority="marcrelator" type="code">prt</mods:roleTerm>
+            </mods:role>
+          </mods:name>
+          <mods:identifier type="urn">urn:nbn:de:gbv:28-rosdok_ppn100673385X-0</mods:identifier>
+          <mods:identifier type="purl">http://purl.uni-rostock.de/rosdok/ppn100673385X</mods:identifier>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/provider" displayLabel="provider" valueURI="https://rosdok.uni-rostock.de/classifications/provider#ubr">Universitätsbibliothek Rostock</mods:classification>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/licenseinfo" displayLabel="licenseinfo" valueURI="https://rosdok.uni-rostock.de/classifications/licenseinfo#metadata.cc0">Lizenz Metadaten: CC0</mods:classification>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/licenseinfo" displayLabel="licenseinfo" valueURI="https://rosdok.uni-rostock.de/classifications/licenseinfo#digitisedimages.norestrictions">Keine Einschränkungen</mods:classification>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/licenseinfo" displayLabel="licenseinfo" valueURI="https://rosdok.uni-rostock.de/classifications/licenseinfo#deposit.publicdomain">gemeinfrei</mods:classification>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/licenseinfo" displayLabel="licenseinfo" valueURI="https://rosdok.uni-rostock.de/classifications/licenseinfo#work.publicdomain">gemeinfrei</mods:classification>
+          <mods:classification authorityURI="https://rosdok.uni-rostock.de/classifications/accesscondition" displayLabel="accesscondition" valueURI="https://rosdok.uni-rostock.de/classifications/accesscondition#openaccess">frei zugänglich (Open Access)</mods:classification>
+          <mods:language>
+            <mods:languageTerm authority="rfc5646" type="code">la</mods:languageTerm>
+          </mods:language>
+          <mods:physicalDescription>
+            <mods:extent>19 Seiten</mods:extent>
+            <mods:note type="source_dimensions">4°</mods:note>
+            <mods:digitalOrigin>reformatted digital</mods:digitalOrigin>
+          </mods:physicalDescription>
+          <mods:originInfo eventType="publication">
+            <mods:dateIssued encoding="w3cdtf" keyDate="yes">1806</mods:dateIssued>
+            <mods:dateIssued>MDCCCVI.</mods:dateIssued>
+            <mods:publisher>Litteris Adlerianis</mods:publisher>
+            <mods:place>
+              <mods:placeTerm type="text">Rostochii</mods:placeTerm>
+            </mods:place>
+            <mods:place supplied="yes">
+              <mods:placeTerm lang="ger" type="text">Rostock</mods:placeTerm>
+            </mods:place>
+            <mods:issuance>monographic</mods:issuance>
+            <mods:dateOther encoding="w3cdtf" type="defence">1806</mods:dateOther>
+          </mods:originInfo>
+          <mods:originInfo eventType="digitization">
+            <mods:dateCaptured encoding="w3cdtf" keyDate="yes">2017</mods:dateCaptured>
+            <mods:publisher>Universitätsbibliothek Rostock</mods:publisher>
+            <mods:place>
+              <mods:placeTerm type="text">Rostock</mods:placeTerm>
+            </mods:place>
+            <mods:dateCaptured>2017</mods:dateCaptured>
+          </mods:originInfo>
+          <mods:location>
+            <mods:physicalLocation authorityURI="http://d-nb.info/gnd/" type="current" valueURI="http://d-nb.info/gnd/25968-8">Universitätsbibliothek Rostock</mods:physicalLocation>
+            <mods:shelfLocator>R.U.-med 1806 Köppen, Karl Friedrich</mods:shelfLocator>
+          </mods:location>
+          <mods:location>
+            <mods:physicalLocation authorityURI="http://d-nb.info/gnd/" type="online" valueURI="http://d-nb.info/gnd/25968-8">Universitätsbibliothek Rostock</mods:physicalLocation>
+            <mods:url access="object in context" usage="primary">http://purl.uni-rostock.de/rosdok/ppn100673385X</mods:url>
+          </mods:location>
+          <mods:note type="source_note">Vorlageform der Veröffentlichungsangabe: "Rostochii Litteris Adlerianis MDCCCVI."</mods:note>
+          <mods:note type="statement of responsibility">Quam Consensu ... Facultatis Medicae Rostochiensis Pro Obtinendo Doctoris Gradu Examini Publico Submittit Carolus Friedericus Köppen Treptoviensis</mods:note>
+          <mods:classification authority="ivdcc">bibliotheken#101ub_rostock</mods:classification>
+        </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:dmdSec ID="DMDLOG_0001">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods:mods>
+          <mods:titleInfo>
+            <mods:title>Discrimen, quod corpus virile et  muliedre intercedit, in diversa...</mods:title>
+          </mods:titleInfo>
+        </mods:mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:amdSec ID="AMD_DFGVIEWER">
+    <mets:rightsMD ID="RIGHTS">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="DVRIGHTS">
+        <mets:xmlData>
+          <dv:rights>
+            <dv:owner>Universitätsbibliothek Rostock</dv:owner>
+            <dv:ownerLogo>https://rosdok.uni-rostock.de/images/dfgviewer/dfgviewer_ublogo.png</dv:ownerLogo>
+            <dv:ownerSiteURL>http://www.ub.uni-rostock.de</dv:ownerSiteURL>
+            <dv:ownerContact>mailto:digibib.ub@uni-rostock.de</dv:ownerContact>
+          </dv:rights>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:rightsMD>
+    <mets:digiprovMD ID="DIGIPROV">
+      <mets:mdWrap MDTYPE="OTHER" MIMETYPE="text/xml" OTHERMDTYPE="DVLINKS">
+        <mets:xmlData>
+          <dv:links>
+            <dv:reference>https://opac.lbs-rostock.gbv.de/DB=1/PPN?PPN=100673385X</dv:reference>
+            <dv:presentation>http://purl.uni-rostock.de/rosdok/ppn100673385X</dv:presentation>
+            <dv:iiif>https://rosdok.uni-rostock.de/api/iiif/presentation/v2/rosdok_ppn100673385X/manifest</dv:iiif>
+          </dv:links>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:digiprovMD>
+  </mets:amdSec>
+  <mets:fileSec>
+    <mets:fileGrp ID="ALTO" USE="FULLTEXT">
+      <mets:file ID="ALTO_file_0001" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0001.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0002" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0002.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0003" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0003.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0004" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0004.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0005" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0005.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0006" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0006.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0007" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0007.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0008" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0008.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0009" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0009.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0010" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0010.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0011" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0011.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0012" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0012.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0013" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0013.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0014" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0014.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0015" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0015.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0016" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0016.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0017" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0017.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0018" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0018.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0019" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0019.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0020" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0020.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0021" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0021.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0022" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0022.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0023" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0023.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0024" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0024.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0025" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0025.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0026" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0026.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0027" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0027.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0028" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0028.alto.xml" />
+      </mets:file>
+      <mets:file ID="ALTO_file_0029" MIMETYPE="text/xml">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/depot/rosdok_ppn100673385X/alto/phys_0029.alto.xml" />
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="DEFAULT">
+      <mets:file ID="DEFAULT_file_0001" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0001/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0002" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0002/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0003" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0003/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0004" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0004/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0005" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0005/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0006" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0006/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0007" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0007/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0008" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0008/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0009" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0009/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0010" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0010/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0011" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0011/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0012" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0012/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0013" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0013/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0014" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0014/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0015" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0015/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0016" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0016/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0017" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0017/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0018" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0018/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0019" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0019/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0020" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0020/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0021" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0021/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0022" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0022/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0023" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0023/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0024" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0024/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0025" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0025/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0026" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0026/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0027" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0027/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0028" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0028/info.json" />
+      </mets:file>
+      <mets:file ID="DEFAULT_file_0029" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0029/info.json" />
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="THUMBS">
+      <mets:file ID="THUMBS_file_0001" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0001/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0002" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0002/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0003" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0003/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0004" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0004/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0005" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0005/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0006" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0006/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0007" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0007/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0008" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0008/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0009" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0009/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0010" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0010/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0011" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0011/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0012" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0012/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0013" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0013/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0014" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0014/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0015" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0015/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0016" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0016/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0017" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0017/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0018" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0018/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0019" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0019/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0020" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0020/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0021" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0021/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0022" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0022/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0023" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0023/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0024" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0024/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0025" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0025/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0026" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0026/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0027" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0027/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0028" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0028/full/!150,150/0/native.jpg" />
+      </mets:file>
+      <mets:file ID="THUMBS_file_0029" MIMETYPE="image/jpeg">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0029/full/!150,150/0/native.jpg" />
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="DOWNLOAD">
+      <mets:file ID="DOWNLOAD_file_0000" MIMETYPE="text/html">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/resolve/recordIdentifier/rosdok%252Fppn100673385X/pdfdownload" />
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="TEASER">
+      <mets:file ID="TEASER_file_0000" MIMETYPE="text/html">
+        <mets:FLocat LOCTYPE="URL" xlink:href="https://rosdok.uni-rostock.de/iiif/image-api/rosdok%252Fppn100673385X%252Fphys_0005/full/!400,400/0/native.jpg" />
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="PHYSICAL">
+    <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X" ID="phys_0000" TYPE="physSequence">
+      <mets:fptr FILEID="DOWNLOAD_file_0000" />
+      <mets:fptr FILEID="TEASER_file_0000" />
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0001" ID="phys_0001" ORDER="1" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0001" />
+        <mets:fptr FILEID="DEFAULT_file_0001" />
+        <mets:fptr FILEID="THUMBS_file_0001" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0002" ID="phys_0002" ORDER="2" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0002" />
+        <mets:fptr FILEID="DEFAULT_file_0002" />
+        <mets:fptr FILEID="THUMBS_file_0002" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0003" ID="phys_0003" ORDER="3" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0003" />
+        <mets:fptr FILEID="DEFAULT_file_0003" />
+        <mets:fptr FILEID="THUMBS_file_0003" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0004" ID="phys_0004" ORDER="4" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0004" />
+        <mets:fptr FILEID="DEFAULT_file_0004" />
+        <mets:fptr FILEID="THUMBS_file_0004" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0005" ID="phys_0005" ORDER="5" ORDERLABEL="[1]" TYPE="page" xlink:label="START_PAGE">
+        <mets:fptr FILEID="ALTO_file_0005" />
+        <mets:fptr FILEID="DEFAULT_file_0005" />
+        <mets:fptr FILEID="THUMBS_file_0005" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0006" ID="phys_0006" ORDER="6" ORDERLABEL="[2]" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0006" />
+        <mets:fptr FILEID="DEFAULT_file_0006" />
+        <mets:fptr FILEID="THUMBS_file_0006" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0007" ID="phys_0007" ORDER="7" ORDERLABEL="[3]" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0007" />
+        <mets:fptr FILEID="DEFAULT_file_0007" />
+        <mets:fptr FILEID="THUMBS_file_0007" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0008" ID="phys_0008" ORDER="8" ORDERLABEL="4" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0008" />
+        <mets:fptr FILEID="DEFAULT_file_0008" />
+        <mets:fptr FILEID="THUMBS_file_0008" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0009" ID="phys_0009" ORDER="9" ORDERLABEL="5" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0009" />
+        <mets:fptr FILEID="DEFAULT_file_0009" />
+        <mets:fptr FILEID="THUMBS_file_0009" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0010" ID="phys_0010" ORDER="10" ORDERLABEL="6" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0010" />
+        <mets:fptr FILEID="DEFAULT_file_0010" />
+        <mets:fptr FILEID="THUMBS_file_0010" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0011" ID="phys_0011" ORDER="11" ORDERLABEL="7" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0011" />
+        <mets:fptr FILEID="DEFAULT_file_0011" />
+        <mets:fptr FILEID="THUMBS_file_0011" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0012" ID="phys_0012" ORDER="12" ORDERLABEL="8" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0012" />
+        <mets:fptr FILEID="DEFAULT_file_0012" />
+        <mets:fptr FILEID="THUMBS_file_0012" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0013" ID="phys_0013" ORDER="13" ORDERLABEL="9" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0013" />
+        <mets:fptr FILEID="DEFAULT_file_0013" />
+        <mets:fptr FILEID="THUMBS_file_0013" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0014" ID="phys_0014" ORDER="14" ORDERLABEL="10" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0014" />
+        <mets:fptr FILEID="DEFAULT_file_0014" />
+        <mets:fptr FILEID="THUMBS_file_0014" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0015" ID="phys_0015" ORDER="15" ORDERLABEL="11" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0015" />
+        <mets:fptr FILEID="DEFAULT_file_0015" />
+        <mets:fptr FILEID="THUMBS_file_0015" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0016" ID="phys_0016" ORDER="16" ORDERLABEL="12" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0016" />
+        <mets:fptr FILEID="DEFAULT_file_0016" />
+        <mets:fptr FILEID="THUMBS_file_0016" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0017" ID="phys_0017" ORDER="17" ORDERLABEL="13" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0017" />
+        <mets:fptr FILEID="DEFAULT_file_0017" />
+        <mets:fptr FILEID="THUMBS_file_0017" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0018" ID="phys_0018" ORDER="18" ORDERLABEL="14" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0018" />
+        <mets:fptr FILEID="DEFAULT_file_0018" />
+        <mets:fptr FILEID="THUMBS_file_0018" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0019" ID="phys_0019" ORDER="19" ORDERLABEL="15" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0019" />
+        <mets:fptr FILEID="DEFAULT_file_0019" />
+        <mets:fptr FILEID="THUMBS_file_0019" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0020" ID="phys_0020" ORDER="20" ORDERLABEL="16" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0020" />
+        <mets:fptr FILEID="DEFAULT_file_0020" />
+        <mets:fptr FILEID="THUMBS_file_0020" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0021" ID="phys_0021" ORDER="21" ORDERLABEL="17" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0021" />
+        <mets:fptr FILEID="DEFAULT_file_0021" />
+        <mets:fptr FILEID="THUMBS_file_0021" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0022" ID="phys_0022" ORDER="22" ORDERLABEL="18" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0022" />
+        <mets:fptr FILEID="DEFAULT_file_0022" />
+        <mets:fptr FILEID="THUMBS_file_0022" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0023" ID="phys_0023" ORDER="23" ORDERLABEL="19" TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0023" />
+        <mets:fptr FILEID="DEFAULT_file_0023" />
+        <mets:fptr FILEID="THUMBS_file_0023" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0024" ID="phys_0024" ORDER="24" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0024" />
+        <mets:fptr FILEID="DEFAULT_file_0024" />
+        <mets:fptr FILEID="THUMBS_file_0024" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0025" ID="phys_0025" ORDER="25" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0025" />
+        <mets:fptr FILEID="DEFAULT_file_0025" />
+        <mets:fptr FILEID="THUMBS_file_0025" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0026" ID="phys_0026" ORDER="26" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0026" />
+        <mets:fptr FILEID="DEFAULT_file_0026" />
+        <mets:fptr FILEID="THUMBS_file_0026" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0027" ID="phys_0027" ORDER="27" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0027" />
+        <mets:fptr FILEID="DEFAULT_file_0027" />
+        <mets:fptr FILEID="THUMBS_file_0027" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0028" ID="phys_0028" ORDER="28" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0028" />
+        <mets:fptr FILEID="DEFAULT_file_0028" />
+        <mets:fptr FILEID="THUMBS_file_0028" />
+      </mets:div>
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/phys_0029" ID="phys_0029" ORDER="29" ORDERLABEL=" - " TYPE="page">
+        <mets:fptr FILEID="ALTO_file_0029" />
+        <mets:fptr FILEID="DEFAULT_file_0029" />
+        <mets:fptr FILEID="THUMBS_file_0029" />
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structMap TYPE="LOGICAL">
+    <mets:div ADMID="AMD_DFGVIEWER" CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X" DMDID="DMDLOG_0000" ID="log_0000" LABEL="Dissertatio Inauguralis Medica De Inversione Uteri" TYPE="monograph">
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/log_0001" ID="log_0001" TYPE="binding" />
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/log_0002" ID="log_0002" TYPE="title_page" />
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/log_0003" DMDID="DMDLOG_0001" ID="log_0003" LABEL="Discrimen, quod corpus virile et  muliedre intercedit, in diversa..." TYPE="section" />
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/log_0004" ID="log_0004" TYPE="binding" />
+      <mets:div CONTENTIDS="http://purl.uni-rostock.de/rosdok/ppn100673385X/log_0005" ID="log_0005" TYPE="colour_checker" />
+    </mets:div>
+  </mets:structMap>
+  <mets:structLink>
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0001" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0002" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0003" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0004" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0005" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0006" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0007" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0008" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0009" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0010" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0011" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0012" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0013" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0014" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0015" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0016" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0017" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0018" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0019" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0020" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0021" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0022" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0023" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0024" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0025" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0026" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0027" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0028" />
+    <mets:smLink xlink:from="log_0000" xlink:to="phys_0029" />
+    <mets:smLink xlink:from="log_0001" xlink:to="phys_0001" />
+    <mets:smLink xlink:from="log_0001" xlink:to="phys_0002" />
+    <mets:smLink xlink:from="log_0001" xlink:to="phys_0003" />
+    <mets:smLink xlink:from="log_0001" xlink:to="phys_0004" />
+    <mets:smLink xlink:from="log_0002" xlink:to="phys_0005" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0007" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0008" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0009" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0010" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0011" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0012" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0013" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0014" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0015" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0016" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0017" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0018" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0019" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0020" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0021" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0022" />
+    <mets:smLink xlink:from="log_0003" xlink:to="phys_0023" />
+    <mets:smLink xlink:from="log_0004" xlink:to="phys_0025" />
+    <mets:smLink xlink:from="log_0004" xlink:to="phys_0026" />
+    <mets:smLink xlink:from="log_0004" xlink:to="phys_0027" />
+    <mets:smLink xlink:from="log_0004" xlink:to="phys_0028" />
+    <mets:smLink xlink:from="log_0005" xlink:to="phys_0029" />
+  </mets:structLink>
+</mets:mets>

--- a/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
+++ b/src/DigitalPreservation/XmlGen.Tests/XmlGen.Tests.csproj
@@ -90,6 +90,9 @@
       <None Update="Samples\goobi-mixed.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
+      <None Update="Samples\goobi-2026.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
       <None Update="Samples\goobi-mixed-2.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>


### PR DESCRIPTION
## My (Tom) explanation:

This PR builds a new cache when working with METS to allow finding the mets XML element for the physical file, given its relative path on disk.

e.g., for the file `objects/images/hello.jpg`, where is its `mets:div`? And from there you can find `mets:file` in the `fileSec`, and traverse the XML via `ADMID` attributes to the metadata for that file, and so on..

We used to answer this question by basing the file XML element's `ID` on the file path, e.g., `objects/images/hello.jpg` => `PHYS_objects/images/hello.jpg`

But this introduces two problems - 
1. `/` in an XML element ID is not valid according to the strict schema (all XML parsers don't mind it but a correct METS parser does)
2. What about the file `objects/docs/my nice word document.doc`? It has spaces in it. 

So we end up with `<mets:div ID="PHYS_objects/docs/my nice word document.doc" ADMID="ADM_objects/docs/my nice word document.doc" ... >`

... but :collision:, because this _actually_ means:

"I point to FOUR separate ADM xml elements and their IDs are `ADM_objects/docs/my`, `nice`, `word`, and `document.doc`"

For files, we use the `FLocat@xlink:href` on the `mets:file` element (div → fptr → FILE → FLocat).

For folders, we will now use `premis:originalName` in ADM to record the actual relative path on disk of the file, and traverse back to the file mets:div element that points at it; this builds a map of original path on disk to file divs, which is what we need.

This puts some constraints on what a valid _editable_ METS looks like, for the future work. It is not needed just to _read_ Goobi METS.

## Claude's explanation

Step 1 of the fix for #188 (METS XML IDs like `PHYS_objects/my file.pdf` are not valid `xs:ID`/NCName values). This PR does **not** change any IDs — it removes the last dependency on their format, so that step 2 (minting NCName-safe IDs via `XmlConvert.EncodeLocalName`) can ship without breaking navigation or backward compatibility. Full plan: [issue-188-plan.md](https://github.com/digirati-co-uk/digital-preservation/blob/main/docs/issues/188/issue-188-plan.md) (v2), [issue-188-reassessment.md](https://github.com/digirati-co-uk/digital-preservation/blob/main/docs/issues/188/issue-188-reassessment.md) and the [IDREFS companion plan](https://github.com/digirati-co-uk/digital-preservation/blob/main/docs/issues/188/issue-188-idrefs-plan.md) (in `docs/issues/188/` on main, via PR #212).

**Zero behavior change to produced XML.** No existing test assertion was altered; the full XmlGen.Tests suite (312 tests) passes unchanged.

## How it works

- **`FullMets.PhysicalDivsByPath`** — a cache mapping each deposit-relative path to its div in the PHYSICAL structMap, built by the new **`MetsCache`** from the div's own metadata: `premis:originalName` for directories, the referenced FILE's `FLocat` href for files. Never from the div's ID.
- Populated when either `IMetsStorage` implementation loads a METS, lazily on first navigation for a directly-constructed `FullMets`, and maintained by `AddNewFile` / `AddNewDirectory` / `DeleteDiv`. A `[Conditional("DEBUG")]` assertion verifies the maintained cache equals a fresh rebuild on every navigation, so every existing MetsManager test exercises cache consistency.
- **`LocateMetsDivByLocalPath` navigates in three tiers**: cache lookup → resolving the current div's children by their own metadata (defeats duplicate-path collisions) → the legacy `PHYS_ + path` ID convention. Navigation is therefore a strict superset of what main does today; the legacy tier is the step-2 backward-compat mechanism and is removable after a step-3 bulk migration.
- **Diagnosability**: `MetsCache.Populate` returns (and keeps on `FullMets.PathDiagnostics`) one entry per div whose path could not be resolved or that collided — appended to navigation error messages, and the seed of a future "is this METS editable?" conformance check (relevant to editing third-party METS).
- Path normalisation (`./`, BagIt `data/` prefix, trailing `/`) is applied identically to cache keys, incoming edit paths, minted IDs and `FLocat` comparisons.

## Also in this PR

- **ClamAV digiprovMD lookup fix** (`MetsParser`): the fallback was a case-insensitive *substring* match, which cross-talks between files whose IDs are prefixes of each other — under step 2's encoded IDs that becomes a real hazard (`ADM_a` ⊂ `ADM_a_x002F_b`). Now an exact case-insensitive match, with regression tests. Note for the docs repo: `02c-METS-Parsing.md` says digiprov IDs are matched "by containment" — needs updating when this merges.
- **Hardening from a high-effort review pass** (second commit): tolerate zero/multiple PHYSICAL structMaps at load (diagnostic, not exception); adds attach nothing to the METS until the fallible metadata step succeeds, and refuse to add a div whose ID already exists (no duplicate-ID corruption); `Set*ByPath` methods no longer write metadata to an ancestor div when a path only partially resolves.

## Test coverage

14 new cache/navigation tests + 2 ClamAV regressions, all deliberately **ID-agnostic** (they assert on paths, labels and reference identity, never on ID attribute values) so they survive step 2 unchanged. Coverage includes: population on load, add/update/delete maintenance verified against fresh rebuilds, lazy population, normalisation variants (`data/`, `./`, `./data/`, trailing `/`), duplicate-path impostor resolution, unresolvable-div diagnostics, failed-add atomicity, and editing the frozen legacy spaces fixture (`Samples/path-fixture-spaces.xml`) by path.

## Sequencing

The [IDREFS companion](https://github.com/digirati-co-uk/digital-preservation/blob/main/docs/issues/188/issue-188-idrefs-plan.md) is already implemented on `feat/188-idrefs-resolution`, stacked on this branch; its PR opens once this merges. Step 2 (`feat/188-encoded-mets-ids`) then branches from that and must not merge first. This PR deploys standalone with no coordination requirements — it produces byte-identical METS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
