### PR TITLE
feat: IDREFS-aware ID resolution on both METS stacks (#188 companion)

### DIFF
--- a/docs/issues/188/issue-188-analysis.md
+++ b/docs/issues/188/issue-188-analysis.md
@@ -147,11 +147,21 @@ are already valid NCNames. No issue.
 
 ### structLink FILE_ IDs
 
-`LinkFile`, `UnLinkFile`, `SetFileLinks` (lines 671–708) construct smLink from/to IDs using
-`Constants.FileIdPrefix + localPath`. Both the FILE element in FileSec and the smLink from/to
-are constructed by the same code — changing the format keeps them mutually consistent.
+`LinkFile`, `UnLinkFile`, `SetFileLinks` construct smLink from/to IDs using
+`Constants.FileIdPrefix + localPath`, and `BuildFptr` mints logical-fptr FILEIDs the same way.
 MetsParser resolves `from`/`to` against its `FileMap` dictionary by exact string match.
 No external consumer parses a path from a structLink ID.
+
+> **Correction (2026-08-12, independent whole-feature review):** the original claim here —
+> that FILE element and smLink are "constructed by the same code so changing the format keeps
+> them mutually consistent" — is only true for files ADDED after the format change. A legacy
+> deposit keeps its raw FILE IDs (`FILE_objects/my file.pdf`) until a step 3 migration, so a
+> post-step-2 `LinkFile`/`SetStructMap` that MINTS the encoded form would create dangling
+> FILEID/smLink references, and `UnLinkFile`/`SetFileLinks` would be unable to remove
+> pre-existing raw-ID links. Step 2 must make these sites RESOLVE the actual FILE element's
+> ID (via the path cache div's `Fptr`, or a FLocat lookup in the fileSec) rather than mint —
+> the same navigate-don't-derive principle as the rest of the fix. See the step 2 checklist
+> in `issue-188-plan.md`.
 
 ### The ByDivId / UI round-trip
 
@@ -213,7 +223,7 @@ are already valid NCNames.
 | `iiif-builder` (Python) | None | None — already opaque |
 | `LocateMetsDivByDivId` / `FindDiv` | None | None — already format-agnostic |
 | Logical structMap / `logical-structmap.js` | None | None — LOG_ IDs already valid |
-| structLink FILE_ IDs | None | Update minting; lookups remain consistent |
+| structLink FILE_ IDs | None | **Resolve, don’t mint** — see correction in §structLink FILE_ IDs |
 | Test files with path-containing ID assertions | None | **Significant churn across 5+ files** |
 | Test `ByDivId` calls with `"PHYS_objects"` | None | None — no `/` in those IDs |
 | UI / API layer | None | None — opaque round-trip |

--- a/docs/issues/188/issue-188-idrefs-plan.md
+++ b/docs/issues/188/issue-188-idrefs-plan.md
@@ -5,6 +5,16 @@
 > is *tolerant* of unresolvable amdSec/dmdSec references rather than failing cleanly —
 > deletion is how broken content gets cleaned up, and this also fixes a latent crash on
 > by-design dangling DMDIDs (lazy dmdSec creation).
+>
+> **Status (2026-08-12, after PR #213 review):** the review found the deletion sites needed
+> more than `ResolveSingle`, so — revising §"What NOT to do" point 3 — `IdRefs.ResolveAll`
+> now exists for them: `DeleteDiv` and `RemoveLogicalStructMapDmdSecs` (the one site the
+> original inventory missed) remove **every** section a reference resolves, EXCEPT a section
+> another div/file still references (`SectionReferencedElsewhere`) — a genuinely shared
+> section (e.g. Archivematica's shared rightsMD) must survive the deletion of one referrer.
+> `TryRemoveRedundantDmd` now drops only the reference to the dmdSec it removed
+> (`IdRefs.RemoveReference`), not the div's whole DMDID list. And the raw-string overload
+> splits on all XML whitespace (tab/newline/CR), not just spaces.
 
 > 2026-08-11. Companion to `issue-188-plan.md` (v2). Analysed against
 > `feat/188-physical-divs-cache` (PR #211), which this work should follow.
@@ -143,7 +153,8 @@ ordering intact).
   (this is the same lifecycle as the frozen `Samples/path-fixture-spaces.xml` corpus).
 - Do not try to make `ResolveSingle` return multiple elements for multi-IDREFS in step 1 of
   this work — no current caller can consume more than one; add `ResolveAll` only when a caller
-  needs it.
+  needs it. *(Superseded 2026-08-12: the deletion sites are exactly such callers — see the
+  status note above.)*
 
 ## Sequencing and tests
 

--- a/docs/issues/188/issue-188-idrefs-plan.md
+++ b/docs/issues/188/issue-188-idrefs-plan.md
@@ -15,6 +15,18 @@
 > `TryRemoveRedundantDmd` now drops only the reference to the dmdSec it removed
 > (`IdRefs.RemoveReference`), not the div's whole DMDID list. And the raw-string overload
 > splits on all XML whitespace (tab/newline/CR), not just spaces.
+>
+> **Round 2 (same day):** the shared-section guard became a single-pass index
+> (`CollectSectionReferences`) so deletion is one document walk, not one per section;
+> `TryRemoveRedundantDmd` additionally sweeps sibling tokens that resolve nothing (restoring
+> the old Clear() cleanup for danglers while keeping live references); the parser reads the
+> ClamAV digiprovMD structurally from the resolved amdSec (conventional-key lookup kept only
+> as fallback); and Get/SetModsForDiv's multi-DMDID stance is now documented + tested as
+> deliberate: the first-resolving dmdSec is the div's editable MODS record, further
+> referenced dmdSecs are third-party content that reads and writes never touch. The two
+> `ResolveSingle` overloads deliberately do NOT share an implementation - the raw-string
+> side's first tier must match the attribute value verbatim (any whitespace a filename can
+> contain), which the token side cannot reconstruct; see the doc comment on the overload.
 
 > 2026-08-11. Companion to `issue-188-plan.md` (v2). Analysed against
 > `feat/188-physical-divs-cache` (PR #211), which this work should follow.

--- a/docs/issues/188/issue-188-plan.md
+++ b/docs/issues/188/issue-188-plan.md
@@ -7,6 +7,24 @@
 > (`issue-188-idrefs-plan.md`) is also implemented, on `feat/188-idrefs-resolution`, stacked
 > on #211. Step 2 is not started. `chore/sonar-cleanup-main` has since merged; "the mainline"
 > below now simply means `main`.
+>
+> **Status addendum (2026-08-12, after PR #211 merge + independent whole-feature review):**
+> further deltas the review found unrecorded — the "pure refactor / zero assertion changes"
+> claim below no longer holds precisely: (a) `IMetsManager` Set* methods now return `Result`
+> instead of `void` (failures surface to callers; `SetModsInformation` propagates); (b)
+> `EditMets`/`LinkFile`/`UnLinkFile`/`SetFileLinks` normalise incoming paths (`./` strip,
+> trailing-`/` trim, BagIt `data/` strip), changing produced XML for variant path inputs;
+> (c) FLocat comparisons in update/delete/metadata paths are normalised the same way. All
+> deliberate improvements from the review rounds.
+>
+> **Step 2 checklist addition (2026-08-12, from the whole-feature review):**
+> `BuildFptr` and `LinkFile`/`UnLinkFile`/`SetFileLinks` must switch from MINTING
+> `FILE_`+path to RESOLVING the actual FILE element's ID (via the cached div's `Fptr`, or a
+> FLocat lookup) — on legacy documents the fileSec keeps raw IDs, so minting encoded IDs
+> would create dangling FILEID/smLink references and make raw-ID smLinks unremovable. The
+> §2.x "structLink FILE_ IDs — just re-mint" assumption (and its counterpart in
+> `issue-188-analysis.md`, now corrected there) was wrong for legacy content. Add a legacy
+> structLink/logical-fptr regression test on `Samples/path-fixture-spaces.xml` with it.
 
 > v2, 2026-08-10. Revised against `chore/sonar-cleanup-main` after full re-verification of every
 > code claim — see `issue-188-reassessment.md` for what changed and why the approach stands.

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
@@ -32,9 +32,11 @@ public interface IMetsManager
     // SetAccessRestrictionsByDivId(mets, "PHYS_objects/child-folder", ["Closed"])  // equiv to first one
     // Each returns a failure when the write did NOT happen, and the caller must not report
     // success (silently writing to an ancestor div, or silently doing nothing, are both
-    // worse than failing). ByPath methods return BadRequest for an unresolvable path (the
-    // same condition and code as EditMets). ByDivId methods return NotFound for an unknown
-    // divId. Both return BadRequest when the descriptive metadata cannot be edited as MODS.
+    // worse than failing). ByPath methods return BadRequest for an unresolvable path (as
+    // EditMets does for adds and updates; EditMets' DELETE of a missing entry returns
+    // NotFound - deleting a thing that isn't there). ByDivId methods return NotFound for an
+    // unknown divId. Both return BadRequest when the descriptive metadata cannot be edited
+    // as MODS.
     Result SetRecordInfoByPath(FullMets mets, string localPath, RecordInfo recordInfo);
     Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo);
     Result SetRightsStatementByPath(FullMets mets, string localPath, Uri? rightsStatement);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
@@ -45,6 +45,27 @@ public static class IdRefs
     }
 
     /// <summary>
+    /// Mirror-image resolution for the XDocument/raw-string side (MetsParser), where the whole
+    /// IDREFS attribute value arrives as one string: try the whole value first (a single ID,
+    /// or a legacy ID containing spaces), then each whitespace-separated token (schema-valid
+    /// IDREFS list - XML allows tab/newline/CR separators as well as spaces), first match
+    /// winning.
+    /// </summary>
+    public static T? ResolveSingle<T>(string attributeValue, Func<string, T?> lookupById)
+        where T : class
+    {
+        var whole = lookupById(attributeValue);
+        if (whole != null || attributeValue.IndexOfAny(XmlWhitespace) < 0)
+        {
+            return whole;
+        }
+        return attributeValue
+            .Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries)
+            .Select(lookupById)
+            .FirstOrDefault(match => match != null);
+    }
+
+    /// <summary>
     /// Resolve an IDREFS token collection to every referenced element. The same tiering as
     /// <see cref="ResolveSingle{T}(IReadOnlyList{string},Func{string,T})"/>: a joined-form
     /// match means the tokens are ONE legacy space-containing ID, so exactly that element is
@@ -97,26 +118,5 @@ public static class IdRefs
         {
             tokens.Remove(resolvedId);
         }
-    }
-
-    /// <summary>
-    /// Mirror-image resolution for the XDocument/raw-string side (MetsParser), where the whole
-    /// IDREFS attribute value arrives as one string: try the whole value first (a single ID,
-    /// or a legacy ID containing spaces), then each whitespace-separated token (schema-valid
-    /// IDREFS list - XML allows tab/newline/CR separators as well as spaces), first match
-    /// winning.
-    /// </summary>
-    public static T? ResolveSingle<T>(string attributeValue, Func<string, T?> lookupById)
-        where T : class
-    {
-        var whole = lookupById(attributeValue);
-        if (whole != null || attributeValue.IndexOfAny(XmlWhitespace) < 0)
-        {
-            return whole;
-        }
-        return attributeValue
-            .Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries)
-            .Select(lookupById)
-            .FirstOrDefault(match => match != null);
     }
 }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
@@ -49,7 +49,11 @@ public static class IdRefs
     /// IDREFS attribute value arrives as one string: try the whole value first (a single ID,
     /// or a legacy ID containing spaces), then each whitespace-separated token (schema-valid
     /// IDREFS list - XML allows tab/newline/CR separators as well as spaces), first match
-    /// winning.
+    /// winning. Deliberately NOT implemented by delegating to the token-collection overload:
+    /// this side's first tier must match the attribute value VERBATIM (a legacy ID could
+    /// contain any whitespace a filename can), whereas the collection overload's joined tier
+    /// reconstructs with single spaces because that is all the XmlSerializer's split leaves
+    /// it - the two first tiers are subtly different and each is right for its input.
     /// </summary>
     public static T? ResolveSingle<T>(string attributeValue, Func<string, T?> lookupById)
         where T : class
@@ -94,14 +98,6 @@ public static class IdRefs
                     .ToList();
         }
     }
-
-    /// <summary>
-    /// True when the token collection references the element with this ID - as its only token,
-    /// as one token of a genuine IDREFS list, or as the joined form of a legacy
-    /// space-containing ID. Pure string comparison; no lookup involved.
-    /// </summary>
-    public static bool References(IReadOnlyList<string> tokens, string id) =>
-        tokens.Contains(id) || (tokens.Count > 1 && Joined(tokens) == id);
 
     /// <summary>
     /// Remove from an IDREFS token collection the reference to an element previously resolved

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
@@ -17,6 +17,12 @@ namespace DigitalPreservation.Mets;
 /// </summary>
 public static class IdRefs
 {
+    /// <summary>
+    /// The characters XML treats as whitespace, and therefore as IDREFS separators. The
+    /// XmlSerializer splits on all of them; the raw-string side must do the same.
+    /// </summary>
+    private static readonly char[] XmlWhitespace = [' ', '\t', '\n', '\r'];
+
     /// <summary>The single intended ID that a legacy space-containing ID was split from.</summary>
     public static string Joined(IEnumerable<string> tokens) => string.Join(' ', tokens);
 
@@ -39,21 +45,77 @@ public static class IdRefs
     }
 
     /// <summary>
+    /// Resolve an IDREFS token collection to every referenced element. The same tiering as
+    /// <see cref="ResolveSingle{T}(IReadOnlyList{string},Func{string,T})"/>: a joined-form
+    /// match means the tokens are ONE legacy space-containing ID, so exactly that element is
+    /// returned; otherwise each token resolves individually (genuine IDREFS list), skipping
+    /// tokens that don't resolve. Never throws; empty when nothing matches.
+    /// </summary>
+    public static IReadOnlyList<T> ResolveAll<T>(IReadOnlyList<string> tokens, Func<string, T?> lookupById)
+        where T : class
+    {
+        switch (tokens.Count)
+        {
+            case 0:
+                return [];
+            case 1:
+                return lookupById(tokens[0]) is { } single ? [single] : [];
+            default:
+                if (lookupById(Joined(tokens)) is { } legacy)
+                {
+                    return [legacy];
+                }
+                return tokens
+                    .Select(lookupById)
+                    .Where(match => match != null)
+                    .Distinct()
+                    .Cast<T>()
+                    .ToList();
+        }
+    }
+
+    /// <summary>
+    /// True when the token collection references the element with this ID - as its only token,
+    /// as one token of a genuine IDREFS list, or as the joined form of a legacy
+    /// space-containing ID. Pure string comparison; no lookup involved.
+    /// </summary>
+    public static bool References(IReadOnlyList<string> tokens, string id) =>
+        tokens.Contains(id) || (tokens.Count > 1 && Joined(tokens) == id);
+
+    /// <summary>
+    /// Remove from an IDREFS token collection the reference to an element previously resolved
+    /// from it: every token when the tokens jointly formed a legacy space-containing ID, else
+    /// just the token equal to the element's ID. Other references are left intact.
+    /// </summary>
+    public static void RemoveReference(IList<string> tokens, string resolvedId)
+    {
+        if (Joined(tokens) == resolvedId)
+        {
+            tokens.Clear();
+        }
+        else
+        {
+            tokens.Remove(resolvedId);
+        }
+    }
+
+    /// <summary>
     /// Mirror-image resolution for the XDocument/raw-string side (MetsParser), where the whole
     /// IDREFS attribute value arrives as one string: try the whole value first (a single ID,
     /// or a legacy ID containing spaces), then each whitespace-separated token (schema-valid
-    /// IDREFS list), first match winning.
+    /// IDREFS list - XML allows tab/newline/CR separators as well as spaces), first match
+    /// winning.
     /// </summary>
     public static T? ResolveSingle<T>(string attributeValue, Func<string, T?> lookupById)
         where T : class
     {
         var whole = lookupById(attributeValue);
-        if (whole != null || !attributeValue.Contains(' '))
+        if (whole != null || attributeValue.IndexOfAny(XmlWhitespace) < 0)
         {
             return whole;
         }
         return attributeValue
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries)
             .Select(lookupById)
             .FirstOrDefault(match => match != null);
     }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IdRefs.cs
@@ -1,0 +1,60 @@
+namespace DigitalPreservation.Mets;
+
+/// <summary>
+/// Resolution helpers for METS IDREFS attributes (ADMID, DMDID) read through the XmlGen typed
+/// model, where the XmlSerializer splits the attribute value on whitespace into a token
+/// collection. Two incompatible realities have to be served:
+/// <list type="bullet">
+/// <item>legacy platform METS (pre issue #188) minted IDs containing spaces, so ONE intended
+/// ID arrives as SEVERAL tokens and must be rejoined before lookup;</item>
+/// <item>schema-valid METS may genuinely reference several elements, one complete ID per
+/// token.</item>
+/// </list>
+/// The joined form is tried first: no schema-valid ID can contain a space, so a joined
+/// multi-token string can only match in a legacy document, where it is the right answer.
+/// After issue #188 step 2 no newly minted ID can contain a space, so the joined tier only
+/// ever fires for legacy content; it is removable after a step 3 bulk migration.
+/// </summary>
+public static class IdRefs
+{
+    /// <summary>The single intended ID that a legacy space-containing ID was split from.</summary>
+    public static string Joined(IEnumerable<string> tokens) => string.Join(' ', tokens);
+
+    /// <summary>
+    /// Resolve an IDREFS token collection to one referenced element: first as a legacy single
+    /// ID containing spaces (the joined form), otherwise each token individually with the
+    /// first match winning. Returns null - never throws - when nothing matches or the
+    /// collection is empty.
+    /// </summary>
+    public static T? ResolveSingle<T>(IReadOnlyList<string> tokens, Func<string, T?> lookupById)
+        where T : class
+    {
+        return tokens.Count switch
+        {
+            0 => null,
+            1 => lookupById(tokens[0]),
+            _ => lookupById(Joined(tokens))
+                 ?? tokens.Select(lookupById).FirstOrDefault(match => match != null)
+        };
+    }
+
+    /// <summary>
+    /// Mirror-image resolution for the XDocument/raw-string side (MetsParser), where the whole
+    /// IDREFS attribute value arrives as one string: try the whole value first (a single ID,
+    /// or a legacy ID containing spaces), then each whitespace-separated token (schema-valid
+    /// IDREFS list), first match winning.
+    /// </summary>
+    public static T? ResolveSingle<T>(string attributeValue, Func<string, T?> lookupById)
+        where T : class
+    {
+        var whole = lookupById(attributeValue);
+        if (whole != null || !attributeValue.Contains(' '))
+        {
+            return whole;
+        }
+        return attributeValue
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(lookupById)
+            .FirstOrDefault(match => match != null);
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -33,7 +33,10 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
 
         if (!newUpload)
         {
-            ctx.AmdSec = fullMets.Mets.AmdSec.Single(a => a.Id == ctx.FileAdmId);
+            // GetMetadataXml resolves the file's amdSec from its ADMID tokens and sets
+            // ctx.AmdSec / ctx.FileAdmId from the resolved element - which handles legacy
+            // space-containing IDs, whose convention-derived form may not equal
+            // AdmIdPrefix + operationPath in a mixed-format METS.
             var resultGetMetadataXml = GetMetadataXml(ctx, fullMets, div, operationPath);
 
             if (resultGetMetadataXml.Failure)
@@ -192,11 +195,19 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
         }
 
-        // TODO: This is a quick fix to get round the problem of spaces in XML IDs.
-        // We need to not have any spaces in XML IDs, which means we need to escape them
-        // in a reversible way (replacing with _ won't do)
-        ctx.FileAdmId = string.Join(' ', ctx.File.Admid);
-        var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == ctx.FileAdmId);
+        // ADMID is IDREFS: legacy platform IDs containing spaces arrive split into several
+        // tokens, while a schema-valid METS may genuinely reference several amdSecs.
+        // IdRefs handles both; FileAdmId is then the RESOLVED amdSec's actual ID (identical
+        // to the rejoined tokens for legacy content), so IDs derived from it - the ClamAV
+        // digiprovMD ID - always embed a real amdSec ID.
+        var amdSec = IdRefs.ResolveSingle(ctx.File.Admid, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id));
+        if (amdSec == null)
+        {
+            return Result.Fail(ErrorCodes.BadRequest,
+                $"No amdSec found for ADMID '{IdRefs.Joined(ctx.File.Admid)}' of file {operationPath}");
+        }
+        ctx.FileAdmId = amdSec.Id;
+        ctx.AmdSec = amdSec;
         ctx.PremisIncExifXml = amdSec.TechMd.FirstOrDefault()?.MdWrap.XmlData.Any?.FirstOrDefault(); //TODO: this includes exif - separate this out
         ctx.VirusXml = amdSec.DigiprovMd.FirstOrDefault(x => x.Id.Contains(Constants.VirusProvEventPrefix))?.MdWrap.XmlData.Any?.FirstOrDefault();
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -111,15 +111,14 @@ public static class MetsCache
                 break;
             case Constants.DirectoryType:
             {
-                // Legacy IDs may contain spaces, which the XML processor splits into multiple
-                // IDREFS tokens; joining reconstructs the single amdSec ID (see MetadataManager).
-                var admId = string.Join(' ', child.Admid);
-                var amdSec = mets.AmdSec.FirstOrDefault(a => a.Id == admId);
+                // ADMID is an IDREFS token collection; IdRefs resolves both legacy
+                // space-containing IDs and genuine multi-references.
+                var amdSec = IdRefs.ResolveSingle(child.Admid, id => mets.AmdSec.FirstOrDefault(a => a.Id == id));
                 path = ExtractPremisOriginalName(amdSec);
                 if (path == null)
                 {
                     diagnostics?.Add(
-                        $"Directory div '{child.Id}' has no premis:originalName via ADMID '{admId}'");
+                        $"Directory div '{child.Id}' has no premis:originalName via ADMID '{IdRefs.Joined(child.Admid)}'");
                 }
                 break;
             }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -205,7 +205,7 @@ public class MetsManager(
         if (dmdResult.Failure) return dmdResult;
 
         parentDiv.Div.Add(childItemDiv);
-        fullMets.PhysicalDivsByPath[localPath] = childItemDiv;
+        CacheAddedDiv(fullMets, localPath, childItemDiv);
 
         SortChildDivs(parentDiv);
         return Result.Ok();
@@ -246,10 +246,30 @@ public class MetsManager(
         // as AddNewFile).
         parentDiv.Div.Add(childDirectoryDiv);
         fullMets.Mets.AmdSec.Add(amdSec);
-        fullMets.PhysicalDivsByPath[localPath] = childDirectoryDiv;
+        CacheAddedDiv(fullMets, localPath, childDirectoryDiv);
 
         SortChildDivs(parentDiv);
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// Record a newly attached div in the path cache. If a div ELSEWHERE in the tree had
+    /// already claimed this path (its metadata resolves a path that disagrees with its tree
+    /// position - only producible by edited or third-party METS, since navigation rejects
+    /// such an entry as this path's target), a plain overwrite would leave the cache silently
+    /// disagreeing with a rebuild while no diagnostic records the duplicate. Rebuild instead:
+    /// the duplicate lands on PathDiagnostics/HasDuplicatePaths, so every trust gate sees it
+    /// and navigation drops to strict per-child resolution for the contested paths.
+    /// </summary>
+    private static void CacheAddedDiv(FullMets fullMets, string localPath, DivType div)
+    {
+        if (fullMets.PhysicalDivsByPath.TryGetValue(localPath, out var existing)
+            && !ReferenceEquals(existing, div))
+        {
+            MetsCache.Populate(fullMets);
+            return;
+        }
+        fullMets.PhysicalDivsByPath[localPath] = div;
     }
 
     private static void SortChildDivs(DivType div)
@@ -391,10 +411,18 @@ public class MetsManager(
         // section it resolves - except one that another div or file still references (e.g. a
         // rightsMD shared across files, common in Archivematica METS), which must survive.
         var referencedElsewhere = CollectSectionReferences(fullMets.Mets, [div], file);
+        MdSecType? DmdLookup(string id) => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id);
         var amdSecs = IdRefs.ResolveAll(admTokens, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id))
             .Where(a => !referencedElsewhere.Contains(a.Id))
             .ToList();
-        var dmdSecs = IdRefs.ResolveAll(div.Dmdid, id => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id))
+        // DMDID can sit on the div or (in third-party shapes) on the FILE element - resolve
+        // both, matching what CollectSectionReferences excludes from the survival index.
+        var dmdCandidates = IdRefs.ResolveAll(div.Dmdid, DmdLookup);
+        if (file is { Dmdid.Count: > 0 })
+        {
+            dmdCandidates = dmdCandidates.Concat(IdRefs.ResolveAll(file.Dmdid, DmdLookup)).Distinct().ToList();
+        }
+        var dmdSecs = dmdCandidates
             .Where(d => !referencedElsewhere.Contains(d.Id))
             .ToList();
 
@@ -421,7 +449,7 @@ public class MetsManager(
     /// candidate section in O(1) instead of re-walking the document per section. A section
     /// whose ID is in this set is genuinely shared and must survive the deletion.
     /// </summary>
-    private static HashSet<string> CollectSectionReferences(
+    internal static HashSet<string> CollectSectionReferences(
         DigitalPreservation.XmlGen.Mets.Mets mets,
         HashSet<DivType> excludedDivs,
         FileType? excludedFile)
@@ -487,10 +515,14 @@ public class MetsManager(
             fullMets.PhysicalDivsByPath.Remove(key);
         }
 
-        if (keys.Count > 0 && fullMets.HasDuplicatePaths)
+        if (fullMets.PathDiagnostics.Count > 0)
         {
-            // In a duplicate-path document another div may have been claiming one of the
-            // evicted paths - rebuild so the cache reflects post-delete reality.
+            // In a flagged document this delete may have changed what the diagnostics
+            // describe: another div may have been claiming an evicted path, or the deleted
+            // div may BE the one a diagnostic recorded (deletion is how broken content gets
+            // cleaned up). Rebuild so both the cache and the diagnostics reflect post-delete
+            // reality instead of load-time state - a fully healed document regains the
+            // trusted-cache fast path.
             MetsCache.Populate(fullMets);
         }
     }
@@ -963,9 +995,12 @@ public class MetsManager(
 
     public void SetStructMapOrder(FullMets mets, string[] ids)
     {
-        var logicalMaps = mets.Mets.StructMap
-            .Where(sm => sm.Type == Constants.Logical)
-            .ToDictionary(sm => sm.Div.Id);
+        // Tolerate malformed logical structMaps rather than throwing: one with no root div
+        // (or no root ID) cannot be ordered, and only the first of two claiming the same ID
+        // is ordered - the same first-wins convention navigation uses.
+        var logicalMaps = new Dictionary<string, StructMapType>();
+        foreach (var sm in mets.Mets.StructMap.Where(sm => sm.Type == Constants.Logical && sm.Div?.Id != null))
+            logicalMaps.TryAdd(sm.Div.Id, sm);
 
         foreach (var map in logicalMaps.Values)
             mets.Mets.StructMap.Remove(map);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -423,7 +423,7 @@ public class MetsManager(
     private static bool SectionReferencedElsewhere(
         DigitalPreservation.XmlGen.Mets.Mets mets,
         string sectionId,
-        ISet<DivType> excludedDivs,
+        HashSet<DivType> excludedDivs,
         FileType? excludedFile)
     {
         var referencingDivs = mets.StructMap

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Xml;
 using DigitalPreservation.Common.Model;
@@ -364,56 +363,48 @@ public class MetsManager(
             return Result.Fail(ErrorCodes.BadRequest, "Cannot delete a non-empty directory.");
         }
 
-        // Deletion is tolerant of dangling or absent references - a broken reference is
-        // exactly the kind of thing a delete may be cleaning up.
-        string? admId;
+        // Resolve everything BEFORE mutating anything, so a failed delete leaves the METS
+        // exactly as it was.
+        FileType? file = null;
+        MetsTypeFileSecFileGrp? fileGroup = null;
+        IReadOnlyList<string> admTokens;
         if (div is { Type: "Item" })
         {
-            var (file, fileGroup) = SetFileAndFileGroup(div, fullMets);
+            (file, fileGroup) = SetFileAndFileGroup(div, fullMets);
 
             if (MetsCache.NormalisePathKey(file.FLocat[0].Href) != operationPath)
             {
                 return Result.Fail(ErrorCodes.BadRequest, "Delete path doesn't match METS flocat");
             }
 
-            admId = JoinedIdOrNull(file.Admid);
-            fileGroup.File.Remove(file);
+            admTokens = file.Admid;
         }
         else
         {
-            admId = JoinedIdOrNull(div.Admid);
+            admTokens = div.Admid;
         }
 
-        RemoveById(fullMets.Mets.AmdSec, admId, a => a.Id);
-        RemoveById(fullMets.Mets.DmdSec, JoinedIdOrNull(div.Dmdid), d => d.Id);
+        // ADMID/DMDID are IDREFS token collections (see IdRefs). Deletion is tolerant of a
+        // section that doesn't resolve - a dangling reference is exactly the kind of breakage
+        // a delete may be cleaning up, and DMDID references dangle by design until metadata
+        // is first set (lazy dmdSec creation).
+        var amdSec = IdRefs.ResolveSingle(admTokens, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id));
+        var dmdSec = IdRefs.ResolveSingle(div.Dmdid, id => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id));
+
+        fileGroup?.File.Remove(file!);
+        if (amdSec != null)
+        {
+            fullMets.Mets.AmdSec.Remove(amdSec);
+        }
+        if (dmdSec != null)
+        {
+            fullMets.Mets.DmdSec.Remove(dmdSec);
+        }
 
         parent!.Div.Remove(div);
         EvictFromPathCache(fullMets, div);
 
         return Result.Ok();
-    }
-
-    /// <summary>
-    /// Legacy IDs containing spaces arrive from the XmlSerializer split into IDREFS tokens;
-    /// rejoining reconstructs the single intended ID. Null when there is no reference at all.
-    /// </summary>
-    private static string? JoinedIdOrNull(Collection<string> tokens) =>
-        tokens.Count switch
-        {
-            0 => null,
-            1 => tokens[0],
-            _ => string.Join(" ", tokens)
-        };
-
-    private static void RemoveById<T>(ICollection<T> sections, string? id, Func<T, string?> idOf)
-        where T : class
-    {
-        if (id is null) return;
-        var match = sections.FirstOrDefault(s => idOf(s) == id);
-        if (match != null)
-        {
-            sections.Remove(match);
-        }
     }
 
     /// <summary>

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -480,10 +480,7 @@ public class MetsManager(
 
     private static void AddReferences(IReadOnlyList<string> tokens, HashSet<string> referencedIds)
     {
-        foreach (var token in tokens)
-        {
-            referencedIds.Add(token);
-        }
+        referencedIds.UnionWith(tokens);
         if (tokens.Count > 1)
         {
             referencedIds.Add(IdRefs.Joined(tokens));

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -387,16 +387,23 @@ public class MetsManager(
         // ADMID/DMDID are IDREFS token collections (see IdRefs). Deletion is tolerant of a
         // section that doesn't resolve - a dangling reference is exactly the kind of breakage
         // a delete may be cleaning up, and DMDID references dangle by design until metadata
-        // is first set (lazy dmdSec creation).
-        var amdSec = IdRefs.ResolveSingle(admTokens, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id));
-        var dmdSec = IdRefs.ResolveSingle(div.Dmdid, id => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id));
+        // is first set (lazy dmdSec creation). A genuine multi-token reference removes EVERY
+        // section it resolves - except one that another div or file still references (e.g. a
+        // rightsMD shared across files, common in Archivematica METS), which must survive.
+        var doomed = new HashSet<DivType> { div };
+        var amdSecs = IdRefs.ResolveAll(admTokens, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id))
+            .Where(a => !SectionReferencedElsewhere(fullMets.Mets, a.Id, doomed, file))
+            .ToList();
+        var dmdSecs = IdRefs.ResolveAll(div.Dmdid, id => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id))
+            .Where(d => !SectionReferencedElsewhere(fullMets.Mets, d.Id, doomed, file))
+            .ToList();
 
         fileGroup?.File.Remove(file!);
-        if (amdSec != null)
+        foreach (var amdSec in amdSecs)
         {
             fullMets.Mets.AmdSec.Remove(amdSec);
         }
-        if (dmdSec != null)
+        foreach (var dmdSec in dmdSecs)
         {
             fullMets.Mets.DmdSec.Remove(dmdSec);
         }
@@ -405,6 +412,43 @@ public class MetsManager(
         EvictFromPathCache(fullMets, div);
 
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// True when any div (in any structMap) or file other than the ones being deleted still
+    /// references the section - as a single token, as one token of a genuine IDREFS list, or
+    /// as the joined form of a legacy space-containing ID. Guards deletion from removing a
+    /// section that is genuinely shared.
+    /// </summary>
+    private static bool SectionReferencedElsewhere(
+        DigitalPreservation.XmlGen.Mets.Mets mets,
+        string sectionId,
+        ISet<DivType> excludedDivs,
+        FileType? excludedFile)
+    {
+        var referencingDivs = mets.StructMap
+            .Where(sm => sm.Div != null)
+            .SelectMany(sm => SelfAndDescendants(sm.Div))
+            .Where(d => !excludedDivs.Contains(d))
+            .Any(d => IdRefs.References(d.Admid, sectionId) || IdRefs.References(d.Dmdid, sectionId));
+        if (referencingDivs)
+        {
+            return true;
+        }
+
+        return (mets.FileSec?.FileGrp ?? [])
+            .SelectMany(fg => fg.File)
+            .Where(f => !ReferenceEquals(f, excludedFile))
+            .Any(f => IdRefs.References(f.Admid, sectionId) || IdRefs.References(f.Dmdid, sectionId));
+    }
+
+    private static IEnumerable<DivType> SelfAndDescendants(DivType div)
+    {
+        yield return div;
+        foreach (var descendant in div.Div.SelectMany(SelfAndDescendants))
+        {
+            yield return descendant;
+        }
     }
 
     /// <summary>
@@ -879,16 +923,21 @@ public class MetsManager(
         return new DivTypeFptr { Fileid = fileId };
     }
 
-    private static void RemoveLogicalStructMapDmdSecs(FullMets mets, DivType div)
+    private static void RemoveLogicalStructMapDmdSecs(FullMets mets, DivType root)
     {
-        foreach (var dmdId in div.Dmdid)
+        // DMDID is an IDREFS token collection (see IdRefs): resolve it properly so a legacy
+        // space-containing dmdSec ID (split into tokens by the XmlSerializer) is found and
+        // removed, not silently orphaned. A dmdSec still referenced from outside the structMap
+        // being removed (e.g. shared with a physical div) survives.
+        var structMapDivs = new HashSet<DivType>(SelfAndDescendants(root));
+        foreach (var div in structMapDivs)
         {
-            var dmdSec = mets.Mets.DmdSec.FirstOrDefault(d => d.Id == dmdId);
-            if (dmdSec != null)
+            var dmdSecs = IdRefs
+                .ResolveAll(div.Dmdid, id => mets.Mets.DmdSec.FirstOrDefault(d => d.Id == id))
+                .Where(d => !SectionReferencedElsewhere(mets.Mets, d.Id, structMapDivs, null));
+            foreach (var dmdSec in dmdSecs)
                 mets.Mets.DmdSec.Remove(dmdSec);
         }
-        foreach (var child in div.Div)
-            RemoveLogicalStructMapDmdSecs(mets, child);
     }
 
     public void SetStructMapOrder(FullMets mets, string[] ids)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -478,7 +478,7 @@ public class MetsManager(
         return referencedIds;
     }
 
-    private static void AddReferences(IReadOnlyList<string> tokens, HashSet<string> referencedIds)
+    private static void AddReferences(System.Collections.ObjectModel.Collection<string> tokens, HashSet<string> referencedIds)
     {
         referencedIds.UnionWith(tokens);
         if (tokens.Count > 1)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -390,12 +390,12 @@ public class MetsManager(
         // is first set (lazy dmdSec creation). A genuine multi-token reference removes EVERY
         // section it resolves - except one that another div or file still references (e.g. a
         // rightsMD shared across files, common in Archivematica METS), which must survive.
-        var doomed = new HashSet<DivType> { div };
+        var referencedElsewhere = CollectSectionReferences(fullMets.Mets, [div], file);
         var amdSecs = IdRefs.ResolveAll(admTokens, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id))
-            .Where(a => !SectionReferencedElsewhere(fullMets.Mets, a.Id, doomed, file))
+            .Where(a => !referencedElsewhere.Contains(a.Id))
             .ToList();
         var dmdSecs = IdRefs.ResolveAll(div.Dmdid, id => fullMets.Mets.DmdSec.FirstOrDefault(d => d.Id == id))
-            .Where(d => !SectionReferencedElsewhere(fullMets.Mets, d.Id, doomed, file))
+            .Where(d => !referencedElsewhere.Contains(d.Id))
             .ToList();
 
         fileGroup?.File.Remove(file!);
@@ -415,31 +415,51 @@ public class MetsManager(
     }
 
     /// <summary>
-    /// True when any div (in any structMap) or file other than the ones being deleted still
-    /// references the section - as a single token, as one token of a genuine IDREFS list, or
-    /// as the joined form of a legacy space-containing ID. Guards deletion from removing a
-    /// section that is genuinely shared.
+    /// Every section ID referenced by any div (in any structMap) or file other than the ones
+    /// being deleted: each individual token, and the joined form of multi-token collections
+    /// (a legacy space-containing ID). Built in ONE traversal so deletion can check each
+    /// candidate section in O(1) instead of re-walking the document per section. A section
+    /// whose ID is in this set is genuinely shared and must survive the deletion.
     /// </summary>
-    private static bool SectionReferencedElsewhere(
+    private static HashSet<string> CollectSectionReferences(
         DigitalPreservation.XmlGen.Mets.Mets mets,
-        string sectionId,
         HashSet<DivType> excludedDivs,
         FileType? excludedFile)
     {
-        var referencingDivs = mets.StructMap
+        var referencedIds = new HashSet<string>();
+
+        var divs = mets.StructMap
             .Where(sm => sm.Div != null)
             .SelectMany(sm => SelfAndDescendants(sm.Div))
-            .Where(d => !excludedDivs.Contains(d))
-            .Any(d => IdRefs.References(d.Admid, sectionId) || IdRefs.References(d.Dmdid, sectionId));
-        if (referencingDivs)
+            .Where(d => !excludedDivs.Contains(d));
+        foreach (var d in divs)
         {
-            return true;
+            AddReferences(d.Admid, referencedIds);
+            AddReferences(d.Dmdid, referencedIds);
         }
 
-        return (mets.FileSec?.FileGrp ?? [])
+        var files = (mets.FileSec?.FileGrp ?? [])
             .SelectMany(fg => fg.File)
-            .Where(f => !ReferenceEquals(f, excludedFile))
-            .Any(f => IdRefs.References(f.Admid, sectionId) || IdRefs.References(f.Dmdid, sectionId));
+            .Where(f => !ReferenceEquals(f, excludedFile));
+        foreach (var f in files)
+        {
+            AddReferences(f.Admid, referencedIds);
+            AddReferences(f.Dmdid, referencedIds);
+        }
+
+        return referencedIds;
+    }
+
+    private static void AddReferences(IReadOnlyList<string> tokens, HashSet<string> referencedIds)
+    {
+        foreach (var token in tokens)
+        {
+            referencedIds.Add(token);
+        }
+        if (tokens.Count > 1)
+        {
+            referencedIds.Add(IdRefs.Joined(tokens));
+        }
     }
 
     private static IEnumerable<DivType> SelfAndDescendants(DivType div)
@@ -930,11 +950,12 @@ public class MetsManager(
         // removed, not silently orphaned. A dmdSec still referenced from outside the structMap
         // being removed (e.g. shared with a physical div) survives.
         var structMapDivs = new HashSet<DivType>(SelfAndDescendants(root));
+        var referencedElsewhere = CollectSectionReferences(mets.Mets, structMapDivs, null);
         foreach (var div in structMapDivs)
         {
             var dmdSecs = IdRefs
                 .ResolveAll(div.Dmdid, id => mets.Mets.DmdSec.FirstOrDefault(d => d.Id == id))
-                .Where(d => !SectionReferencedElsewhere(mets.Mets, d.Id, structMapDivs, null));
+                .Where(d => !referencedElsewhere.Contains(d.Id));
             foreach (var dmdSec in dmdSecs)
                 mets.Mets.DmdSec.Remove(dmdSec);
         }

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -326,8 +326,10 @@ public class MetsParser(
                 var admId = div.Attribute("ADMID")?.Value;
                 if (admId.HasText())
                 {
-                    // Use pre-built dictionary for O(1) lookup instead of LINQ query
-                    if (lookupMaps.AmdSecMap.TryGetValue(admId, out var amd))
+                    // IDREFS-aware: whole value first (single or legacy space-containing ID),
+                    // then per-token (schema-valid multi-reference)
+                    var amd = IdRefs.ResolveSingle(admId, id => lookupMaps.AmdSecMap.GetValueOrDefault(id));
+                    if (amd != null)
                     {
                         var originalName = amd.Descendants(XNames.PremisOriginalName).SingleOrDefault()?.Value;
                         Uri? storageLocation = null;
@@ -419,13 +421,13 @@ public class MetsParser(
                 VirusScanMetadata? virusScanMetadata = null;
                 ExifMetadata? exifMetadata = null;
                 ExtentMetadata? extentMetadata = null;
+                XElement? techMd = null;
                 if (!haveUsedAdmIdAlready && admId != null)
                 {
-                    if (!lookupMaps.TechMdMap.TryGetValue(admId, out var techMd))
-                    {
-                        // Archivematica does it this way - fall back to amdSec map
-                        lookupMaps.AmdSecMap.TryGetValue(admId, out techMd);
-                    }
+                    // IDREFS-aware, preserving the techMD-then-amdSec fallback per candidate id
+                    // (Archivematica points ADMID at the amdSec rather than the techMD)
+                    techMd = IdRefs.ResolveSingle(admId, id =>
+                        lookupMaps.TechMdMap.GetValueOrDefault(id) ?? lookupMaps.AmdSecMap.GetValueOrDefault(id));
 
                     if (techMd == null)
                     {
@@ -496,9 +498,10 @@ public class MetsParser(
                     } // end else (techMd != null)
                 }
 
-                // Use pre-built dictionary for O(1) lookup instead of LINQ query
-                // The digiprovMD ID has the form "digiprovMD_ClamAV_{admId}"
-                var clamavKey = $"{Constants.VirusProvEventPrefix}{admId}";
+                // The digiprovMD ID has the form "digiprovMD_ClamAV_{admId}". Derive the key
+                // from the RESOLVED amdSec/techMD's actual ID where we have one - for a
+                // genuine multi-token ADMID the raw attribute value is not an ID at all.
+                var clamavKey = $"{Constants.VirusProvEventPrefix}{techMd?.Attribute("ID")?.Value ?? admId}";
                 if (!lookupMaps.DigiprovMdMap.TryGetValue(clamavKey, out var digiprovMd))
                 {
                     // Fall back to a case-insensitive but EXACT match. A substring match here
@@ -557,9 +560,12 @@ public class MetsParser(
                 }
                 
                 
-                if (admId != null && lookupMaps.AmdSecMap.TryGetValue(admId, out var amd))
+                var exifAmd = admId == null
+                    ? null
+                    : IdRefs.ResolveSingle(admId, id => lookupMaps.AmdSecMap.GetValueOrDefault(id));
+                if (exifAmd != null)
                 {
-                    var exifMetadataNode = amd.Descendants("ExifMetadata").SingleOrDefault();
+                    var exifMetadataNode = exifAmd.Descendants("ExifMetadata").SingleOrDefault();
                
                     if (exifMetadataNode != null)
                     {
@@ -711,7 +717,8 @@ public class MetsParser(
 
         var dmdId = div.Attribute("DMDID")?.Value;
         if (!dmdId.HasText()) return (null, null, null, false);
-        if (!lookupMaps.DmdSecMap.TryGetValue(dmdId, out var dmd)) return (null, null, null, false);
+        var dmd = IdRefs.ResolveSingle(dmdId, id => lookupMaps.DmdSecMap.GetValueOrDefault(id));
+        if (dmd == null) return (null, null, null, false);
 
         foreach (var accessConditionEl in dmd.Descendants(XNames.ModsAccessCondition))
         {
@@ -1090,8 +1097,8 @@ public class MetsParser(
     {
         var dmdId = div.Attribute("DMDID")?.Value;
         if (!dmdId.HasText()) return null;
-        if (!lookupMaps.DmdSecMap.TryGetValue(dmdId, out var dmd)) return null;
-        return dmd.Descendants(XNames.ModsTitle).FirstOrDefault()?.Value;
+        var dmd = IdRefs.ResolveSingle(dmdId, id => lookupMaps.DmdSecMap.GetValueOrDefault(id));
+        return dmd?.Descendants(XNames.ModsTitle).FirstOrDefault()?.Value;
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsParser.cs
@@ -498,21 +498,31 @@ public class MetsParser(
                     } // end else (techMd != null)
                 }
 
-                // The digiprovMD ID has the form "digiprovMD_ClamAV_{admId}". Derive the key
-                // from the RESOLVED amdSec/techMD's actual ID where we have one - for a
-                // genuine multi-token ADMID the raw attribute value is not an ID at all.
-                var clamavKey = $"{Constants.VirusProvEventPrefix}{techMd?.Attribute("ID")?.Value ?? admId}";
-                if (!lookupMaps.DigiprovMdMap.TryGetValue(clamavKey, out var digiprovMd))
+                // The virus-scan event is a digiprovMD in the same amdSec as the file's
+                // techMD, so read it structurally from the RESOLVED element (identified among
+                // its siblings by the platform's "digiprovMD_ClamAV_" ID prefix) rather than
+                // deriving its full ID by string convention - the derived key breaks for
+                // genuine multi-token ADMIDs and for IDs the platform didn't mint.
+                var amdScope = techMd?.Name == XNames.MetsAmdSec ? techMd : techMd?.Parent;
+                var digiprovMd = amdScope?.Elements(XNames.MetsDigiprovMD)
+                    .FirstOrDefault(d => (d.Attribute("ID")?.Value ?? "")
+                        .StartsWith(Constants.VirusProvEventPrefix, StringComparison.OrdinalIgnoreCase));
+                if (digiprovMd == null)
                 {
-                    // Fall back to a case-insensitive but EXACT match. A substring match here
+                    // Conventional-key fallback for documents where nothing resolved
+                    // structurally. Case-insensitive but EXACT match - a substring match here
                     // cross-talks between files whose IDs are prefixes of each other
                     // (e.g. "ADM_a" is contained in "ADM_a2"), returning one file's virus-scan
                     // event for a different file.
-                    var matchingKey = lookupMaps.DigiprovMdMap.Keys
-                        .FirstOrDefault(k => string.Equals(k, clamavKey, StringComparison.OrdinalIgnoreCase));
-                    if (matchingKey != null)
+                    var clamavKey = $"{Constants.VirusProvEventPrefix}{techMd?.Attribute("ID")?.Value ?? admId}";
+                    if (!lookupMaps.DigiprovMdMap.TryGetValue(clamavKey, out digiprovMd))
                     {
-                        digiprovMd = lookupMaps.DigiprovMdMap[matchingKey];
+                        var matchingKey = lookupMaps.DigiprovMdMap.Keys
+                            .FirstOrDefault(k => string.Equals(k, clamavKey, StringComparison.OrdinalIgnoreCase));
+                        if (matchingKey != null)
+                        {
+                            digiprovMd = lookupMaps.DigiprovMdMap[matchingKey];
+                        }
                     }
                 }
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -183,7 +183,7 @@ public static class ModsManager
         // If clearing the last piece of metadata has left the MODS carrying nothing,
         // don't write an empty <mods/> shell wrapped in a redundant dmdSec — prune it.
         // Only do so when it is safe: the dmdSec must wrap MODS and nothing else.
-        if (mods.IsEmpty() && TryRemoveRedundantDmd(mets, div, normalised))
+        if (mods.IsEmpty() && TryRemoveRedundantDmd(mets, div, dmd))
         {
             return;
         }
@@ -192,16 +192,16 @@ public static class ModsManager
     }
 
     /// <summary>
-    /// Removes the dmdSec addressed by <paramref name="dmdId"/> together with the div's
-    /// (now dangling) DMDID reference, but ONLY when it is safe: the dmdSec must carry
-    /// nothing beyond the MODS we are clearing — no external mdRef, no admin links and
-    /// no other identifying attributes. Returns <c>true</c> if the dmdSec was removed
+    /// Removes the resolved dmdSec together with the div's DMDID reference to it, but ONLY
+    /// when it is safe: the dmdSec must carry nothing beyond the MODS we are clearing — no
+    /// external mdRef, no admin links and no other identifying attributes. Only the reference
+    /// to THIS dmdSec is dropped: a div with a genuine multi-token DMDID keeps its other
+    /// references (and their dmdSecs) intact. Returns <c>true</c> if the dmdSec was removed
     /// (or there was nothing to remove), <c>false</c> if it had to be kept because it
     /// still carries other information.
     /// </summary>
-    private static bool TryRemoveRedundantDmd(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, string dmdId)
+    private static bool TryRemoveRedundantDmd(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, MdSecType? dmd)
     {
-        var dmd = string.IsNullOrEmpty(dmdId) ? null : mets.DmdSec.FirstOrDefault(d => d.Id == dmdId);
         if (dmd != null)
         {
             if (!DmdSecWrapsOnlyMods(dmd))
@@ -210,10 +210,14 @@ public static class ModsManager
                 return false;
             }
             mets.DmdSec.Remove(dmd);
+            IdRefs.RemoveReference(div.Dmdid, dmd.Id);
         }
-
-        // Drop the div's now-dangling DMDID reference (a no-op if it was never set).
-        div.Dmdid.Clear();
+        else
+        {
+            // Nothing resolved at all: every token dangles, so clearing them is cleanup
+            // (and a no-op if DMDID was never set).
+            div.Dmdid.Clear();
+        }
         return true;
     }
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -122,7 +122,7 @@ public static class ModsManager
 
     public static ModsDefinition? GetModsForDmdId(DigitalPreservation.XmlGen.Mets.Mets mets, string dmdId, bool createDmd = false)
     {
-        var dmd = mets.DmdSec.SingleOrDefault(x => x.Id == dmdId);
+        var dmd = mets.DmdSec.FirstOrDefault(x => x.Id == dmdId);
         if (dmd == null && createDmd)
         {
             dmd = new MdSecType
@@ -168,14 +168,17 @@ public static class ModsManager
                 div.Dmdid.Add(Constants.DmdIdPrefix + div.Id);
             }
         }
-        var normalised = string.Join(' ', div.Dmdid);
-        return GetModsForDmdId(mets, normalised, createDmd);
+        // Resolve the DMDID tokens to the actual dmdSec where one exists; the id used for
+        // lazy creation is the joined legacy form only when no dmdSec resolves (see IdRefs).
+        var dmd = IdRefs.ResolveSingle(div.Dmdid, id => mets.DmdSec.FirstOrDefault(x => x.Id == id));
+        return GetModsForDmdId(mets, dmd?.Id ?? IdRefs.Joined(div.Dmdid), createDmd);
     }
 
     
     public static void SetModsForDiv(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, ModsDefinition mods)
     {
-        var normalised = string.Join(' ', div.Dmdid);
+        var dmd = IdRefs.ResolveSingle(div.Dmdid, id => mets.DmdSec.FirstOrDefault(x => x.Id == id));
+        var normalised = dmd?.Id ?? IdRefs.Joined(div.Dmdid);
 
         // If clearing the last piece of metadata has left the MODS carrying nothing,
         // don't write an empty <mods/> shell wrapped in a redundant dmdSec — prune it.

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -219,7 +219,15 @@ public static class ModsManager
                 // The dmdSec carries information beyond the MODS we are clearing; leave it intact.
                 return false;
             }
-            mets.DmdSec.Remove(dmd);
+
+            // Parity with the deletion sites' shared-section guard: a dmdSec that another
+            // div or file still references is genuinely shared, so clearing THIS div's MODS
+            // drops only this div's reference and leaves the section (and its other
+            // referrers) untouched.
+            if (!MetsManager.CollectSectionReferences(mets, [div], null).Contains(dmd.Id))
+            {
+                mets.DmdSec.Remove(dmd);
+            }
             IdRefs.RemoveReference(div.Dmdid, dmd.Id);
 
             // Sweep any sibling tokens that resolve nothing (the pre-existing Clear()

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -153,6 +153,12 @@ public static class ModsManager
         return null;
     }
 
+    /// <summary>
+    /// The MODS for a div. When the div's DMDID is a genuine multi-token reference, the FIRST
+    /// dmdSec a token resolves is treated as the div's editable MODS record; the platform only
+    /// ever writes one descriptive record per div, so any further referenced dmdSecs are
+    /// third-party content that read/write operations deliberately leave untouched.
+    /// </summary>
     public static ModsDefinition? GetModsForDiv(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, bool createDmd = false)
     {
         if (div.Dmdid.Count == 0 && createDmd)
@@ -175,6 +181,10 @@ public static class ModsManager
     }
 
     
+    /// <summary>
+    /// Write the div's MODS record - the same single dmdSec <see cref="GetModsForDiv"/>
+    /// resolves; other dmdSecs a genuine multi-token DMDID references are never mutated.
+    /// </summary>
     public static void SetModsForDiv(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, ModsDefinition mods)
     {
         var dmd = IdRefs.ResolveSingle(div.Dmdid, id => mets.DmdSec.FirstOrDefault(x => x.Id == id));
@@ -211,6 +221,18 @@ public static class ModsManager
             }
             mets.DmdSec.Remove(dmd);
             IdRefs.RemoveReference(div.Dmdid, dmd.Id);
+
+            // Sweep any sibling tokens that resolve nothing (the pre-existing Clear()
+            // behaviour, scoped): they are dangling, while a token still naming a real
+            // dmdSec keeps both its reference and its section.
+            for (var i = div.Dmdid.Count - 1; i >= 0; i--)
+            {
+                var token = div.Dmdid[i];
+                if (mets.DmdSec.All(d => d.Id != token))
+                {
+                    div.Dmdid.RemoveAt(i);
+                }
+            }
         }
         else
         {

--- a/src/DigitalPreservation/XmlGen.Tests/CacheMutationConsistencyTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/CacheMutationConsistencyTests.cs
@@ -1,0 +1,151 @@
+using System.Xml;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using DigitalPreservation.XmlGen.Mets;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// The path cache must stay truthful under mutation even when a document's metadata
+/// disagrees with its tree structure (edited or third-party METS): a mutation that creates
+/// a duplicate-path state must RECORD it (diagnostics/HasDuplicatePaths) rather than
+/// silently overwrite a cache entry, and a delete in a flagged document must refresh the
+/// diagnostics so a healed document regains the trusted-cache fast path.
+/// </summary>
+public class CacheMutationConsistencyTests
+{
+    private readonly MetsManager metsManager;
+
+    private const string TestDigest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f";
+
+    public CacheMutationConsistencyTests()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parser = new MetsParser(new FileSystemMetsLoader(), factory!.CreateLogger<MetsParser>());
+        var metsStorage = new FileSystemMetsStorage(parser);
+        var metadataManager = new MetadataManager(
+            new PremisManager(), new PremisManagerExif(), new PremisEventManagerVirus());
+        metsManager = new MetsManager(parser, metsStorage, metadataManager);
+    }
+
+    private async Task<FullMets> CreateAndLoadStandardMets(string outputFileName)
+    {
+        var fi = new FileInfo($"Outputs/{outputFileName}");
+        var uri = new Uri(fi.FullName);
+        var createResult = await metsManager.CreateStandardMets(uri, "Cache Consistency Test METS");
+        createResult.Success.Should().BeTrue(createResult.ErrorMessage ?? "");
+        var loadResult = await metsManager.GetFullMets(uri, createResult.Value!.ETag);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        return loadResult.Value!;
+    }
+
+    private static WorkingFile SimpleFile(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            ContentType = "application/pdf",
+            Digest = TestDigest,
+            Size = 54321,
+            Modified = DateTime.UtcNow
+        };
+
+    private static void RewriteOriginalName(FullMets fullMets, DivType div, string newPath)
+    {
+        var amdSec = IdRefs.ResolveSingle(div.Admid,
+            id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id))!;
+        var premisXml = (XmlElement)amdSec.TechMd.First().MdWrap!.XmlData.Any.First();
+        var originalName = premisXml
+            .GetElementsByTagName("originalName", XNames.premis.NamespaceName)
+            .OfType<XmlElement>()
+            .First();
+        originalName.InnerText = newPath;
+    }
+
+    [Fact]
+    public async Task Adding_At_A_Path_Claimed_By_A_Foreign_Div_Records_A_Duplicate()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-foreign-claim.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
+        var adHocDiv = metadataDiv.Div.Single();
+
+        // A div under metadata/ whose premis:originalName claims a path under objects/ -
+        // resolvable and unique at (re)load, so the document carries no diagnostics and the
+        // cache trusts the foreign claim.
+        RewriteOriginalName(fullMets, adHocDiv, "objects/clash.pdf");
+        MetsCache.Populate(fullMets).Should().BeEmpty();
+        fullMets.PhysicalDivsByPath["objects/clash.pdf"].Should().BeSameAs(adHocDiv);
+
+        // Adding a real file at the claimed path succeeds, and the resulting duplicate-path
+        // state is RECORDED rather than silently overwriting the foreign div's cache entry.
+        var firstAdd = metsManager.AddToMets(fullMets, SimpleFile("objects/clash.pdf", "clash.pdf"));
+        firstAdd.Success.Should().BeTrue(firstAdd.ErrorMessage ?? "");
+        fullMets.HasDuplicatePaths.Should().BeTrue();
+        fullMets.PathDiagnostics.Should().Contain(d => d.Contains("objects/clash.pdf"));
+
+        // The next mutation must not trip the cache-consistency assertion (it previously
+        // threw InvalidOperationException in DEBUG builds).
+        var secondAdd = metsManager.AddToMets(fullMets, SimpleFile("objects/after.pdf", "after.pdf"));
+        secondAdd.Success.Should().BeTrue(secondAdd.ErrorMessage ?? "");
+    }
+
+    [Fact]
+    public async Task Deleting_The_Contested_File_In_A_Duplicate_Path_Document_Heals_It()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-duplicate-heal.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
+        var adHocDiv = metadataDiv.Div.Single();
+
+        RewriteOriginalName(fullMets, adHocDiv, "objects/clash.pdf");
+        MetsCache.Populate(fullMets);
+        metsManager.AddToMets(fullMets, SimpleFile("objects/clash.pdf", "clash.pdf"))
+            .Success.Should().BeTrue();
+        fullMets.HasDuplicatePaths.Should().BeTrue();
+
+        // Deleting the real file leaves only the foreign claim - the rebuild on delete must
+        // reflect that: the duplicate diagnostic is gone and the claim owns the path again.
+        var delete = metsManager.DeleteFromMets(fullMets, "objects/clash.pdf");
+
+        delete.Success.Should().BeTrue(delete.ErrorMessage ?? "");
+        fullMets.HasDuplicatePaths.Should().BeFalse();
+        fullMets.PathDiagnostics.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath["objects/clash.pdf"].Should().BeSameAs(adHocDiv);
+    }
+
+    [Fact]
+    public async Task Deleting_The_Div_A_Diagnostic_Describes_Clears_The_Diagnostic()
+    {
+        var fullMets = await CreateAndLoadStandardMets("cache-ghost-cleanup.xml");
+        var addDir = metsManager.AddToMets(fullMets, new WorkingDirectory
+        {
+            LocalPath = "objects/ghost",
+            Name = "ghost",
+            Modified = DateTime.UtcNow
+        });
+        addDir.Success.Should().BeTrue(addDir.ErrorMessage ?? "");
+
+        // Break the div: no ADMID means no resolvable path, so a rebuild records a
+        // diagnostic and the trusted-cache fast path is off for the whole document.
+        var ghostDiv = fullMets.PhysicalDivsByPath["objects/ghost"];
+        ghostDiv.Admid.Clear();
+        MetsCache.Populate(fullMets).Should().NotBeEmpty();
+
+        // Deletion is how broken content gets cleaned up - and a successful cleanup must
+        // take its diagnostic with it, restoring the trusted-cache fast path.
+        var delete = metsManager.DeleteFromMets(fullMets, "objects/ghost");
+
+        delete.Success.Should().BeTrue(delete.ErrorMessage ?? "");
+        fullMets.PathDiagnostics.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/ghost");
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
@@ -1,6 +1,9 @@
 using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Mets.StorageImpl;
+using DigitalPreservation.XmlGen.Mets;
+using DigitalPreservation.XmlGen.Mods.V3;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -131,6 +134,81 @@ public class IdRefsMetsManagerTests
         deleteFile.Success.Should().BeTrue(deleteFile.ErrorMessage ?? "");
         fileGroup.File.Should().BeEmpty();
         fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/orphan.pdf");
+    }
+
+    [Fact]
+    public async Task Deleting_A_File_With_Genuine_Multi_Admid_Removes_Its_Sections_But_Keeps_Shared_Ones()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-multi-admid-delete.xml");
+        metsManager.AddToMets(fullMets, SimpleFile("objects/a.pdf", "a.pdf")).Success.Should().BeTrue();
+        metsManager.AddToMets(fullMets, SimpleFile("objects/b.pdf", "b.pdf")).Success.Should().BeTrue();
+
+        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        var fileA = fileGroup.File.Single(
+            f => f.Id == fullMets.PhysicalDivsByPath["objects/a.pdf"].Fptr[0].Fileid);
+        var fileB = fileGroup.File.Single(
+            f => f.Id == fullMets.PhysicalDivsByPath["objects/b.pdf"].Fptr[0].Fileid);
+        var ownAdmId = fileA.Admid.Single();
+
+        // Give a.pdf a genuine multi-token ADMID: its own amdSec, an extra section of its
+        // own, and a section shared with b.pdf (the Archivematica shared-rightsMD pattern).
+        fullMets.Mets.AmdSec.Add(new AmdSecType { Id = "ADM_rights_a" });
+        fullMets.Mets.AmdSec.Add(new AmdSecType { Id = "ADM_rights_shared" });
+        fileA.Admid.Add("ADM_rights_a");
+        fileA.Admid.Add("ADM_rights_shared");
+        fileB.Admid.Add("ADM_rights_shared");
+
+        var delete = metsManager.DeleteFromMets(fullMets, "objects/a.pdf");
+
+        delete.Success.Should().BeTrue(delete.ErrorMessage ?? "");
+        fullMets.Mets.AmdSec.Should().NotContain(a => a.Id == ownAdmId);
+        fullMets.Mets.AmdSec.Should().NotContain(a => a.Id == "ADM_rights_a");
+        fullMets.Mets.AmdSec.Should().Contain(a => a.Id == "ADM_rights_shared");
+    }
+
+    [Fact]
+    public async Task Replacing_A_Logical_StructMap_Removes_A_Legacy_Spaced_DmdSec()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-logical-replace.xml");
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "RANGE_1", Type = "Sequence" });
+
+        // Simulate a legacy structMap div carrying a space-containing DMDID: the
+        // XmlSerializer delivers it as two tokens, but the dmdSec ID is the whole string.
+        var logical = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Logical);
+        fullMets.Mets.DmdSec.Add(new MdSecType { Id = "DMD_my range" });
+        logical.Div.Dmdid.Add("DMD_my");
+        logical.Div.Dmdid.Add("range");
+
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "RANGE_1", Type = "Sequence" });
+
+        fullMets.Mets.DmdSec.Should().NotContain(d => d.Id == "DMD_my range");
+        fullMets.Mets.StructMap.Count(sm => sm.Type == Constants.Logical).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Clearing_Mods_On_A_Div_With_Genuine_Multi_Dmdid_Keeps_The_Other_DmdSec()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-multi-dmdid-mods.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+
+        // Give the div MODS content (lazily creating its own dmdSec)...
+        var mods = ModsManager.GetModsForDiv(fullMets.Mets, objectsDiv, createDmd: true)!;
+        mods.AddAccessCondition("Restricted", Constants.RestrictionOnAccess);
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, mods);
+        var ownDmdId = objectsDiv.Dmdid.Single();
+
+        // ...then a second, genuine reference to another real dmdSec.
+        fullMets.Mets.DmdSec.Add(new MdSecType { Id = "DMD_other" });
+        objectsDiv.Dmdid.Add("DMD_other");
+
+        // Clearing the MODS must prune only the div's own (now empty) dmdSec and its
+        // reference - not the other genuinely-referenced dmdSec.
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, new ModsDefinition());
+
+        fullMets.Mets.DmdSec.Should().NotContain(d => d.Id == ownDmdId);
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == "DMD_other");
+        objectsDiv.Dmdid.Should().Equal("DMD_other");
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
@@ -1,0 +1,150 @@
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// MetsManager-side IDREFS handling (IdRefs): legacy space-containing IDs arrive from the
+/// XmlSerializer as several tokens and must resolve via the rejoined form, while genuine
+/// multi-reference IDREFS must resolve per token. Deletion is tolerant of references that
+/// don't resolve. See docs/issues/188/issue-188-idrefs-plan.md.
+/// </summary>
+public class IdRefsMetsManagerTests
+{
+    private readonly MetsManager metsManager;
+    private readonly FileSystemMetsStorage metsStorage;
+
+    private const string TestDigest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f";
+
+    public IdRefsMetsManagerTests()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        var parser = new MetsParser(metsLoader, parserLogger);
+        metsStorage = new FileSystemMetsStorage(parser);
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManager = new PremisEventManagerVirus();
+        var metadataManager = new MetadataManager(premisManager, premisManagerExif, premisEventManager);
+        metsManager = new MetsManager(parser, metsStorage, metadataManager);
+    }
+
+    private async Task<FullMets> CreateAndLoadStandardMets(string outputFileName)
+    {
+        var fi = new FileInfo($"Outputs/{outputFileName}");
+        var uri = new Uri(fi.FullName);
+        var createResult = await metsManager.CreateStandardMets(uri, "IdRefs Test METS");
+        createResult.Success.Should().BeTrue(createResult.ErrorMessage ?? "");
+        var loadResult = await metsManager.GetFullMets(uri, createResult.Value!.ETag);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        return loadResult.Value!;
+    }
+
+    private static Uri CopyFixture(string fixtureName, string outputName)
+    {
+        var source = new FileInfo($"Samples/{fixtureName}");
+        var dest = new FileInfo($"Outputs/{outputName}");
+        File.Copy(source.FullName, dest.FullName, overwrite: true);
+        return new Uri(dest.FullName);
+    }
+
+    private static WorkingFile SimpleFile(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            ContentType = "application/pdf",
+            Digest = TestDigest,
+            Size = 54321,
+            Modified = DateTime.UtcNow
+        };
+
+    [Fact]
+    public async Task Directory_With_Genuine_Multi_Token_Admid_Resolves_Via_A_Later_Token()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-multi-admid.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+
+        // A genuine two-reference ADMID: the first token resolves nothing, the second is the
+        // real objects amdSec (carrying premis:originalName).
+        objectsDiv.Admid.Insert(0, "ADM_missing");
+
+        var diagnostics = MetsCache.Populate(fullMets);
+
+        diagnostics.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath[FolderNames.Objects].Should().BeSameAs(objectsDiv);
+
+        // And navigation-dependent editing still works
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/multi.pdf", "multi.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+    }
+
+    [Fact]
+    public async Task Deleting_A_Div_With_A_Dangling_Dmdid_Succeeds()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-dangling-dmdid.xml");
+        var addDir = metsManager.AddToMets(fullMets, new WorkingDirectory
+        {
+            LocalPath = "objects/sub",
+            Name = "sub",
+            Modified = DateTime.UtcNow
+        });
+        addDir.Success.Should().BeTrue(addDir.ErrorMessage ?? "");
+
+        // DMDID references dangle by design until metadata is first set (lazy dmdSec
+        // creation) - deleting such a div must not fail on the unresolvable reference.
+        fullMets.PhysicalDivsByPath["objects/sub"].Dmdid.Add("DMD_dangling");
+
+        var deleteDir = metsManager.DeleteFromMets(fullMets, "objects/sub");
+
+        deleteDir.Success.Should().BeTrue(deleteDir.ErrorMessage ?? "");
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/sub");
+    }
+
+    [Fact]
+    public async Task Deleting_A_File_Whose_AmdSec_Is_Missing_Succeeds()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-missing-amdsec.xml");
+        var addFile = metsManager.AddToMets(fullMets, SimpleFile("objects/orphan.pdf", "orphan.pdf"));
+        addFile.Success.Should().BeTrue(addFile.ErrorMessage ?? "");
+
+        // Break the METS: remove the file's amdSec, leaving its ADMID dangling. Deletion is
+        // how broken content gets cleaned up, so it must still succeed.
+        var div = fullMets.PhysicalDivsByPath["objects/orphan.pdf"];
+        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        var file = fileGroup.File.Single(f => f.Id == div.Fptr[0].Fileid);
+        var amdSec = IdRefs.ResolveSingle(file.Admid, id => fullMets.Mets.AmdSec.FirstOrDefault(a => a.Id == id));
+        fullMets.Mets.AmdSec.Remove(amdSec!);
+
+        var deleteFile = metsManager.DeleteFromMets(fullMets, "objects/orphan.pdf");
+
+        deleteFile.Success.Should().BeTrue(deleteFile.ErrorMessage ?? "");
+        fileGroup.File.Should().BeEmpty();
+        fullMets.PhysicalDivsByPath.Should().NotContainKey("objects/orphan.pdf");
+    }
+
+    [Fact]
+    public async Task Updating_A_Legacy_Spaced_File_Resolves_Its_AmdSec_Via_The_Rejoined_Tokens()
+    {
+        // The frozen fixture's file IDs contain spaces, so ADMID arrives as multiple tokens;
+        // updating the file exercises MetadataManager's amdSec resolution through IdRefs.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "idrefs-legacy-update.xml");
+        var loadResult = await metsStorage.GetFullMets(metsUri, null);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        var fullMets = loadResult.Value!;
+
+        var update = metsManager.AddToMets(fullMets, SimpleFile("objects/my file.pdf", "my file.pdf"));
+
+        update.Success.Should().BeTrue(update.ErrorMessage ?? "");
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
@@ -212,6 +212,55 @@ public class IdRefsMetsManagerTests
     }
 
     [Fact]
+    public async Task Clearing_Mods_Sweeps_Dangling_Sibling_Tokens_But_Keeps_Live_Ones()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-dangling-sibling-sweep.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+
+        var mods = ModsManager.GetModsForDiv(fullMets.Mets, objectsDiv, createDmd: true)!;
+        mods.AddAccessCondition("Restricted", Constants.RestrictionOnAccess);
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, mods);
+        var ownDmdId = objectsDiv.Dmdid.Single();
+
+        // A three-token DMDID: the div's own dmdSec, a dangling token, and a live reference.
+        fullMets.Mets.DmdSec.Add(new MdSecType { Id = "DMD_other" });
+        objectsDiv.Dmdid.Add("DMD_dangling");
+        objectsDiv.Dmdid.Add("DMD_other");
+
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, new ModsDefinition());
+
+        // Own dmdSec pruned, dangling sibling swept, live reference (and its dmdSec) kept.
+        fullMets.Mets.DmdSec.Should().NotContain(d => d.Id == ownDmdId);
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == "DMD_other");
+        objectsDiv.Dmdid.Should().Equal("DMD_other");
+    }
+
+    [Fact]
+    public async Task Setting_Mods_On_A_Div_With_Genuine_Multi_Dmdid_Never_Mutates_The_Other_DmdSec()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-multi-dmdid-set.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+
+        var mods = ModsManager.GetModsForDiv(fullMets.Mets, objectsDiv, createDmd: true)!;
+        var ownDmdId = objectsDiv.Dmdid.Single();
+        var otherDmd = new MdSecType { Id = "DMD_other" };
+        fullMets.Mets.DmdSec.Add(otherDmd);
+        objectsDiv.Dmdid.Add("DMD_other");
+
+        // The first-resolving dmdSec is the div's editable MODS record; the second referenced
+        // dmdSec is third-party content and must come through a write completely untouched.
+        mods.AddAccessCondition("Restricted", Constants.RestrictionOnAccess);
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, mods);
+
+        ModsManager.GetModsForDiv(fullMets.Mets, objectsDiv)!
+            .GetAccessConditions(Constants.RestrictionOnAccess).Should().Equal("Restricted");
+        otherDmd.MdWrap.Should().BeNull();
+        objectsDiv.Dmdid.Should().Equal(ownDmdId, "DMD_other");
+    }
+
+    [Fact]
     public async Task Updating_A_Legacy_Spaced_File_Resolves_Its_AmdSec_Via_The_Rejoined_Tokens()
     {
         // The frozen fixture's file IDs contain spaces, so ADMID arrives as multiple tokens;

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsMetsManagerTests.cs
@@ -261,6 +261,78 @@ public class IdRefsMetsManagerTests
     }
 
     [Fact]
+    public async Task Clearing_Mods_On_One_Referrer_Of_A_Shared_DmdSec_Keeps_The_Section()
+    {
+        var fullMets = await CreateAndLoadStandardMets("idrefs-shared-dmdid-clear.xml");
+        var physRoot = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var metadataDiv = physRoot.Div.Single(d => d.Label == FolderNames.Metadata);
+
+        var mods = ModsManager.GetModsForDiv(fullMets.Mets, objectsDiv, createDmd: true)!;
+        mods.AddAccessCondition("Restricted", Constants.RestrictionOnAccess);
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, mods);
+        var sharedDmdId = objectsDiv.Dmdid.Single();
+
+        // A second div genuinely references the same dmdSec (Goobi-style sharing).
+        metadataDiv.Dmdid.Add(sharedDmdId);
+
+        // Clearing the FIRST referrer's MODS drops only its reference - the shared section
+        // and the other referrer are untouched (parity with the deletion sites' guard).
+        ModsManager.SetModsForDiv(fullMets.Mets, objectsDiv, new ModsDefinition());
+
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == sharedDmdId);
+        objectsDiv.Dmdid.Should().BeEmpty();
+        metadataDiv.Dmdid.Should().Contain(sharedDmdId);
+    }
+
+    [Fact]
+    public async Task Legacy_Spaced_Div_Mods_Can_Be_Set_Read_Back_And_Cleared()
+    {
+        // The frozen fixture's div IDs contain spaces, so the derived DMDID
+        // ("DMD_objects/my file.pdf") splits into tokens on serialization - setting,
+        // re-reading and clearing MODS must all resolve it via the rejoined form.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "idrefs-legacy-mods.xml");
+        var loadResult = await metsStorage.GetFullMets(metsUri, null);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        var fullMets = loadResult.Value!;
+        var spacedDiv = fullMets.PhysicalDivsByPath["objects/my file.pdf"];
+
+        var mods = ModsManager.GetModsForDiv(fullMets.Mets, spacedDiv, createDmd: true)!;
+        mods.AddAccessCondition("Restricted", Constants.RestrictionOnAccess);
+        ModsManager.SetModsForDiv(fullMets.Mets, spacedDiv, mods);
+
+        ModsManager.GetModsForDiv(fullMets.Mets, spacedDiv)!
+            .GetAccessConditions(Constants.RestrictionOnAccess).Should().Equal("Restricted");
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == "DMD_objects/my file.pdf");
+
+        ModsManager.SetModsForDiv(fullMets.Mets, spacedDiv, new ModsDefinition());
+
+        fullMets.Mets.DmdSec.Should().NotContain(d => d.Id == "DMD_objects/my file.pdf");
+        spacedDiv.Dmdid.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Legacy_Spaced_SmLinks_Reference_File_Ids_That_Exist_In_The_FileSec()
+    {
+        // Pins the invariant issue #188 step 2 must preserve: a link minted against a LEGACY
+        // document must reference the FILE element's ACTUAL (raw, space-containing) ID.
+        // If step 2 changes LinkFile to mint encoded IDs instead of resolving real ones,
+        // this test fails - see the step 2 checklist in issue-188-plan.md.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "idrefs-legacy-smlink.xml");
+        var loadResult = await metsStorage.GetFullMets(metsUri, null);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        var fullMets = loadResult.Value!;
+
+        metsManager.LinkFile(fullMets, "objects/my file.pdf", "objects/my file.pdf",
+            new Uri("http://example.org/roles/transcription-of"));
+
+        var link = fullMets.Mets.StructLink!.SmLink.OfType<StructLinkTypeSmLink>().Single();
+        var fileIds = fullMets.Mets.FileSec.FileGrp.SelectMany(fg => fg.File).Select(f => f.Id).ToList();
+        fileIds.Should().Contain(link.From);
+        fileIds.Should().Contain(link.To);
+    }
+
+    [Fact]
     public async Task Updating_A_Legacy_Spaced_File_Resolves_Its_AmdSec_Via_The_Rejoined_Tokens()
     {
         // The frozen fixture's file IDs contain spaces, so ADMID arrives as multiple tokens;

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
@@ -107,4 +107,108 @@ public class IdRefsTests
     {
         IdRefs.ResolveSingle("ADM_nope ADM_also_nope", Lookup).Should().BeNull();
     }
+
+    [Theory]
+    [InlineData("ADM_missing\tADM_B")]
+    [InlineData("ADM_missing\nADM_B")]
+    [InlineData("ADM_missing\r\nADM_B")]
+    public void Idrefs_attribute_value_splits_on_any_xml_whitespace(string attributeValue)
+    {
+        // XML permits tab/newline/CR as IDREFS separators, not just spaces
+        IdRefs.ResolveSingle(attributeValue, Lookup).Should().Be("b");
+    }
+
+    // -----------------------------------------------------------------------
+    // ResolveAll (deletion sites: every referenced element, not just the first)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ResolveAll_of_an_empty_collection_is_empty()
+    {
+        IdRefs.ResolveAll(Array.Empty<string>(), Lookup).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ResolveAll_of_a_single_token_resolves_that_element()
+    {
+        IdRefs.ResolveAll(new[] { "ADM_A" }, Lookup).Should().Equal("a");
+    }
+
+    [Fact]
+    public void ResolveAll_of_legacy_spaced_tokens_is_exactly_the_one_legacy_element()
+    {
+        IdRefs.ResolveAll(new[] { "ADM_objects/my", "file.pdf" }, Lookup)
+            .Should().Equal("legacy-spaced");
+    }
+
+    [Fact]
+    public void ResolveAll_of_a_genuine_idrefs_list_resolves_every_token()
+    {
+        IdRefs.ResolveAll(new[] { "ADM_A", "ADM_B" }, Lookup).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void ResolveAll_skips_tokens_that_do_not_resolve()
+    {
+        IdRefs.ResolveAll(new[] { "ADM_missing", "ADM_B" }, Lookup).Should().Equal("b");
+    }
+
+    [Fact]
+    public void ResolveAll_returns_distinct_elements_for_duplicate_tokens()
+    {
+        IdRefs.ResolveAll(new[] { "ADM_A", "ADM_A" }, Lookup).Should().Equal("a");
+    }
+
+    // -----------------------------------------------------------------------
+    // References / RemoveReference (pure token-collection bookkeeping)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void References_matches_a_single_token()
+    {
+        IdRefs.References(new[] { "ADM_A" }, "ADM_A").Should().BeTrue();
+    }
+
+    [Fact]
+    public void References_matches_one_token_of_a_genuine_list()
+    {
+        IdRefs.References(new[] { "ADM_A", "ADM_B" }, "ADM_B").Should().BeTrue();
+    }
+
+    [Fact]
+    public void References_matches_the_joined_legacy_form()
+    {
+        IdRefs.References(new[] { "ADM_objects/my", "file.pdf" }, "ADM_objects/my file.pdf")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void References_does_not_match_an_unrelated_id()
+    {
+        IdRefs.References(new[] { "ADM_A", "ADM_B" }, "ADM_C").Should().BeFalse();
+    }
+
+    [Fact]
+    public void RemoveReference_clears_all_tokens_of_a_legacy_spaced_id()
+    {
+        var tokens = new List<string> { "DMD_objects/my", "file.pdf" };
+        IdRefs.RemoveReference(tokens, "DMD_objects/my file.pdf");
+        tokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveReference_removes_only_the_matching_token_of_a_genuine_list()
+    {
+        var tokens = new List<string> { "DMD_A", "DMD_B" };
+        IdRefs.RemoveReference(tokens, "DMD_A");
+        tokens.Should().Equal("DMD_B");
+    }
+
+    [Fact]
+    public void RemoveReference_leaves_tokens_untouched_when_nothing_matches()
+    {
+        var tokens = new List<string> { "DMD_A", "DMD_B" };
+        IdRefs.RemoveReference(tokens, "DMD_C");
+        tokens.Should().Equal("DMD_A", "DMD_B");
+    }
 }

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
@@ -170,33 +170,8 @@ public class IdRefsTests
     }
 
     // -----------------------------------------------------------------------
-    // References / RemoveReference (pure token-collection bookkeeping)
+    // RemoveReference (pure token-collection bookkeeping)
     // -----------------------------------------------------------------------
-
-    [Fact]
-    public void References_matches_a_single_token()
-    {
-        IdRefs.References(TokenA, "ADM_A").Should().BeTrue();
-    }
-
-    [Fact]
-    public void References_matches_one_token_of_a_genuine_list()
-    {
-        IdRefs.References(GenuinePair, "ADM_B").Should().BeTrue();
-    }
-
-    [Fact]
-    public void References_matches_the_joined_legacy_form()
-    {
-        IdRefs.References(LegacySpacedTokens, "ADM_objects/my file.pdf")
-            .Should().BeTrue();
-    }
-
-    [Fact]
-    public void References_does_not_match_an_unrelated_id()
-    {
-        IdRefs.References(GenuinePair, "ADM_C").Should().BeFalse();
-    }
 
     [Fact]
     public void RemoveReference_clears_all_tokens_of_a_legacy_spaced_id()

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
@@ -1,0 +1,110 @@
+using DigitalPreservation.Mets;
+using FluentAssertions;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// Unit tests for IdRefs: resolution of METS IDREFS attributes that may be either a single
+/// legacy ID containing spaces (split into tokens by the XmlSerializer) or a schema-valid
+/// list of complete IDs. See docs/issues/188/issue-188-idrefs-plan.md.
+/// </summary>
+public class IdRefsTests
+{
+    private static readonly Dictionary<string, string> Elements = new()
+    {
+        ["ADM_objects/plain.pdf"] = "plain",
+        ["ADM_objects/my file.pdf"] = "legacy-spaced",
+        ["ADM_A"] = "a",
+        ["ADM_B"] = "b"
+    };
+
+    private static string? Lookup(string id) => Elements.GetValueOrDefault(id);
+
+    // -----------------------------------------------------------------------
+    // Collection overload (XmlGen side: tokens from the XmlSerializer's IDREFS split)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Empty_token_collection_resolves_to_null()
+    {
+        IdRefs.ResolveSingle(Array.Empty<string>(), Lookup).Should().BeNull();
+    }
+
+    [Fact]
+    public void Single_token_resolves_directly()
+    {
+        IdRefs.ResolveSingle(new[] { "ADM_objects/plain.pdf" }, Lookup).Should().Be("plain");
+    }
+
+    [Fact]
+    public void Single_unmatched_token_resolves_to_null()
+    {
+        IdRefs.ResolveSingle(new[] { "ADM_nope" }, Lookup).Should().BeNull();
+    }
+
+    [Fact]
+    public void Legacy_spaced_id_split_into_tokens_resolves_via_the_joined_form()
+    {
+        // "ADM_objects/my file.pdf" arrives from the XmlSerializer as two tokens
+        IdRefs.ResolveSingle(new[] { "ADM_objects/my", "file.pdf" }, Lookup)
+            .Should().Be("legacy-spaced");
+    }
+
+    [Fact]
+    public void Genuine_idrefs_list_resolves_to_the_first_matching_token()
+    {
+        IdRefs.ResolveSingle(new[] { "ADM_A", "ADM_B" }, Lookup).Should().Be("a");
+    }
+
+    [Fact]
+    public void Genuine_idrefs_list_falls_through_to_a_later_token_when_earlier_ones_miss()
+    {
+        IdRefs.ResolveSingle(new[] { "ADM_missing", "ADM_B" }, Lookup).Should().Be("b");
+    }
+
+    [Fact]
+    public void Nothing_matching_resolves_to_null()
+    {
+        IdRefs.ResolveSingle(new[] { "ADM_missing", "ADM_also_missing" }, Lookup).Should().BeNull();
+    }
+
+    [Fact]
+    public void Joined_reconstructs_the_original_attribute_value()
+    {
+        IdRefs.Joined(new[] { "ADM_objects/my", "file.pdf" }).Should().Be("ADM_objects/my file.pdf");
+    }
+
+    // -----------------------------------------------------------------------
+    // String overload (XDocument side: the whole attribute value as one string)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Whole_attribute_value_resolves_directly()
+    {
+        IdRefs.ResolveSingle("ADM_A", Lookup).Should().Be("a");
+    }
+
+    [Fact]
+    public void Legacy_spaced_id_resolves_as_the_whole_attribute_value()
+    {
+        IdRefs.ResolveSingle("ADM_objects/my file.pdf", Lookup).Should().Be("legacy-spaced");
+    }
+
+    [Fact]
+    public void Genuine_idrefs_attribute_value_splits_and_resolves_per_token()
+    {
+        IdRefs.ResolveSingle("ADM_missing ADM_B", Lookup).Should().Be("b");
+    }
+
+    [Fact]
+    public void Unmatched_attribute_value_without_spaces_resolves_to_null()
+    {
+        IdRefs.ResolveSingle("ADM_nope", Lookup).Should().BeNull();
+    }
+
+    [Fact]
+    public void Unmatched_attribute_value_with_spaces_resolves_to_null()
+    {
+        IdRefs.ResolveSingle("ADM_nope ADM_also_nope", Lookup).Should().BeNull();
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/IdRefsTests.cs
@@ -20,6 +20,16 @@ public class IdRefsTests
 
     private static string? Lookup(string id) => Elements.GetValueOrDefault(id);
 
+    // The token collections under test, as fields rather than inline array arguments (CA1861).
+    private static readonly string[] PlainToken = ["ADM_objects/plain.pdf"];
+    private static readonly string[] UnknownToken = ["ADM_nope"];
+    private static readonly string[] TokenA = ["ADM_A"];
+    private static readonly string[] LegacySpacedTokens = ["ADM_objects/my", "file.pdf"];
+    private static readonly string[] GenuinePair = ["ADM_A", "ADM_B"];
+    private static readonly string[] SecondResolvesPair = ["ADM_missing", "ADM_B"];
+    private static readonly string[] NothingResolvesPair = ["ADM_missing", "ADM_also_missing"];
+    private static readonly string[] DuplicateTokens = ["ADM_A", "ADM_A"];
+
     // -----------------------------------------------------------------------
     // Collection overload (XmlGen side: tokens from the XmlSerializer's IDREFS split)
     // -----------------------------------------------------------------------
@@ -33,45 +43,45 @@ public class IdRefsTests
     [Fact]
     public void Single_token_resolves_directly()
     {
-        IdRefs.ResolveSingle(new[] { "ADM_objects/plain.pdf" }, Lookup).Should().Be("plain");
+        IdRefs.ResolveSingle(PlainToken, Lookup).Should().Be("plain");
     }
 
     [Fact]
     public void Single_unmatched_token_resolves_to_null()
     {
-        IdRefs.ResolveSingle(new[] { "ADM_nope" }, Lookup).Should().BeNull();
+        IdRefs.ResolveSingle(UnknownToken, Lookup).Should().BeNull();
     }
 
     [Fact]
     public void Legacy_spaced_id_split_into_tokens_resolves_via_the_joined_form()
     {
         // "ADM_objects/my file.pdf" arrives from the XmlSerializer as two tokens
-        IdRefs.ResolveSingle(new[] { "ADM_objects/my", "file.pdf" }, Lookup)
+        IdRefs.ResolveSingle(LegacySpacedTokens, Lookup)
             .Should().Be("legacy-spaced");
     }
 
     [Fact]
     public void Genuine_idrefs_list_resolves_to_the_first_matching_token()
     {
-        IdRefs.ResolveSingle(new[] { "ADM_A", "ADM_B" }, Lookup).Should().Be("a");
+        IdRefs.ResolveSingle(GenuinePair, Lookup).Should().Be("a");
     }
 
     [Fact]
     public void Genuine_idrefs_list_falls_through_to_a_later_token_when_earlier_ones_miss()
     {
-        IdRefs.ResolveSingle(new[] { "ADM_missing", "ADM_B" }, Lookup).Should().Be("b");
+        IdRefs.ResolveSingle(SecondResolvesPair, Lookup).Should().Be("b");
     }
 
     [Fact]
     public void Nothing_matching_resolves_to_null()
     {
-        IdRefs.ResolveSingle(new[] { "ADM_missing", "ADM_also_missing" }, Lookup).Should().BeNull();
+        IdRefs.ResolveSingle(NothingResolvesPair, Lookup).Should().BeNull();
     }
 
     [Fact]
     public void Joined_reconstructs_the_original_attribute_value()
     {
-        IdRefs.Joined(new[] { "ADM_objects/my", "file.pdf" }).Should().Be("ADM_objects/my file.pdf");
+        IdRefs.Joined(LegacySpacedTokens).Should().Be("ADM_objects/my file.pdf");
     }
 
     // -----------------------------------------------------------------------
@@ -131,32 +141,32 @@ public class IdRefsTests
     [Fact]
     public void ResolveAll_of_a_single_token_resolves_that_element()
     {
-        IdRefs.ResolveAll(new[] { "ADM_A" }, Lookup).Should().Equal("a");
+        IdRefs.ResolveAll(TokenA, Lookup).Should().Equal("a");
     }
 
     [Fact]
     public void ResolveAll_of_legacy_spaced_tokens_is_exactly_the_one_legacy_element()
     {
-        IdRefs.ResolveAll(new[] { "ADM_objects/my", "file.pdf" }, Lookup)
+        IdRefs.ResolveAll(LegacySpacedTokens, Lookup)
             .Should().Equal("legacy-spaced");
     }
 
     [Fact]
     public void ResolveAll_of_a_genuine_idrefs_list_resolves_every_token()
     {
-        IdRefs.ResolveAll(new[] { "ADM_A", "ADM_B" }, Lookup).Should().Equal("a", "b");
+        IdRefs.ResolveAll(GenuinePair, Lookup).Should().Equal("a", "b");
     }
 
     [Fact]
     public void ResolveAll_skips_tokens_that_do_not_resolve()
     {
-        IdRefs.ResolveAll(new[] { "ADM_missing", "ADM_B" }, Lookup).Should().Equal("b");
+        IdRefs.ResolveAll(SecondResolvesPair, Lookup).Should().Equal("b");
     }
 
     [Fact]
     public void ResolveAll_returns_distinct_elements_for_duplicate_tokens()
     {
-        IdRefs.ResolveAll(new[] { "ADM_A", "ADM_A" }, Lookup).Should().Equal("a");
+        IdRefs.ResolveAll(DuplicateTokens, Lookup).Should().Equal("a");
     }
 
     // -----------------------------------------------------------------------
@@ -166,26 +176,26 @@ public class IdRefsTests
     [Fact]
     public void References_matches_a_single_token()
     {
-        IdRefs.References(new[] { "ADM_A" }, "ADM_A").Should().BeTrue();
+        IdRefs.References(TokenA, "ADM_A").Should().BeTrue();
     }
 
     [Fact]
     public void References_matches_one_token_of_a_genuine_list()
     {
-        IdRefs.References(new[] { "ADM_A", "ADM_B" }, "ADM_B").Should().BeTrue();
+        IdRefs.References(GenuinePair, "ADM_B").Should().BeTrue();
     }
 
     [Fact]
     public void References_matches_the_joined_legacy_form()
     {
-        IdRefs.References(new[] { "ADM_objects/my", "file.pdf" }, "ADM_objects/my file.pdf")
+        IdRefs.References(LegacySpacedTokens, "ADM_objects/my file.pdf")
             .Should().BeTrue();
     }
 
     [Fact]
     public void References_does_not_match_an_unrelated_id()
     {
-        IdRefs.References(new[] { "ADM_A", "ADM_B" }, "ADM_C").Should().BeFalse();
+        IdRefs.References(GenuinePair, "ADM_C").Should().BeFalse();
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerPathFixtureTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerPathFixtureTests.cs
@@ -32,9 +32,13 @@ namespace XmlGen.Tests;
 ///   Samples/path-fixture-spaces.xml  — paths with spaces (single and multiple)
 ///   Samples/path-fixture-special.xml — paths with ampersand and Unicode characters
 ///
-/// To regenerate the fixtures (e.g. after changing MetsManager's output format),
-/// run the Generate_Path_Special_Chars_Fixtures test (Category=Manual), then copy
-/// the outputs from bin/Debug/net8.0/Outputs/ to Samples/.
+/// FROZEN LEGACY CORPUS - do NOT regenerate these fixtures. They pin the pre-issue-#188
+/// ID format (raw paths, including spaces, inside ID attributes), which the platform must
+/// keep reading and editing until a step 3 bulk migration. Once step 2 changes ID minting,
+/// regenerating from current output would silently replace the legacy corpus with new-format
+/// files and erase exactly the coverage these tests (and the IdRefs tests that lean on them)
+/// exist to provide. The Generate_Path_Special_Chars_Fixtures test (Category=Manual) remains
+/// only as documentation of how the originals were produced.
 /// </summary>
 public class MetsManagerPathFixtureTests
 {

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerTests.cs
@@ -55,6 +55,50 @@ public class MetsManagerTests
     }
     
     [Fact]
+    public async Task Creating_Mets_From_An_AG_With_A_Preserved_Metadata_Folder_Reuses_The_Template_Divs()
+    {
+        var agFi = new FileInfo("Samples/archivalGroup.json");
+        var agMetsFi = new FileInfo("Outputs/archivalGroup-mets-with-metadata.xml");
+        var archivalGroup = JsonSerializer.Deserialize<ArchivalGroup>(await File.ReadAllTextAsync(agFi.FullName))!;
+
+        // Give the AG a preserved metadata/ folder with content. The template METS already
+        // contains divs and amdSecs for metadata/ (and metadata/ad-hoc/), so building must
+        // REUSE them - a duplicate metadata div/amdSec was a real production AG-export bug.
+        var metadataContainer = new Container
+        {
+            Id = new Uri($"{archivalGroup.Id}/metadata"),
+            Name = FolderNames.Metadata
+        };
+        metadataContainer.Binaries.Add(new Binary
+        {
+            Id = new Uri($"{archivalGroup.Id}/metadata/report.txt"),
+            Name = "report.txt",
+            ContentType = "text/plain",
+            Digest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f",
+            Size = 123
+        });
+        archivalGroup.Containers.Add(metadataContainer);
+
+        // In DEBUG builds CreateStandardMets also asserts full navigability, which a
+        // duplicate path would fail; the explicit assertions below hold in Release too.
+        var result = await metsFromArchivalGroup.CreateStandardMets(
+            new Uri(agMetsFi.FullName), archivalGroup, "ArchivalGroup Mets With Metadata");
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var xml = XDocument.Load(agMetsFi.FullName);
+        XNamespace mets = "http://www.loc.gov/METS/";
+        var amdSecIds = xml.Descendants(mets + "amdSec")
+            .Select(a => (string)a.Attribute("ID")!).ToList();
+        amdSecIds.Should().OnlyHaveUniqueItems();
+        var physical = xml.Descendants(mets + "structMap")
+            .Single(sm => (string?)sm.Attribute("TYPE") == "PHYSICAL");
+        physical.Descendants(mets + "div")
+            .Count(d => (string?)d.Attribute("ID") == Constants.MetadataDivId).Should().Be(1);
+        xml.Descendants(mets + "file")
+            .Count(f => (string?)f.Attribute("ID") == "FILE_metadata/report.txt").Should().Be(1);
+    }
+
+    [Fact]
     public async Task Can_Create_Mets_From_Archival_Group()
     {
         var agFi = new FileInfo("Samples/archivalGroup.json");

--- a/src/DigitalPreservation/XmlGen.Tests/Parsing/IdRefsParsingTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Parsing/IdRefsParsingTests.cs
@@ -1,0 +1,133 @@
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
+using FluentAssertions;
+
+namespace XmlGen.Tests.Parsing;
+
+/// <summary>
+/// Parser-side IDREFS handling: ADMID/DMDID attribute values that are genuine
+/// whitespace-separated reference lists (schema-valid IDREFS) must resolve per token when the
+/// whole-value lookup misses. Legacy space-containing IDs keep working because the whole raw
+/// attribute value is tried first. See docs/issues/188/issue-188-idrefs-plan.md.
+/// </summary>
+public class IdRefsParsingTests : MetsParserTestBase
+{
+    [Fact]
+    public void Multi_token_ADMID_resolves_per_token_including_the_virus_event_key()
+    {
+        // ADMID lists two references; only ADM_real exists. The parser must resolve the
+        // techMD through the second token, and the ClamAV digiprov key must be derived from
+        // the RESOLVED amdSec's ID (digiprovMD_ClamAV_ADM_real), not from the raw attribute
+        // value ("digiprovMD_ClamAV_ADM_missing ADM_real" matches nothing).
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:premis="http://www.loc.gov/premis/v3">
+              <mets:amdSec ID="ADM_real">
+                <mets:techMD ID="TECH_real">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics>
+                          <premis:fixity>
+                            <premis:messageDigestAlgorithm>SHA256</premis:messageDigestAlgorithm>
+                            <premis:messageDigest>multiRefDigest</premis:messageDigest>
+                          </premis:fixity>
+                        </premis:objectCharacteristics>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+                <mets:digiprovMD ID="digiprovMD_ClamAV_ADM_real">
+                  <mets:mdWrap MDTYPE="PREMIS:EVENT">
+                    <mets:xmlData>
+                      <premis:event>
+                        <premis:eventDateTime>2026-03-18T12:00:00Z</premis:eventDateTime>
+                        <premis:eventDetailInformation>
+                          <premis:eventDetail>ClamAV 1.4.3/27944</premis:eventDetail>
+                        </premis:eventDetailInformation>
+                        <premis:eventOutcomeInformation>
+                          <premis:eventOutcome>pass</premis:eventOutcome>
+                          <premis:eventOutcomeDetail>
+                            <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>
+                          </premis:eventOutcomeDetail>
+                        </premis:eventOutcomeInformation>
+                      </premis:event>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:digiprovMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp>
+                  <mets:file ID="FILE_1" MIMETYPE="application/pdf">
+                    <mets:FLocat xlink:href="objects/multi.pdf"/>
+                  </mets:file>
+                </mets:fileGrp>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div ADMID="ADM_missing ADM_real">
+                  <mets:fptr FILEID="FILE_1"/>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var file = mets.Files.Single(f => f.LocalPath == "objects/multi.pdf");
+        file.Digest.Should().Be("multiRefDigest");
+
+        var virus = file.Metadata.OfType<VirusScanMetadata>().Single();
+        virus.HasVirus.Should().BeFalse();
+        virus.VirusDefinition.Should().Be("ClamAV 1.4.3/27944");
+    }
+
+    [Fact]
+    public void Multi_token_DMDID_resolves_descriptive_metadata_per_token()
+    {
+        var xml = """
+            <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:mods="http://www.loc.gov/mods/v3"
+                       xmlns:premis="http://www.loc.gov/premis/v3">
+              <mets:dmdSec ID="DMD_real">
+                <mets:mdWrap MDTYPE="MODS">
+                  <mets:xmlData>
+                    <mods:mods>
+                      <mods:accessCondition type="restriction on access">Closed</mods:accessCondition>
+                    </mods:mods>
+                  </mets:xmlData>
+                </mets:mdWrap>
+              </mets:dmdSec>
+              <mets:amdSec ID="ADM_dir">
+                <mets:techMD ID="TECH_dir">
+                  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+                    <mets:xmlData>
+                      <premis:object>
+                        <premis:objectCharacteristics/>
+                        <premis:originalName>objects/restricted</premis:originalName>
+                      </premis:object>
+                    </mets:xmlData>
+                  </mets:mdWrap>
+                </mets:techMD>
+              </mets:amdSec>
+              <mets:fileSec>
+                <mets:fileGrp/>
+              </mets:fileSec>
+              <mets:structMap TYPE="PHYSICAL">
+                <mets:div TYPE="Directory" LABEL="root">
+                  <mets:div TYPE="Directory" LABEL="restricted" ADMID="ADM_dir"
+                            DMDID="DMD_missing DMD_real"/>
+                </mets:div>
+              </mets:structMap>
+            </mets:mets>
+            """;
+
+        var mets = Parse(xml);
+
+        var restricted = mets.PhysicalStructure!
+            .FindDirectory("objects/restricted", false);
+        restricted.Should().NotBeNull();
+        restricted!.AccessRestrictions.Should().ContainSingle().Which.Should().Be("Closed");
+    }
+}


### PR DESCRIPTION
Companion to #211 (issue #188). Implements [docs/issues/188/issue-188-idrefs-plan.md](https://github.com/digirati-co-uk/digital-preservation/blob/main/docs/issues/188/issue-188-idrefs-plan.md).

## The problem

`ADMID`/`DMDID` are schema-typed **IDREFS** — whitespace-separated lists of ID references. Our two METS-reading stacks fail in mirror-image ways:

- **XmlGen typed model**: XmlSerializer splits the attribute into tokens, so a legacy space-containing ID (`ADM_objects/my file.pdf`) arrives broken. The existing `string.Join(' ', …)` workaround reconstructs it — but that same join would *break* a genuine multi-reference (`ADMID="ADM_A ADM_B"` matches no element). Several sites also used `Single()`/`[0]`, which throw on no-match or empty collections.
- **XDocument (`MetsParser`)**: raw whole-string lookups mean legacy space IDs work naturally, but a genuine IDREFS list finds nothing — no split fallback existed.

## The fix

**`IdRefs` helper (new, XmlGen side)** — tiered resolution: try the joined form first (a legacy space-containing single ID; unambiguous, because no schema-valid ID can contain a space), then each token individually. Never throws; null means unresolvable. Applied at all six join sites (`MetadataManager`, `ModsManager` ×2, `MetsManager.DeleteDiv` ×2, `MetsCache`).

**String overload for the parser** — whole-value lookup first, then split into tokens. Applied at the five `MetsParser` IDREFS lookup sites.

**Derived keys come from the resolved element, not the reference** — `ctx.FileAdmId` and the parser's ClamAV `digiprovMD_` key are now built from the resolved amdSec/techMD's actual `ID`, so they always embed a real ID even in the multi-IDREFS case.

**Crash fixes along the way** — `DeleteDiv` no longer throws `IndexOutOfRange` on an empty `Admid` collection or `InvalidOperationException` on a dangling reference; deletion is deliberately *tolerant* of unresolvable references (a broken reference is exactly what a delete may be cleaning up, and DMDIDs dangle by design due to lazy dmdSec creation).

## Step 2 interplay

After step 2 (`XmlConvert.EncodeLocalName` minting), no new ID can contain a space, so every new reference tokenises to exactly one member and the joined tier degenerates to `tokens[0]`. The tiering is purely a bridge for legacy and third-party content — removable from the XmlGen side only after a step 3 migration, never removable from the parser (third-party METS can carry real IDREFS lists).

## Tests

19 new tests: `IdRefsTests` (13 unit tests over the tiering), `IdRefsMetsManagerTests` (4, including genuine two-token ADMID/DMDID fixtures and clean-failure DeleteDiv cases), `IdRefsParsingTests` (2, including ClamAV key derivation from the resolved ID). Legacy `path-fixture-spaces.xml` coverage stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
