### PR TITLE
feat: mint schema-valid METS IDs (#188 step 2)

### DIFF
--- a/docs/issues/188/issue-188-plan.md
+++ b/docs/issues/188/issue-188-plan.md
@@ -17,6 +17,43 @@
 > (c) FLocat comparisons in update/delete/metadata paths are normalised the same way. All
 > deliberate improvements from the review rounds.
 >
+> **Status (2026-08-13): Step 2 is IMPLEMENTED** on `feat/188-encoded-mets-ids`. All minting
+> sites in §2.2 go through `MetsIdEncoding.ToMetsId`; the checklist items below are done. Six
+> things differ from the plan as written, all deliberate:
+>
+> 1. **The ID-convention navigation tier had to learn BOTH forms** (not anticipated anywhere in
+>    the plan). `FindChildDivByPath`'s third tier reconstructed only `PHYS_` + raw path, so a
+>    div minted with an encoded ID that later loses its path metadata became unreachable — the
+>    exact failure the tier exists to prevent. Caught by an existing test
+>    (`Deleting_The_Div_A_Diagnostic_Describes_Clears_The_Diagnostic`), not by a new one. It now
+>    tries the encoded ID and the legacy raw ID, and stays ambiguity-safe.
+> 2. **The duplicate-div guard in `AddNewFile`/`AddNewDirectory` needed widening**, not just the
+>    verification §2.2 item (5) asked for: an encoded mint no longer collides with a legacy
+>    raw-ID div for the same path, so the guard checks both forms (`FindConflictingChild`).
+>    Without it an add could silently create a second div for one path.
+> 3. **The merge gate is an ID-integrity gate, not XSD validation** (`MetsIdIntegrityTests`):
+>    every ID valid and unique, every ADMID/FILEID/smLink reference resolving, across empty,
+>    awkward-path, logical-structMap, Archival-Group and mixed legacy documents. Full XSD
+>    validation would need the METS + xlink schema set committed for offline CI, and would fail
+>    on an unrelated pre-existing issue — the template writes DMDID onto the objects/metadata/
+>    ad-hoc divs whose dmdSecs are only created lazily, so those references dangle by design.
+>    **Dangling-DMDID and full XSD validation both go to the conformance-checker backlog.**
+> 4. **`SetStructMap` now returns `Result`** (`IMetsManager` change, propagated by
+>    `SetLogicalStructMapHandler`) — §2.4 asked for BadRequest but the method returned void.
+>    Validation covers nested ranges, and rejects before writing anything.
+> 5. **`GetModsForDiv` takes `localPath`** as §2.3 planned; the `ByDivId` entry points recover
+>    it from the path cache (`PathForDiv`) rather than passing null, so a legacy div edited by
+>    ID also gets a valid encoded DMD id. The div-ID fallback remains only for logical divs and
+>    for physical divs whose path cannot be resolved at all.
+> 6. **No legacy/new split of `MetsManagerPathFixtureTests`** (§2.5) was needed: every assertion
+>    in it is about the frozen legacy corpus and none changed. Mixed-format coverage lives in
+>    `MetsIdIntegrityTests.Editing_A_Legacy_Document_Leaves_Every_Reference_Resolvable`.
+>
+> `Constants.ObjectsDivId`/`MetadataDivId` stay `const` (their folder names need no encoding);
+> `MetsIdEncodingTests` pins that `.ToMetsId()` is the identity for them, so the constants and
+> the minted form cannot drift apart. `MetadataAdHocDivId` became `static readonly`.
+> **Still outstanding: the atomic deploy of every embedder (§2.7) and the docs-repo pass (§2.8).**
+
 > **Step 2 checklist addition (2026-08-12, from the whole-feature review):**
 > `BuildFptr` and `LinkFile`/`UnLinkFile`/`SetFileLinks` must switch from MINTING
 > `FILE_`+path to RESOLVING the actual FILE element's ID (via the cached div's `Fptr`, or a

--- a/docs/issues/188/issue-188-plan.md
+++ b/docs/issues/188/issue-188-plan.md
@@ -49,6 +49,16 @@
 >    in it is about the frozen legacy corpus and none changed. Mixed-format coverage lives in
 >    `MetsIdIntegrityTests.Editing_A_Legacy_Document_Leaves_Every_Reference_Resolvable`.
 >
+> **Cumulative adversarial review (2026-08-13, six independent reviewers over PRs #211+#213+#214).**
+> Ten of its findings are fixed on this branch — seven regressions this change set introduced or
+> made unrecoverable (quadratic navigation on the add path; the ClamAV digiprovMD ID still minted
+> from a legacy amdSec ID; delete leaving unremovable fptr/smLink references; the duplicate-div
+> guard comparing IDs only; `SetStructMap` not checking ID uniqueness; `ResolveFileId` ignoring the
+> OBJECTS fileGrp; every ID-less logical div sharing one dmdSec) and three test defects that let
+> them through. The remaining ~20 findings are pre-existing and tracked separately; **one needs a
+> product decision — `MetsParser.BuildLookupMaps` throws on duplicate IDs, and the pre-#211
+> `MetsFromArchivalGroup` bug wrote such documents into OCFL, so they are unloadable today.**
+>
 > `Constants.ObjectsDivId`/`MetadataDivId` stay `const` (their folder names need no encoding);
 > `MetsIdEncodingTests` pins that `.ToMetsId()` is the identity for them, so the constants and
 > the minted form cannot drift apart. `MetadataAdHocDivId` became `static readonly`.

--- a/docs/issues/188/issue-188-plan.md
+++ b/docs/issues/188/issue-188-plan.md
@@ -55,9 +55,13 @@
 > from a legacy amdSec ID; delete leaving unremovable fptr/smLink references; the duplicate-div
 > guard comparing IDs only; `SetStructMap` not checking ID uniqueness; `ResolveFileId` ignoring the
 > OBJECTS fileGrp; every ID-less logical div sharing one dmdSec) and three test defects that let
-> them through. The remaining ~20 findings are pre-existing and tracked separately; **one needs a
-> product decision — `MetsParser.BuildLookupMaps` throws on duplicate IDs, and the pre-#211
-> `MetsFromArchivalGroup` bug wrote such documents into OCFL, so they are unloadable today.**
+> them through. The remaining ~20 findings are pre-existing and tracked separately; none requires
+> remediating data already in storage. (The review initially flagged `MetsParser.BuildLookupMaps`
+> throwing on duplicate IDs as a remediation problem, on the assumption that the pre-#211
+> `MetsFromArchivalGroup` bug had written such documents into OCFL. It had not — production
+> content only began going in once the platform was METS-first, so nothing was ever preserved
+> through that path. Tolerating duplicate IDs with a diagnostic is still worth doing for
+> third-party and hand-edited METS, but it is robustness, not recovery.)
 >
 > `Constants.ObjectsDivId`/`MetadataDivId` stay `const` (their folder names need no encoding);
 > `MetsIdEncodingTests` pins that `.ToMetsId()` is the identity for them, so the constants and

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/MetsExtensions.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/Extensions/MetsExtensions.cs
@@ -9,11 +9,22 @@ public class MetsExtensions
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Href { get; set; }
     
+    /// <summary>
+    /// The raw ID of the mets:div this resource came from. OPAQUE: never parse, substring or
+    /// derive a path from it, and never construct one to look a div up by. The platform mints
+    /// these from paths, but the encoding has changed (issue #188) and third-party METS uses
+    /// entirely different schemes, so a document can carry several forms at once. Round-trip it
+    /// verbatim; get paths from <see cref="Href"/>.
+    /// </summary>
     [JsonPropertyName("divId")]
     [JsonPropertyOrder(101)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DivId { get; set; }
-    
+
+    /// <summary>
+    /// The raw ID of the mets:amdSec for this resource. Opaque, on the same terms as
+    /// <see cref="DivId"/>.
+    /// </summary>
     [JsonPropertyName("admId")]
     [JsonPropertyOrder(102)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FolderNames.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Transit/FolderNames.cs
@@ -8,7 +8,9 @@ public static class FolderNames
     public const string Metadata = "metadata";
     public const string BagItData = "data";
     public const string AdHoc = "ad-hoc";
-    public const string MetadataAdHoc = $"{Metadata}/{AdHoc}"; // TODO: #188 do not use this as an ID component
+    // A path, never an ID component on its own: the '/' is not valid in an xs:ID. ID minting
+    // encodes it first (see MetsIdEncoding.ToMetsId / Constants.MetadataAdHocDivId, issue #188).
+    public const string MetadataAdHoc = $"{Metadata}/{AdHoc}";
 
     public static bool PathIsKnownFirstLevelDirectory(string localPath)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Mets/Constants.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/Constants.cs
@@ -22,6 +22,9 @@ public static class Constants
     // written before that fix carry the raw "PHYS_metadata/ad-hoc" form and are still navigated
     // by path, so nothing reads this constant to identify an existing div.
     public static readonly string MetadataAdHocDivId = PhysIdPrefix + FolderNames.MetadataAdHoc.ToMetsId();
+    // The fileGrp holding the preserved files. Other groups (derivatives, ALTO, thumbnails)
+    // appear in third-party METS and may carry an entry with the same href.
+    public const string ObjectsFileGrpUse = "OBJECTS";
     public const string DirectoryType = "Directory";
     public const string ItemType = "Item";
     public const string VirusProvEventPrefix = "digiprovMD_ClamAV_";

--- a/src/DigitalPreservation/DigitalPreservation.Mets/Constants.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Utils;
 
 namespace DigitalPreservation.Mets;
 
@@ -16,7 +17,11 @@ public static class Constants
     public const string DmdPhysRoot = "DMD_PHYS_ROOT";
     public const string ObjectsDivId = PhysIdPrefix + FolderNames.Objects;
     public const string MetadataDivId = PhysIdPrefix + FolderNames.Metadata;
-    public const string MetadataAdHocDivId = $"{MetadataDivId}/{FolderNames.AdHoc}";
+    // Not a const: the path this ID is built from contains a '/', which an xs:ID may not, so it
+    // has to go through the same encoding as every other minted ID (issue #188). METS files
+    // written before that fix carry the raw "PHYS_metadata/ad-hoc" form and are still navigated
+    // by path, so nothing reads this constant to identify an existing div.
+    public static readonly string MetadataAdHocDivId = PhysIdPrefix + FolderNames.MetadataAdHoc.ToMetsId();
     public const string DirectoryType = "Directory";
     public const string ItemType = "Item";
     public const string VirusProvEventPrefix = "digiprovMD_ClamAV_";

--- a/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/IMetsManager.cs
@@ -49,8 +49,9 @@ public interface IMetsManager
 
     // There may be more than one so we need to address them better than this, which assumes only one
     // address by ID? There will almost always be only one so we don't want to complicate the UI
-    // Sets a logical struct map (never a physical one)
-    void SetStructMap(FullMets mets, LogicalRange logSm);
+    // Sets a logical struct map (never a physical one). Returns BadRequest, writing nothing, if
+    // any range ID in the supplied tree could not be used as an XML ID.
+    Result SetStructMap(FullMets mets, LogicalRange logSm);
     // This will overwrite a structMap with the same ID, and append one if the ID is different to any currently existing.
 
     // maybe this rarely used operation, if we need to change the order:

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -16,6 +16,16 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
     {
         public required string FileAdmId { get; set; }
         public required string TechId { get; set; }
+
+        /// <summary>
+        /// ID for a virus-scan digiprovMD this run may need to create. Derived from the file's
+        /// PATH, not from <see cref="FileAdmId"/>: on a pre-issue-#188 document that resolves to
+        /// the legacy raw amdSec ID, and embedding it would mint a brand-new ID containing a
+        /// slash and a space - after step 2, from the code step 2 was supposed to have made
+        /// schema-valid. Nothing anywhere references a digiprovMD by ID (the readers find it
+        /// structurally, or by prefix), so there is no compatibility cost to choosing our own.
+        /// </summary>
+        public required string DigiprovId { get; set; }
         public AmdSecType? AmdSec { get; set; }
         public FileType? File { get; set; }
         public MetsTypeFileSecFileGrp? FileGroup { get; set; }
@@ -30,7 +40,12 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
         var admId = Constants.AdmIdPrefix + idPart;
         var techId = Constants.TechIdPrefix + idPart;
 
-        var ctx = new ProcessingContext { FileAdmId = admId, TechId = techId };
+        var ctx = new ProcessingContext
+        {
+            FileAdmId = admId,
+            TechId = techId,
+            DigiprovId = $"{Constants.VirusProvEventPrefix}{Constants.AdmIdPrefix}{idPart}"
+        };
 
         if (!newUpload)
         {
@@ -219,7 +234,7 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
     {
         if (div == null) return;
         var fileId = div.Fptr[0].Fileid;
-        ctx.FileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        ctx.FileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == Constants.ObjectsFileGrpUse);
         ctx.File = ctx.FileGroup.File.Single(f => f.Id == fileId);
     }
 
@@ -276,7 +291,7 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
         {
             ctx.AmdSec.DigiprovMd.Add(new MdSecType
             {
-                Id = $"{Constants.VirusProvEventPrefix}{ctx.FileAdmId}",
+                Id = ctx.DigiprovId,
                 MdWrap = new MdSecTypeMdWrap
                 {
                     Mdtype = MdSecTypeMdWrapMdtype.PremisEvent,

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetadataManager.cs
@@ -25,9 +25,10 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
 
     public Result ProcessAllFileMetadata(FullMets fullMets, DivType? div, WorkingFile workingFile, string operationPath, bool newUpload = false)
     {
-        var fileId = Constants.FileIdPrefix + operationPath;
-        var admId = Constants.AdmIdPrefix + operationPath;
-        var techId = Constants.TechIdPrefix + operationPath;
+        var idPart = operationPath.ToMetsId();
+        var fileId = Constants.FileIdPrefix + idPart;
+        var admId = Constants.AdmIdPrefix + idPart;
+        var techId = Constants.TechIdPrefix + idPart;
 
         var ctx = new ProcessingContext { FileAdmId = admId, TechId = techId };
 
@@ -35,8 +36,8 @@ public class MetadataManager(PremisManager premisManager, PremisManagerExif prem
         {
             // GetMetadataXml resolves the file's amdSec from its ADMID tokens and sets
             // ctx.AmdSec / ctx.FileAdmId from the resolved element - which handles legacy
-            // space-containing IDs, whose convention-derived form may not equal
-            // AdmIdPrefix + operationPath in a mixed-format METS.
+            // space-containing IDs, whose form may not equal the ID minted above in a
+            // mixed-format METS.
             var resultGetMetadataXml = GetMetadataXml(ctx, fullMets, div, operationPath);
 
             if (resultGetMetadataXml.Failure)

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -43,6 +43,10 @@ public static class MetsCache
         DigitalPreservation.XmlGen.Mets.Mets mets, Dictionary<string, DivType> cache)
     {
         var diagnostics = new List<string>();
+        // One ID index for the whole walk. Without it each div's resolution scans the fileSec
+        // (or the amdSecs) end to end, which makes building the cache quadratic in the size of
+        // the deposit - and the cache is built on every load.
+        var index = new MetsIdIndex(mets);
 
         // Tolerate malformed METS: never throw here, this runs on every load. Zero or many
         // PHYSICAL structMaps are diagnostics, not exceptions; with many, the first is used
@@ -66,7 +70,7 @@ public static class MetsCache
             return diagnostics;
         }
 
-        Walk(physRoot, mets, cache, diagnostics);
+        Walk(physRoot, mets, cache, diagnostics, index);
         return diagnostics;
     }
 
@@ -74,18 +78,19 @@ public static class MetsCache
         DivType div,
         DigitalPreservation.XmlGen.Mets.Mets mets,
         Dictionary<string, DivType> cache,
-        List<string> diagnostics)
+        List<string> diagnostics,
+        MetsIdIndex index)
     {
         foreach (var child in div.Div)
         {
-            var key = ResolvePath(child, mets, diagnostics);
+            var key = ResolvePath(child, mets, diagnostics, index);
             if (key != null && !cache.TryAdd(key, child))
             {
                 diagnostics.Add(
                     $"Divs '{cache[key].Id}' and '{child.Id}' {DuplicatePathFragment} '{key}'");
             }
 
-            Walk(child, mets, cache, diagnostics);
+            Walk(child, mets, cache, diagnostics, index);
         }
     }
 
@@ -96,12 +101,22 @@ public static class MetsCache
     /// divs by path rather than by reconstructed ID.
     /// </summary>
     public static string? TryResolvePath(DivType div, DigitalPreservation.XmlGen.Mets.Mets mets)
-        => ResolvePath(div, mets, null);
+        => ResolvePath(div, mets, null, null);
+
+    /// <summary>
+    /// As <see cref="TryResolvePath(DivType, DigitalPreservation.XmlGen.Mets.Mets)"/>, but reusing
+    /// a caller-built ID index. Use this when resolving several divs against the same document -
+    /// resolving each one independently rescans the fileSec every time.
+    /// </summary>
+    internal static string? TryResolvePath(
+        DivType div, DigitalPreservation.XmlGen.Mets.Mets mets, MetsIdIndex index)
+        => ResolvePath(div, mets, null, index);
 
     private static string? ResolvePath(
         DivType child,
         DigitalPreservation.XmlGen.Mets.Mets mets,
-        List<string>? diagnostics)
+        List<string>? diagnostics,
+        MetsIdIndex? index)
     {
         string? path = null;
         switch (child.Type)
@@ -113,7 +128,9 @@ public static class MetsCache
             {
                 // ADMID is an IDREFS token collection; IdRefs resolves both legacy
                 // space-containing IDs and genuine multi-references.
-                var amdSec = IdRefs.ResolveSingle(child.Admid, id => mets.AmdSec.FirstOrDefault(a => a.Id == id));
+                var amdSec = IdRefs.ResolveSingle(child.Admid, id => index != null
+                    ? index.AmdSecById(id)
+                    : mets.AmdSec.FirstOrDefault(a => a.Id == id));
                 path = ExtractPremisOriginalName(amdSec);
                 if (path == null)
                 {
@@ -128,9 +145,9 @@ public static class MetsCache
             case Constants.ItemType:
             {
                 var fileId = child.Fptr[0].Fileid;
-                var file = mets.FileSec?.FileGrp
-                    .SelectMany(fg => fg.File)
-                    .FirstOrDefault(f => f.Id == fileId);
+                var file = index != null
+                    ? index.FileById(fileId)
+                    : mets.FileSec?.FileGrp.SelectMany(fg => fg.File).FirstOrDefault(f => f.Id == fileId);
                 path = file?.FLocat.FirstOrDefault()?.Href;
                 if (path == null)
                 {

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsIdIndex.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsIdIndex.cs
@@ -1,0 +1,47 @@
+using DigitalPreservation.XmlGen.Mets;
+
+namespace DigitalPreservation.Mets;
+
+/// <summary>
+/// ID → element lookup for one METS document, so that resolving many divs against the same
+/// document does not rescan the fileSec and amdSec collections for each one. Resolution used to
+/// be a <c>FirstOrDefault</c> per div, which made both cache population (run on every load) and
+/// the sibling scan behind an add quadratic in the size of the deposit.
+/// </summary>
+/// <remarks>
+/// First-wins on a duplicate ID, matching the <c>FirstOrDefault</c> behaviour it replaces: a
+/// document with duplicate IDs is malformed, and this class is not the place to complain about
+/// it — the path cache reports its own diagnostics, and a duplicate ID is caught by the
+/// integrity tests.
+/// Build one per operation and discard it: it is a snapshot, and every mutation invalidates it.
+/// </remarks>
+internal sealed class MetsIdIndex
+{
+    private readonly Dictionary<string, FileType> filesById = [];
+    private readonly Dictionary<string, AmdSecType> amdSecsById = [];
+
+    internal MetsIdIndex(DigitalPreservation.XmlGen.Mets.Mets mets)
+    {
+        foreach (var file in (mets.FileSec?.FileGrp ?? []).SelectMany(fileGrp => fileGrp.File))
+        {
+            if (file.Id != null)
+            {
+                filesById.TryAdd(file.Id, file);
+            }
+        }
+
+        foreach (var amdSec in mets.AmdSec)
+        {
+            if (amdSec.Id != null)
+            {
+                amdSecsById.TryAdd(amdSec.Id, amdSec);
+            }
+        }
+    }
+
+    internal FileType? FileById(string? id) =>
+        id != null && filesById.TryGetValue(id, out var file) ? file : null;
+
+    internal AmdSecType? AmdSecById(string? id) =>
+        id != null && amdSecsById.TryGetValue(id, out var amdSec) ? amdSec : null;
+}

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -512,15 +512,15 @@ public class MetsManager(
 
         // fptrs live on divs in every structMap - the physical div being deleted takes its own
         // with it, but a LOGICAL div painting this file keeps pointing at a file that is gone.
-        foreach (var div in AllDivs(mets))
-        {
-            var staleFptrs = div.Fptr
+        // Materialise before mutating - the divs cannot be walked while their fptrs are removed.
+        var stalePointers = AllDivs(mets)
+            .SelectMany(div => div.Fptr
                 .Where(fptr => fptr.Fileid == fileId || fptr.Area?.Fileid == fileId)
-                .ToList();
-            foreach (var fptr in staleFptrs)
-            {
-                div.Fptr.Remove(fptr);
-            }
+                .Select(fptr => (div, fptr)))
+            .ToList();
+        foreach (var (div, fptr) in stalePointers)
+        {
+            div.Fptr.Remove(fptr);
         }
     }
 
@@ -572,21 +572,11 @@ public class MetsManager(
     /// legal XML and does occur in malformed documents - dereferencing it unguarded is a real
     /// crash, so this is the single place that tolerance lives.
     /// </summary>
-    private static IEnumerable<DivType> AllDivs(DigitalPreservation.XmlGen.Mets.Mets mets)
-    {
-        foreach (var structMap in mets.StructMap)
-        {
-            var root = structMap.Div;
-            if (root is null)
-            {
-                continue;
-            }
-            foreach (var div in SelfAndDescendants(root))
-            {
-                yield return div;
-            }
-        }
-    }
+    private static IEnumerable<DivType> AllDivs(DigitalPreservation.XmlGen.Mets.Mets mets) =>
+        mets.StructMap
+            .Select(structMap => structMap.Div)
+            .Where(root => root is not null)
+            .SelectMany(SelfAndDescendants);
 
     private static IEnumerable<DivType> SelfAndDescendants(DivType div)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -118,7 +118,7 @@ public class MetsManager(
             if (workingBase is WorkingFile workingFile)
                 return UpdateExistingFile(contextDiv, fullMets, workingFile, localPath);
             if (workingBase is WorkingDirectory workingDirectory)
-                return UpdateExistingDirectory(fullMets, workingDirectory, contextDiv);
+                return UpdateExistingDirectory(fullMets, workingDirectory, contextDiv, localPath);
             return Result.Fail(ErrorCodes.BadRequest, "WorkingBase is unsupported type");
         }
 
@@ -157,12 +157,12 @@ public class MetsManager(
         if (MetsCache.NormalisePathKey(file.FLocat[0].Href) != localPath)
             return Result.Fail(ErrorCodes.BadRequest, "WorkingFile path doesn't match METS flocat");
 
-        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, contextDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, contextDiv, localPath);
         if (dmdResult.Failure) return dmdResult;
         return metadataManager.ProcessAllFileMetadata(fullMets, contextDiv, workingFile, localPath);
     }
 
-    private static Result UpdateExistingDirectory(FullMets fullMets, WorkingDirectory workingDirectory, DivType contextDiv)
+    private static Result UpdateExistingDirectory(FullMets fullMets, WorkingDirectory workingDirectory, DivType contextDiv, string localPath)
     {
         if (contextDiv.Type != Constants.DirectoryType)
             return Result.Fail(ErrorCodes.BadRequest, "WorkingDirectory path does not end on a directory");
@@ -170,21 +170,19 @@ public class MetsManager(
         if (workingDirectory.Name.HasText())
             contextDiv.Label = workingDirectory.Name;
 
-        return PopulateDmdFromResource(fullMets, workingDirectory, contextDiv);
+        return PopulateDmdFromResource(fullMets, workingDirectory, contextDiv, localPath);
     }
 
     private Result AddNewFile(DivType parentDiv, FullMets fullMets, WorkingFile workingFile, string localPath)
     {
-        var physId = Constants.PhysIdPrefix + localPath;
-        var fileId = Constants.FileIdPrefix + localPath;
+        var physId = Constants.PhysIdPrefix + localPath.ToMetsId();
+        var fileId = Constants.FileIdPrefix + localPath.ToMetsId();
 
-        // Reaching an add for a path whose div already exists means that div could not be
-        // resolved by path OR by the legacy ID fallback - adding again would write duplicate
-        // ID attributes into the METS. Refuse rather than corrupt.
-        if (parentDiv.Div.Any(d => d.Id == physId))
+        var conflict = FindConflictingChild(parentDiv, localPath, physId);
+        if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
-                $"METS already contains a div '{physId}' that could not be resolved to path '{localPath}'.");
+                $"METS already contains a div '{conflict}' that could not be resolved to path '{localPath}'.");
         }
 
         var childItemDiv = new DivType
@@ -201,7 +199,7 @@ public class MetsManager(
         if (metadataResult.Failure)
             return metadataResult;
 
-        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, childItemDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingFile, childItemDiv, localPath);
         if (dmdResult.Failure) return dmdResult;
 
         parentDiv.Div.Add(childItemDiv);
@@ -213,14 +211,15 @@ public class MetsManager(
 
     private Result AddNewDirectory(DivType parentDiv, FullMets fullMets, WorkingDirectory workingDirectory, string localPath)
     {
-        var physId = Constants.PhysIdPrefix + localPath;
-        var admId = Constants.AdmIdPrefix + localPath;
-        var techId = Constants.TechIdPrefix + localPath;
+        var physId = Constants.PhysIdPrefix + localPath.ToMetsId();
+        var admId = Constants.AdmIdPrefix + localPath.ToMetsId();
+        var techId = Constants.TechIdPrefix + localPath.ToMetsId();
 
-        if (parentDiv.Div.Any(d => d.Id == physId))
+        var conflict = FindConflictingChild(parentDiv, localPath, physId);
+        if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
-                $"METS already contains a div '{physId}' that could not be resolved to path '{localPath}'.");
+                $"METS already contains a div '{conflict}' that could not be resolved to path '{localPath}'.");
         }
 
         var childDirectoryDiv = new DivType
@@ -238,7 +237,7 @@ public class MetsManager(
             StorageLocation = null
         };
         var amdSec = metadataManager.GetAmdSecType(premisFile, admId, techId);
-        var dmdResult = PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv);
+        var dmdResult = PopulateDmdFromResource(fullMets, workingDirectory, childDirectoryDiv, localPath);
         if (dmdResult.Failure) return dmdResult;
 
         // Attach div, amdSec and cache entry together, after anything that could throw,
@@ -250,6 +249,21 @@ public class MetsManager(
 
         SortChildDivs(parentDiv);
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// The ID of an existing child div that already stands for <paramref name="localPath"/>, or
+    /// null if the path is free. Reaching an add for a path whose div already exists means that
+    /// div could not be resolved by path OR by the legacy ID fallback - adding anyway would put
+    /// a second div for one path into the METS. Both ID forms count: the encoded form this add
+    /// would mint, and the raw-path form carried by documents written before issue #188 (where
+    /// an encoded mint would not collide on the ID attribute, so the raw form has to be checked
+    /// explicitly).
+    /// </summary>
+    private static string? FindConflictingChild(DivType parentDiv, string localPath, string physId)
+    {
+        var legacyPhysId = Constants.PhysIdPrefix + localPath;
+        return parentDiv.Div.FirstOrDefault(d => d.Id == physId || d.Id == legacyPhysId)?.Id;
     }
 
     /// <summary>
@@ -282,6 +296,12 @@ public class MetsManager(
 
     private DigitalPreservation.XmlGen.Mets.Mets GetEmptyMets()
     {
+        // Every ID is built as prefix + encoded path, even where the path needs no encoding, so
+        // that no minting site anywhere concatenates a raw path into an ID (issue #188).
+        var objectsIdPart = FolderNames.Objects.ToMetsId();
+        var metadataIdPart = FolderNames.Metadata.ToMetsId();
+        var adHocIdPart = FolderNames.MetadataAdHoc.ToMetsId();
+
         var mets = new DigitalPreservation.XmlGen.Mets.Mets
         {
             MetsHdr = new()
@@ -325,17 +345,17 @@ public class MetsManager(
                                 Id = Constants.MetadataDivId,
                                 Type = Constants.DirectoryType,
                                 Label = FolderNames.Metadata,
-                                Dmdid = { $"{Constants.DmdIdPrefix}{FolderNames.Metadata}" },
-                                Admid = { $"{Constants.AdmIdPrefix}{FolderNames.Metadata}" },
-                                Div = 
+                                Dmdid = { $"{Constants.DmdIdPrefix}{metadataIdPart}" },
+                                Admid = { $"{Constants.AdmIdPrefix}{metadataIdPart}" },
+                                Div =
                                     {
                                         new DivType
                                         {
                                             Id = Constants.MetadataAdHocDivId,
                                             Type = Constants.DirectoryType,
                                             Label = FolderNames.AdHoc,
-                                            Admid = { $"{Constants.AdmIdPrefix}{FolderNames.MetadataAdHoc}" },
-                                            Dmdid = { $"{Constants.DmdIdPrefix}{FolderNames.MetadataAdHoc}" },
+                                            Admid = { $"{Constants.AdmIdPrefix}{adHocIdPart}" },
+                                            Dmdid = { $"{Constants.DmdIdPrefix}{adHocIdPart}" },
                                         }
                                     }
                             },
@@ -344,8 +364,8 @@ public class MetsManager(
                                 Id = Constants.ObjectsDivId,
                                 Type = Constants.DirectoryType,
                                 Label = FolderNames.Objects,
-                                Dmdid = { $"{Constants.DmdIdPrefix}{FolderNames.Objects}" },
-                                Admid = { $"{Constants.AdmIdPrefix}{FolderNames.Objects}" }
+                                Dmdid = { $"{Constants.DmdIdPrefix}{objectsIdPart}" },
+                                Admid = { $"{Constants.AdmIdPrefix}{objectsIdPart}" }
                             }
                         }
                     }
@@ -357,17 +377,17 @@ public class MetsManager(
                     {
                         Source = Constants.Mets, OriginalName = FolderNames.Objects
                     },
-                    $"{Constants.AdmIdPrefix}{FolderNames.Objects}", $"{Constants.TechIdPrefix}{FolderNames.Objects}"),
+                    $"{Constants.AdmIdPrefix}{objectsIdPart}", $"{Constants.TechIdPrefix}{objectsIdPart}"),
                 metadataManager.GetAmdSecType(new FileFormatMetadata
                     {
                         Source = Constants.Mets, OriginalName = FolderNames.Metadata
                     },
-                    $"{Constants.AdmIdPrefix}{FolderNames.Metadata}", $"{Constants.TechIdPrefix}{FolderNames.Metadata}"),
+                    $"{Constants.AdmIdPrefix}{metadataIdPart}", $"{Constants.TechIdPrefix}{metadataIdPart}"),
                 metadataManager.GetAmdSecType(new FileFormatMetadata
                     {
                         Source = Constants.Mets, OriginalName = FolderNames.MetadataAdHoc
                     },
-                    $"{Constants.AdmIdPrefix}{FolderNames.MetadataAdHoc}", $"{Constants.TechIdPrefix}{FolderNames.MetadataAdHoc}")
+                    $"{Constants.AdmIdPrefix}{adHocIdPart}", $"{Constants.TechIdPrefix}{adHocIdPart}")
             }
             // NB we don't have a structLink because we have no logical structMap (yet)
         };
@@ -592,9 +612,12 @@ public class MetsManager(
     /// <summary>
     /// Fallback resolution among the current div's children when the cache has no usable entry
     /// for a path: first by each child's own path metadata (correct even when an unrelated div
-    /// elsewhere claims the same path), then by the legacy ID convention, which keeps divs with
-    /// broken path metadata navigable exactly as they were before the cache existed. The legacy
-    /// tier can be removed after a bulk ID migration (issue #188 step 3).
+    /// elsewhere claims the same path), then by the ID convention, which keeps divs with broken
+    /// path metadata navigable exactly as they were before the cache existed. The convention
+    /// tier tries BOTH ID forms - the encoded one minted since issue #188 and the raw-path one
+    /// in older documents - because a document can hold both, and a div whose path metadata is
+    /// broken is reachable by nothing else. It can be removed after a bulk ID migration
+    /// (issue #188 step 3).
     /// </summary>
     private static DivType? FindChildDivByPath(DivType parent, string testPath, DigitalPreservation.XmlGen.Mets.Mets mets)
     {
@@ -612,7 +635,9 @@ public class MetsManager(
         {
             return byMetadata.Count == 1 ? byMetadata[0] : null;
         }
-        return UniqueOrNull(parent.Div.Where(d => d.Id == $"{Constants.PhysIdPrefix}{testPath}"));
+        var encodedId = $"{Constants.PhysIdPrefix}{testPath.ToMetsId()}";
+        var legacyId = $"{Constants.PhysIdPrefix}{testPath}";
+        return UniqueOrNull(parent.Div.Where(d => d.Id == encodedId || d.Id == legacyId));
     }
 
     private static DivType? UniqueOrNull(IEnumerable<DivType> divs)
@@ -718,30 +743,43 @@ public class MetsManager(
     /// <param name="mets"></param>
     /// <param name="resource"></param>
     /// <param name="div"></param>
-    private static Result PopulateDmdFromResource(FullMets mets, ResourceBase resource, DivType div)
+    /// <param name="localPath">the div's deposit-relative path, already normalised</param>
+    private static Result PopulateDmdFromResource(FullMets mets, ResourceBase resource, DivType div, string localPath)
     {
         if (resource.AccessRestrictions != null)
         {
             // If it's an empty array rather than null, this will clear the access restrictions
-            var result = SetAccessRestrictionsForDiv(mets, div, resource.AccessRestrictions);
+            var result = SetAccessRestrictionsForDiv(mets, div, resource.AccessRestrictions, localPath);
             if (result.Failure) return result;
         }
 
         if (resource.RightsStatement != null)
         {
             // OK how to clear a Rights statement?
-            var result = SetRightsStatementForDiv(mets, div, resource.RightsStatement);
+            var result = SetRightsStatementForDiv(mets, div, resource.RightsStatement, localPath);
             if (result.Failure) return result;
         }
 
         if (resource.RecordInfo != null)
         {
             // Clear this by passing in a RecordInfo with empty RecordIdentifiers[]
-            var result = SetRecordInfoForDiv(mets, div, resource.RecordInfo);
+            var result = SetRecordInfoForDiv(mets, div, resource.RecordInfo, localPath);
             if (result.Failure) return result;
         }
 
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// The deposit-relative path a div stands for, taken from the path cache. Null for a logical
+    /// div (only physical divs are cached) and for a physical div whose path metadata could not
+    /// be resolved. Used by the ByDivId entry points, which are given an ID rather than a path,
+    /// so that a lazily created dmdSec is still identified by path (issue #188).
+    /// </summary>
+    private static string? PathForDiv(FullMets mets, DivType div)
+    {
+        EnsureCache(mets);
+        return mets.PhysicalDivsByPath.FirstOrDefault(kvp => ReferenceEquals(kvp.Value, div)).Key;
     }
 
     // The failure a Set*ForDiv method returns when the div's descriptive metadata cannot be
@@ -758,7 +796,7 @@ public class MetsManager(
         // BadRequest for consistency with EditMets, which reports the same condition.
         if (foundDepth != totalDepth)
             return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
-        return SetRecordInfoForDiv(mets, div, recordInfo);
+        return SetRecordInfoForDiv(mets, div, recordInfo, MetsCache.NormalisePathKey(localPath));
     }
 
     public Result SetRecordInfoByDivId(FullMets mets, string divId, RecordInfo recordInfo)
@@ -766,12 +804,12 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        return SetRecordInfoForDiv(mets, div, recordInfo);
+        return SetRecordInfoForDiv(mets, div, recordInfo, PathForDiv(mets, div));
     }
 
-    private static Result SetRecordInfoForDiv(FullMets mets, DivType div, RecordInfo recordInfo)
+    private static Result SetRecordInfoForDiv(FullMets mets, DivType div, RecordInfo recordInfo, string? localPath)
     {
-        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
+        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true, localPath);
         if (mods is null) return ModsUnavailable(div);
 
         mods.SetRecordInfo(recordInfo);
@@ -784,7 +822,7 @@ public class MetsManager(
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
             return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
-        return SetRightsStatementForDiv(mets, div, rightsStatement);
+        return SetRightsStatementForDiv(mets, div, rightsStatement, MetsCache.NormalisePathKey(localPath));
     }
 
     public Result SetRightsStatementByDivId(FullMets mets, string divId, Uri? rightsStatement)
@@ -792,7 +830,7 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        return SetRightsStatementForDiv(mets, div, rightsStatement);
+        return SetRightsStatementForDiv(mets, div, rightsStatement, PathForDiv(mets, div));
     }
 
     // Writes a UseAndReproduction element with a non-URI sentinel value so that the
@@ -804,7 +842,7 @@ public class MetsManager(
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
             return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
-        return SuppressRightsInheritanceForDiv(mets, div);
+        return SuppressRightsInheritanceForDiv(mets, div, MetsCache.NormalisePathKey(localPath));
     }
 
     public Result SuppressRightsInheritanceByDivId(FullMets mets, string divId)
@@ -812,12 +850,12 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        return SuppressRightsInheritanceForDiv(mets, div);
+        return SuppressRightsInheritanceForDiv(mets, div, PathForDiv(mets, div));
     }
 
-    private static Result SuppressRightsInheritanceForDiv(FullMets mets, DivType div)
+    private static Result SuppressRightsInheritanceForDiv(FullMets mets, DivType div, string? localPath)
     {
-        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd: true);
+        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd: true, localPath);
         if (mods is null) return ModsUnavailable(div);
         mods.RemoveAccessConditions(Constants.UseAndReproduction);
         mods.AddAccessCondition(Constants.NullRightsStatement, Constants.UseAndReproduction);
@@ -825,9 +863,9 @@ public class MetsManager(
         return Result.Ok();
     }
 
-    private static Result SetRightsStatementForDiv(FullMets mets, DivType div, Uri? rightsStatement)
+    private static Result SetRightsStatementForDiv(FullMets mets, DivType div, Uri? rightsStatement, string? localPath)
     {
-        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
+        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true, localPath);
         if (mods is null) return ModsUnavailable(div);
 
         mods.RemoveAccessConditions(Constants.UseAndReproduction);
@@ -845,7 +883,7 @@ public class MetsManager(
         var (div, _, foundDepth, totalDepth) = LocateMetsDivByLocalPath(mets, localPath);
         if (foundDepth != totalDepth)
             return Result.Fail(ErrorCodes.BadRequest, DescribePathFailure(mets, localPath));
-        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
+        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions, MetsCache.NormalisePathKey(localPath));
     }
 
     public Result SetAccessRestrictionsByDivId(FullMets mets, string divId, List<string> accessRestrictions)
@@ -853,12 +891,12 @@ public class MetsManager(
         var div = LocateMetsDivByDivId(mets, divId);
         if (div is null)
             return Result.Fail(ErrorCodes.NotFound, $"No div with ID '{divId}' in METS");
-        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions);
+        return SetAccessRestrictionsForDiv(mets, div, accessRestrictions, PathForDiv(mets, div));
     }
 
-    private static Result SetAccessRestrictionsForDiv(FullMets mets, DivType div, List<string> accessRestrictions)
+    private static Result SetAccessRestrictionsForDiv(FullMets mets, DivType div, List<string> accessRestrictions, string? localPath)
     {
-        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true);
+        var mods = ModsManager.GetModsForDiv(mets.Mets, div, createDmd:true, localPath);
         if (mods is null) return ModsUnavailable(div);
 
         mods.RemoveAccessConditions(Constants.RestrictionOnAccess);
@@ -870,10 +908,21 @@ public class MetsManager(
         return Result.Ok();
     }
 
-    public void SetStructMap(FullMets mets, LogicalRange logSm)
+    public Result SetStructMap(FullMets mets, LogicalRange logSm)
     {
+        // Logical div IDs are the client's, not ours: they are written into the METS verbatim
+        // and the client round-trips them, so an invalid one is REJECTED rather than encoded -
+        // silently changing an ID would break the client's own references. This is the only
+        // route by which a caller-supplied string becomes an xs:ID (issue #188).
+        var invalid = FindInvalidRangeId(logSm);
+        if (invalid != null)
+        {
+            return Result.Fail(ErrorCodes.BadRequest,
+                $"Logical structMap range ID '{invalid}' is not a valid XML name.");
+        }
+
         var existing = mets.Mets.StructMap
-            .FirstOrDefault(sm => sm.Type == Constants.Logical && sm.Div?.Id == logSm.Id);
+            .FirstOrDefault(sm => sm.Type == Constants.Logical && SameStructMapId(sm.Div?.Id, logSm.Id));
         if (existing != null)
         {
             RemoveLogicalStructMapDmdSecs(mets, existing.Div);
@@ -885,13 +934,54 @@ public class MetsManager(
             Type = Constants.Logical,
             Div = BuildLogicalDiv(mets, logSm)
         });
+        return Result.Ok();
+    }
+
+    /// <summary>
+    /// Match the root IDs of two logical structMaps, treating absent and empty as the same
+    /// thing. A logical div in third-party METS may carry no ID at all; the parser surfaces
+    /// that as an empty string and this class writes it back as no attribute, so both forms
+    /// must go on identifying the same structMap for replace and remove.
+    /// </summary>
+    private static bool SameStructMapId(string? a, string? b) =>
+        (a ?? string.Empty) == (b ?? string.Empty);
+
+    /// <summary>
+    /// The first range ID in the tree that could not be used as an xs:ID, or null if all are
+    /// usable. An absent ID (null, or the empty string the parser reports for a logical div
+    /// with no ID attribute) is not a rejection: BuildLogicalDiv writes no ID attribute for it.
+    /// </summary>
+    private static string? FindInvalidRangeId(LogicalRange range)
+    {
+        if (range.Id.HasText() && !IsValidNCName(range.Id))
+        {
+            return range.Id;
+        }
+        return range.Ranges.Select(FindInvalidRangeId).FirstOrDefault(invalid => invalid != null);
+    }
+
+    private static bool IsValidNCName(string candidate)
+    {
+        try
+        {
+            XmlConvert.VerifyNCName(candidate);
+            return true;
+        }
+        catch (XmlException)
+        {
+            return false;
+        }
     }
 
     private static DivType BuildLogicalDiv(FullMets mets, LogicalRange range)
     {
         var div = new DivType
         {
-            Id = range.Id,
+            // An empty ID would be written as ID="", which is not a valid xs:ID. A logical div
+            // with no ID is a real shape - third-party METS often has one, and the parser
+            // reports it as an empty string - so it is written back as no ID attribute rather
+            // than an empty one (issue #188).
+            Id = range.Id.HasText() ? range.Id : null,
             Type = range.Type,
             Label = range.Name
         };
@@ -907,14 +997,16 @@ public class MetsManager(
             ModsManager.SetModsForDiv(mets.Mets, div, mods);
         }
 
+        // A logical div has no deposit-relative path: its dmdSec is identified from the
+        // client-supplied div ID, which SetStructMap has validated as an NCName.
         if (range.AccessRestrictions is { Count: > 0 })
-            SetAccessRestrictionsForDiv(mets, div, range.AccessRestrictions);
+            SetAccessRestrictionsForDiv(mets, div, range.AccessRestrictions, null);
 
         if (range.RightsStatement != null)
-            SetRightsStatementForDiv(mets, div, range.RightsStatement);
+            SetRightsStatementForDiv(mets, div, range.RightsStatement, null);
 
         foreach (var fp in range.Files)
-            div.Fptr.Add(BuildFptr(fp));
+            div.Fptr.Add(BuildFptr(mets.Mets, fp));
 
         foreach (var child in range.Ranges)
             div.Div.Add(BuildLogicalDiv(mets, child));
@@ -922,9 +1014,30 @@ public class MetsManager(
         return div;
     }
 
-    private static DivTypeFptr BuildFptr(FilePointer fp)
+    /// <summary>
+    /// The ID of the FILE element in the fileSec that stands for a deposit-relative path -
+    /// looked up by FLocat href, never reconstructed from the path. A METS file written before
+    /// issue #188 carries raw-path FILE IDs, so minting the encoded form here would produce
+    /// fptr/smLink references to IDs that do not exist in the document (and would make the
+    /// existing raw-ID smLinks unremovable, since removal matches on the same derivation).
+    /// Minting is the last resort, for a path with no FILE element at all; the caller is then
+    /// writing a reference the fileSec has yet to catch up with, exactly as before.
+    /// </summary>
+    private static string ResolveFileId(DigitalPreservation.XmlGen.Mets.Mets mets, string? localPath)
     {
-        var fileId = Constants.FileIdPrefix + fp.LocalPath;
+        var normalised = MetsCache.NormalisePathKey(localPath);
+        // First-wins among duplicate hrefs, the same convention navigation uses for a
+        // malformed document.
+        var file = (mets.FileSec?.FileGrp ?? [])
+            .SelectMany(fg => fg.File)
+            .FirstOrDefault(f => normalised != null
+                                 && MetsCache.NormalisePathKey(f.FLocat.FirstOrDefault()?.Href) == normalised);
+        return file?.Id ?? Constants.FileIdPrefix + (normalised ?? string.Empty).ToMetsId();
+    }
+
+    private static DivTypeFptr BuildFptr(DigitalPreservation.XmlGen.Mets.Mets mets, FilePointer fp)
+    {
+        var fileId = ResolveFileId(mets, fp.LocalPath);
 
         if (fp.BeginTime.HasValue || fp.EndTime.HasValue)
         {
@@ -1012,23 +1125,24 @@ public class MetsManager(
     public void RemoveStructMap(FullMets mets, string id)
     {
         var existing = mets.Mets.StructMap
-            .FirstOrDefault(sm => sm.Type == Constants.Logical && sm.Div?.Id == id);
+            .FirstOrDefault(sm => sm.Type == Constants.Logical && SameStructMapId(sm.Div?.Id, id));
         if (existing == null) return;
 
         RemoveLogicalStructMapDmdSecs(mets, existing.Div);
         mets.Mets.StructMap.Remove(existing);
     }
 
-    // FILE_ ids are minted from paths; normalise incoming paths the same way navigation and
-    // ID minting do, so that a path variant the setters accept (./, BagIt data/ prefix)
-    // cannot produce smLinks referencing FILE ids that don't exist.
+    // smLinks reference the FILE elements the fileSec actually holds, so both ends are resolved
+    // by path (see ResolveFileId) rather than reconstructed - which keeps links to legacy
+    // raw-ID files correct, and removable. Paths are normalised first (./, BagIt data/ prefix)
+    // so the variants the setters accept all resolve to the same file.
     public void LinkFile(FullMets mets, string from, string to, Uri role)
     {
         mets.Mets.StructLink ??= new MetsTypeStructLink();
         mets.Mets.StructLink.SmLink.Add(new StructLinkTypeSmLink
         {
-            From = Constants.FileIdPrefix + MetsCache.NormalisePathKey(from),
-            To = Constants.FileIdPrefix + MetsCache.NormalisePathKey(to),
+            From = ResolveFileId(mets.Mets, from),
+            To = ResolveFileId(mets.Mets, to),
             Arcrole = role.ToString()
         });
     }
@@ -1037,8 +1151,8 @@ public class MetsManager(
     {
         if (mets.Mets.StructLink == null) return;
 
-        var fromId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(from);
-        var toId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(to);
+        var fromId = ResolveFileId(mets.Mets, from);
+        var toId = ResolveFileId(mets.Mets, to);
         var arcrole = role.ToString();
 
         var link = mets.Mets.StructLink.SmLink
@@ -1052,7 +1166,7 @@ public class MetsManager(
         // Remove all existing outgoing smLinks from this file
         if (mets.Mets.StructLink != null)
         {
-            var fromId = Constants.FileIdPrefix + MetsCache.NormalisePathKey(localPath);
+            var fromId = ResolveFileId(mets.Mets, localPath);
             var toRemove = mets.Mets.StructLink.SmLink.Where(sl => sl.From == fromId).ToList();
             foreach (var sl in toRemove)
                 mets.Mets.StructLink.SmLink.Remove(sl);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -178,7 +178,7 @@ public class MetsManager(
         var physId = Constants.PhysIdPrefix + localPath.ToMetsId();
         var fileId = Constants.FileIdPrefix + localPath.ToMetsId();
 
-        var conflict = FindConflictingChild(parentDiv, localPath, physId);
+        var conflict = FindConflictingChild(parentDiv, localPath, physId, fullMets);
         if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
@@ -215,7 +215,7 @@ public class MetsManager(
         var admId = Constants.AdmIdPrefix + localPath.ToMetsId();
         var techId = Constants.TechIdPrefix + localPath.ToMetsId();
 
-        var conflict = FindConflictingChild(parentDiv, localPath, physId);
+        var conflict = FindConflictingChild(parentDiv, localPath, physId, fullMets);
         if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
@@ -252,18 +252,41 @@ public class MetsManager(
     }
 
     /// <summary>
-    /// The ID of an existing child div that already stands for <paramref name="localPath"/>, or
-    /// null if the path is free. Reaching an add for a path whose div already exists means that
-    /// div could not be resolved by path OR by the legacy ID fallback - adding anyway would put
-    /// a second div for one path into the METS. Both ID forms count: the encoded form this add
-    /// would mint, and the raw-path form carried by documents written before issue #188 (where
-    /// an encoded mint would not collide on the ID attribute, so the raw form has to be checked
-    /// explicitly).
+    /// A description of an existing child div that already stands for <paramref name="localPath"/>,
+    /// or null if the path is free. Reaching an add for a path whose div already exists means
+    /// that div could not be resolved unambiguously - adding anyway would put a second div for
+    /// one path into the METS.
     /// </summary>
-    private static string? FindConflictingChild(DivType parentDiv, string localPath, string physId)
+    /// <remarks>
+    /// Three ways a child can already stand for the path, and all three have to be checked:
+    /// the encoded ID this add would mint; the raw-path ID carried by documents written before
+    /// issue #188 (an encoded mint would not collide with it, so it cannot be caught by the
+    /// first check); and - the case IDs cannot catch at all - a div whose own metadata resolves
+    /// to this path while carrying an ID of some entirely different scheme. That last one is
+    /// exactly what happens when two siblings resolve to one path: navigation rightly refuses
+    /// to guess between them, which brings the operation here as an ADD.
+    /// </remarks>
+    private static string? FindConflictingChild(
+        DivType parentDiv, string localPath, string physId, FullMets fullMets)
     {
         var legacyPhysId = Constants.PhysIdPrefix + localPath;
-        return parentDiv.Div.FirstOrDefault(d => d.Id == physId || d.Id == legacyPhysId)?.Id;
+        var byId = parentDiv.Div.FirstOrDefault(d => d.Id == physId || d.Id == legacyPhysId);
+        if (byId != null)
+        {
+            return byId.Id;
+        }
+
+        // A complete cache with no entry for this path proves no div resolves to it, so the
+        // scan below cannot match. Skipping it keeps the ordinary add - by far the common case -
+        // free of a per-sibling resolution.
+        if (fullMets.PathDiagnostics.Count == 0 && !fullMets.PhysicalDivsByPath.ContainsKey(localPath))
+        {
+            return null;
+        }
+
+        var index = new MetsIdIndex(fullMets.Mets);
+        var byPath = parentDiv.Div.FirstOrDefault(d => MetsCache.TryResolvePath(d, fullMets.Mets, index) == localPath);
+        return byPath == null ? null : byPath.Id ?? "(no ID)";
     }
 
     /// <summary>
@@ -325,7 +348,7 @@ public class MetsManager(
             {
                 FileGrp =
                 {
-                    new MetsTypeFileSecFileGrp { Use = "OBJECTS" }
+                    new MetsTypeFileSecFileGrp { Use = Constants.ObjectsFileGrpUse }
                 }
             },
             StructMap =
@@ -447,6 +470,10 @@ public class MetsManager(
             .ToList();
 
         fileGroup?.File.Remove(file!);
+        if (file?.Id != null)
+        {
+            RemoveReferencesToFile(fullMets.Mets, file.Id);
+        }
         foreach (var amdSec in amdSecs)
         {
             fullMets.Mets.AmdSec.Remove(amdSec);
@@ -460,6 +487,41 @@ public class MetsManager(
         EvictFromPathCache(fullMets, div);
 
         return Result.Ok();
+    }
+
+    /// <summary>
+    /// Drop every structLink and logical-structMap pointer to a FILE element that has just been
+    /// removed. Both <c>fptr/@FILEID</c> and <c>smLink/@xlink:from|to</c> are IDREFs, so leaving
+    /// them behind makes the document invalid - and worse than invalid: since issue #188 step 2
+    /// a file re-added at the same path is minted a NEW (encoded) ID, so the stale reference can
+    /// never again be matched, and no API call can remove it. Before step 2 the re-add happened
+    /// to reproduce the same raw ID and quietly healed the link.
+    /// </summary>
+    private static void RemoveReferencesToFile(DigitalPreservation.XmlGen.Mets.Mets mets, string fileId)
+    {
+        if (mets.StructLink != null)
+        {
+            var staleLinks = mets.StructLink.SmLink
+                .Where(link => link.From == fileId || link.To == fileId)
+                .ToList();
+            foreach (var link in staleLinks)
+            {
+                mets.StructLink.SmLink.Remove(link);
+            }
+        }
+
+        // fptrs live on divs in every structMap - the physical div being deleted takes its own
+        // with it, but a LOGICAL div painting this file keeps pointing at a file that is gone.
+        foreach (var div in mets.StructMap.Where(sm => sm.Div != null).SelectMany(sm => SelfAndDescendants(sm.Div)))
+        {
+            var staleFptrs = div.Fptr
+                .Where(fptr => fptr.Fileid == fileId || fptr.Area?.Fileid == fileId)
+                .ToList();
+            foreach (var fptr in staleFptrs)
+            {
+                div.Fptr.Remove(fptr);
+            }
+        }
     }
 
     /// <summary>
@@ -547,7 +609,7 @@ public class MetsManager(
     private static (FileType file, MetsTypeFileSecFileGrp fileGroup) SetFileAndFileGroup(DivType div, FullMets fullMets)
     {
         var fileId = div.Fptr[0].Fileid;
-        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == "OBJECTS");
+        var fileGroup = fullMets.Mets.FileSec.FileGrp.Single(fg => fg.Use == Constants.ObjectsFileGrpUse);
         var file = fileGroup.File.Single(f => f.Id == fileId);
         return (file, fileGroup);
     }
@@ -587,14 +649,26 @@ public class MetsManager(
             // diagnostics exist (duplicate paths, unresolvable divs) every step resolves
             // strictly among the current div's children, so an ambiguous path can never be
             // silently satisfied by whichever div the cache walked first.
-            DivType? childDiv = null;
-            if (fullMets.PathDiagnostics.Count == 0 &&
-                fullMets.PhysicalDivsByPath.TryGetValue(testPath, out var cached) &&
-                div.Div.Contains(cached))
+            DivType? childDiv;
+            DivType? cached = null;
+            var cacheIsComplete = fullMets.PathDiagnostics.Count == 0;
+            var cacheHit = cacheIsComplete &&
+                           fullMets.PhysicalDivsByPath.TryGetValue(testPath, out cached);
+            if (cacheHit && div.Div.Contains(cached!))
             {
                 childDiv = cached;
             }
-            childDiv ??= FindChildDivByPath(div, testPath, fullMets.Mets);
+            else
+            {
+                // A complete cache already records the path every div's own metadata resolves
+                // to, so on a MISS no sibling can resolve this path and the metadata tier is
+                // provably empty - skipping it is what stops an add from resolving every
+                // sibling (and rescanning the fileSec for each one). The ID-convention tier
+                // still runs: it answers a different question, and dropping it would narrow
+                // backwards compatibility rather than just speed things up.
+                var metadataTierCanMatch = !cacheIsComplete || cacheHit;
+                childDiv = FindChildDivByPath(div, testPath, fullMets.Mets, metadataTierCanMatch);
+            }
 
             if (childDiv is null)
             {
@@ -619,7 +693,8 @@ public class MetsManager(
     /// broken is reachable by nothing else. It can be removed after a bulk ID migration
     /// (issue #188 step 3).
     /// </summary>
-    private static DivType? FindChildDivByPath(DivType parent, string testPath, DigitalPreservation.XmlGen.Mets.Mets mets)
+    private static DivType? FindChildDivByPath(
+        DivType parent, string testPath, DigitalPreservation.XmlGen.Mets.Mets mets, bool tryMetadataTier = true)
     {
         // In each tier the match must be UNIQUE among the parent's children - if two children
         // claim the same path or the same conventional ID (corrupted METS), guessing one would
@@ -627,13 +702,19 @@ public class MetsManager(
         // incomplete-path error with the load-time diagnostics attached. An AMBIGUOUS
         // metadata tier is terminal: falling through to the legacy-ID tier would resolve by
         // guesswork exactly the ambiguity this method exists to refuse.
-        var byMetadata = parent.Div
-            .Where(d => MetsCache.TryResolvePath(d, mets) == testPath)
-            .Take(2)
-            .ToList();
-        if (byMetadata.Count > 0)
+        if (tryMetadataTier)
         {
-            return byMetadata.Count == 1 ? byMetadata[0] : null;
+            // One ID index for the whole sibling scan - resolving each child independently
+            // would rescan the fileSec per child.
+            var index = new MetsIdIndex(mets);
+            var byMetadata = parent.Div
+                .Where(d => MetsCache.TryResolvePath(d, mets, index) == testPath)
+                .Take(2)
+                .ToList();
+            if (byMetadata.Count > 0)
+            {
+                return byMetadata.Count == 1 ? byMetadata[0] : null;
+            }
         }
         var encodedId = $"{Constants.PhysIdPrefix}{testPath.ToMetsId()}";
         var legacyId = $"{Constants.PhysIdPrefix}{testPath}";
@@ -921,6 +1002,13 @@ public class MetsManager(
                 $"Logical structMap range ID '{invalid}' is not a valid XML name.");
         }
 
+        var duplicate = FindDuplicateRangeId(mets, logSm);
+        if (duplicate != null)
+        {
+            return Result.Fail(ErrorCodes.BadRequest,
+                $"Logical structMap range ID '{duplicate}' is already used in this METS file.");
+        }
+
         var existing = mets.Mets.StructMap
             .FirstOrDefault(sm => sm.Type == Constants.Logical && SameStructMapId(sm.Div?.Id, logSm.Id));
         if (existing != null)
@@ -958,6 +1046,45 @@ public class MetsManager(
             return range.Id;
         }
         return range.Ranges.Select(FindInvalidRangeId).FirstOrDefault(invalid => invalid != null);
+    }
+
+    /// <summary>
+    /// The first range ID that would not be unique in the document, or null if all are.
+    /// An xs:ID is an NCName AND unique - validating only the first half would still let a
+    /// caller write a document no schema-aware consumer can load. Both halves of the check
+    /// matter in practice: the UI mints LOG_ + epoch-milliseconds, so two ranges created in the
+    /// same millisecond collide with each other.
+    /// </summary>
+    /// <remarks>
+    /// IDs already in the structMap being REPLACED don't count as taken - re-applying an edited
+    /// structMap under its own ID is the normal path, and that map is removed before the new
+    /// one is written.
+    /// </remarks>
+    private static string? FindDuplicateRangeId(FullMets mets, LogicalRange logSm)
+    {
+        var replaced = mets.Mets.StructMap
+            .FirstOrDefault(sm => sm.Type == Constants.Logical && SameStructMapId(sm.Div?.Id, logSm.Id));
+        var replacedDivs = replaced?.Div == null
+            ? []
+            : new HashSet<DivType>(SelfAndDescendants(replaced.Div));
+
+        var taken = new HashSet<string>(mets.Mets.StructMap
+            .Where(sm => sm.Div != null)
+            .SelectMany(sm => SelfAndDescendants(sm.Div))
+            .Where(d => !replacedDivs.Contains(d) && d.Id.HasText())
+            .Select(d => d.Id));
+
+        return FindFirstTakenId(logSm, taken);
+    }
+
+    private static string? FindFirstTakenId(LogicalRange range, HashSet<string> taken)
+    {
+        // An ID-less range takes no ID, so several of them are not a collision with each other.
+        if (range.Id.HasText() && !taken.Add(range.Id))
+        {
+            return range.Id;
+        }
+        return range.Ranges.Select(child => FindFirstTakenId(child, taken)).FirstOrDefault(found => found != null);
     }
 
     private static bool IsValidNCName(string candidate)
@@ -1026,14 +1153,28 @@ public class MetsManager(
     private static string ResolveFileId(DigitalPreservation.XmlGen.Mets.Mets mets, string? localPath)
     {
         var normalised = MetsCache.NormalisePathKey(localPath);
-        // First-wins among duplicate hrefs, the same convention navigation uses for a
+        if (normalised == null)
+        {
+            return Constants.FileIdPrefix + string.Empty.ToMetsId();
+        }
+
+        // The OBJECTS group holds the preserved files; other groups (THUMBS, ALTO, derivatives
+        // in third-party METS) can carry an entry with the SAME href for a derivative of the
+        // same source. A link must name the master, so OBJECTS is searched first and the other
+        // groups only as a fallback - matching SetFileAndFileGroup, which requires OBJECTS
+        // outright. First-wins within a group, the same convention navigation uses for a
         // malformed document.
-        var file = (mets.FileSec?.FileGrp ?? [])
-            .SelectMany(fg => fg.File)
-            .FirstOrDefault(f => normalised != null
-                                 && MetsCache.NormalisePathKey(f.FLocat.FirstOrDefault()?.Href) == normalised);
-        return file?.Id ?? Constants.FileIdPrefix + (normalised ?? string.Empty).ToMetsId();
+        var fileGrps = mets.FileSec?.FileGrp ?? [];
+        var file = fileGrps.Where(fg => fg.Use == Constants.ObjectsFileGrpUse).SelectMany(fg => fg.File)
+                       .FirstOrDefault(f => HrefMatches(f, normalised))
+                   ?? fileGrps.Where(fg => fg.Use != Constants.ObjectsFileGrpUse).SelectMany(fg => fg.File)
+                       .FirstOrDefault(f => HrefMatches(f, normalised));
+
+        return file?.Id ?? Constants.FileIdPrefix + normalised.ToMetsId();
     }
+
+    private static bool HrefMatches(FileType file, string normalisedPath) =>
+        MetsCache.NormalisePathKey(file.FLocat.FirstOrDefault()?.Href) == normalisedPath;
 
     private static DivTypeFptr BuildFptr(DigitalPreservation.XmlGen.Mets.Mets mets, FilePointer fp)
     {

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -178,7 +178,7 @@ public class MetsManager(
         var physId = Constants.PhysIdPrefix + localPath.ToMetsId();
         var fileId = Constants.FileIdPrefix + localPath.ToMetsId();
 
-        var conflict = FindConflictingChild(parentDiv, localPath, physId, fullMets);
+        var conflict = FindConflictingChild(parentDiv, localPath, fullMets);
         if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
@@ -215,7 +215,7 @@ public class MetsManager(
         var admId = Constants.AdmIdPrefix + localPath.ToMetsId();
         var techId = Constants.TechIdPrefix + localPath.ToMetsId();
 
-        var conflict = FindConflictingChild(parentDiv, localPath, physId, fullMets);
+        var conflict = FindConflictingChild(parentDiv, localPath, fullMets);
         if (conflict != null)
         {
             return Result.Fail(ErrorCodes.BadRequest,
@@ -266,11 +266,10 @@ public class MetsManager(
     /// exactly what happens when two siblings resolve to one path: navigation rightly refuses
     /// to guess between them, which brings the operation here as an ADD.
     /// </remarks>
-    private static string? FindConflictingChild(
-        DivType parentDiv, string localPath, string physId, FullMets fullMets)
+    private static string? FindConflictingChild(DivType parentDiv, string localPath, FullMets fullMets)
     {
-        var legacyPhysId = Constants.PhysIdPrefix + localPath;
-        var byId = parentDiv.Div.FirstOrDefault(d => d.Id == physId || d.Id == legacyPhysId);
+        var (encodedId, legacyId) = PhysicalDivIdCandidates(localPath);
+        var byId = parentDiv.Div.FirstOrDefault(d => d.Id == encodedId || d.Id == legacyId);
         if (byId != null)
         {
             return byId.Id;
@@ -725,10 +724,22 @@ public class MetsManager(
                 return byMetadata.Count == 1 ? byMetadata[0] : null;
             }
         }
-        var encodedId = $"{Constants.PhysIdPrefix}{testPath.ToMetsId()}";
-        var legacyId = $"{Constants.PhysIdPrefix}{testPath}";
+        var (encodedId, legacyId) = PhysicalDivIdCandidates(testPath);
         return UniqueOrNull(parent.Div.Where(d => d.Id == encodedId || d.Id == legacyId));
     }
+
+    /// <summary>
+    /// The two ID forms a physical div may carry for one path: the encoded form minted since
+    /// issue #188, and the raw-path form in documents written before it.
+    /// </summary>
+    /// <remarks>
+    /// Navigation's ID-convention tier and the duplicate-div guard both accept either form, and
+    /// they have to agree on the set — if they disagree, a div one of them can find is invisible
+    /// to the other, which is precisely the duplicate-div bug the guard exists to prevent. A
+    /// step 3 migration would change what belongs here, so it is one place rather than two.
+    /// </remarks>
+    private static (string Encoded, string Legacy) PhysicalDivIdCandidates(string localPath) =>
+        (Constants.PhysIdPrefix + localPath.ToMetsId(), Constants.PhysIdPrefix + localPath);
 
     private static DivType? UniqueOrNull(IEnumerable<DivType> divs)
     {
@@ -866,6 +877,21 @@ public class MetsManager(
     /// be resolved. Used by the ByDivId entry points, which are given an ID rather than a path,
     /// so that a lazily created dmdSec is still identified by path (issue #188).
     /// </summary>
+    /// <remarks>
+    /// The reverse scan is deliberate, and is doing more than recovering a path: only physical
+    /// divs are in the cache, so a miss is what tells us the div is LOGICAL. Resolving the div's
+    /// metadata directly instead (<see cref="MetsCache.TryResolvePath(DivType,
+    /// DigitalPreservation.XmlGen.Mets.Mets)"/>) would look like the same answer for less work,
+    /// but a logical div of TYPE="Item" carrying an fptr resolves the path of the file it paints
+    /// — so it would be handed the DMD_ id of the PHYSICAL div for that path, and the two would
+    /// share a dmdSec. Any future change here has to keep the physical/logical distinction.
+    ///
+    /// Cost is O(cache) per call, which is fine for the one-div-at-a-time callers that exist
+    /// today (none is wired to a controller yet). The ByDivId shape is documented on
+    /// <see cref="IMetsManager"/> as suiting a caller looping over many div IDs against one
+    /// FullMets, and that caller would be O(divs x cache): it should hoist a reverse map, or a
+    /// physical-div set, across its loop rather than paying this per div.
+    /// </remarks>
     private static string? PathForDiv(FullMets mets, DivType div)
     {
         EnsureCache(mets);

--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsManager.cs
@@ -512,7 +512,7 @@ public class MetsManager(
 
         // fptrs live on divs in every structMap - the physical div being deleted takes its own
         // with it, but a LOGICAL div painting this file keeps pointing at a file that is gone.
-        foreach (var div in mets.StructMap.Where(sm => sm.Div != null).SelectMany(sm => SelfAndDescendants(sm.Div)))
+        foreach (var div in AllDivs(mets))
         {
             var staleFptrs = div.Fptr
                 .Where(fptr => fptr.Fileid == fileId || fptr.Area?.Fileid == fileId)
@@ -538,10 +538,7 @@ public class MetsManager(
     {
         var referencedIds = new HashSet<string>();
 
-        var divs = mets.StructMap
-            .Where(sm => sm.Div != null)
-            .SelectMany(sm => SelfAndDescendants(sm.Div))
-            .Where(d => !excludedDivs.Contains(d));
+        var divs = AllDivs(mets).Where(d => !excludedDivs.Contains(d));
         foreach (var d in divs)
         {
             AddReferences(d.Admid, referencedIds);
@@ -566,6 +563,28 @@ public class MetsManager(
         if (tokens.Count > 1)
         {
             referencedIds.Add(IdRefs.Joined(tokens));
+        }
+    }
+
+    /// <summary>
+    /// Every div in the document, across all structMaps. The generated model types
+    /// <c>StructMapType.Div</c> as non-nullable, but a structMap element with no root div is
+    /// legal XML and does occur in malformed documents - dereferencing it unguarded is a real
+    /// crash, so this is the single place that tolerance lives.
+    /// </summary>
+    private static IEnumerable<DivType> AllDivs(DigitalPreservation.XmlGen.Mets.Mets mets)
+    {
+        foreach (var structMap in mets.StructMap)
+        {
+            var root = structMap.Div;
+            if (root is null)
+            {
+                continue;
+            }
+            foreach (var div in SelfAndDescendants(root))
+            {
+                yield return div;
+            }
         }
     }
 
@@ -1068,9 +1087,7 @@ public class MetsManager(
             ? []
             : new HashSet<DivType>(SelfAndDescendants(replaced.Div));
 
-        var taken = new HashSet<string>(mets.Mets.StructMap
-            .Where(sm => sm.Div != null)
-            .SelectMany(sm => SelfAndDescendants(sm.Div))
+        var taken = new HashSet<string>(AllDivs(mets.Mets)
             .Where(d => !replacedDivs.Contains(d) && d.Id.HasText())
             .Select(d => d.Id));
 

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -175,7 +175,7 @@ public static class ModsManager
             var idPart = localPath != null
                 ? localPath.ToMetsId()
                 : div.Id.RemoveStart(Constants.PhysIdPrefix);
-            div.Dmdid.Add(Constants.DmdIdPrefix + idPart);
+            div.Dmdid.Add(idPart.HasText() ? Constants.DmdIdPrefix + idPart : UnusedDmdId(mets));
         }
         // Resolve the DMDID tokens to the actual dmdSec where one exists; the id used for
         // lazy creation is the joined legacy form only when no dmdSec resolves (see IdRefs).
@@ -184,6 +184,28 @@ public static class ModsManager
     }
 
     
+    /// <summary>
+    /// A dmdSec ID for a div that offers nothing to derive one from: a logical div with no ID
+    /// of its own, which third-party structMaps use freely and which the parser reports as an
+    /// empty ID. Deriving from the absent ID yields the bare prefix <c>DMD_</c> for EVERY such
+    /// div, so they would all share one section and each save would overwrite the previous
+    /// div's metadata. A dmdSec ID is ours to choose - unlike a div ID, which belongs to the
+    /// client and is never rewritten - so an unused one is minted instead.
+    /// </summary>
+    private static string UnusedDmdId(DigitalPreservation.XmlGen.Mets.Mets mets)
+    {
+        // Each caller creates its dmdSec before the next one asks, so the count is enough to
+        // make progress; the loop covers a document that already contains these IDs.
+        var suffix = 1;
+        string candidate;
+        do
+        {
+            candidate = $"{Constants.DmdIdPrefix}ANON_{suffix++}";
+        }
+        while (mets.DmdSec.Any(dmdSec => dmdSec.Id == candidate));
+        return candidate;
+    }
+
     /// <summary>
     /// Write the div's MODS record - the same single dmdSec <see cref="GetModsForDiv"/>
     /// resolves; other dmdSecs a genuine multi-token DMDID references are never mutated.

--- a/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/ModsManager.cs
@@ -159,20 +159,23 @@ public static class ModsManager
     /// ever writes one descriptive record per div, so any further referenced dmdSecs are
     /// third-party content that read/write operations deliberately leave untouched.
     /// </summary>
-    public static ModsDefinition? GetModsForDiv(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div, bool createDmd = false)
+    /// <param name="localPath">
+    /// The div's deposit-relative path, where it has one. A dmdSec created for a physical div is
+    /// identified from this path rather than from the div's ID, so a legacy raw-ID div gets a
+    /// valid encoded DMD_ id instead of a second invalid one (issue #188). Null for logical divs,
+    /// and for a physical div whose path could not be resolved - both fall back to deriving the
+    /// ID from div.Id, which for a logical div is the client-supplied (NCName-validated) ID.
+    /// </param>
+    public static ModsDefinition? GetModsForDiv(DigitalPreservation.XmlGen.Mets.Mets mets, DivType div,
+        bool createDmd = false, string? localPath = null)
     {
         if (div.Dmdid.Count == 0 && createDmd)
         {
             // There is no DMDID on this div
-            if (div.Id.StartsWith(Constants.PhysIdPrefix))
-            {
-                div.Dmdid.Add(Constants.DmdIdPrefix + div.Id.RemoveStart(Constants.PhysIdPrefix));
-            }
-            else
-            {
-                // A logical structMap div that might have been supplied by the client
-                div.Dmdid.Add(Constants.DmdIdPrefix + div.Id);
-            }
+            var idPart = localPath != null
+                ? localPath.ToMetsId()
+                : div.Id.RemoveStart(Constants.PhysIdPrefix);
+            div.Dmdid.Add(Constants.DmdIdPrefix + idPart);
         }
         // Resolve the DMDID tokens to the actual dmdSec where one exists; the id used for
         // lazy creation is the joined legacy form only when no dmdSec resolves (see IdRefs).

--- a/src/DigitalPreservation/DigitalPreservation.Utils/MetsIdEncoding.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/MetsIdEncoding.cs
@@ -1,0 +1,33 @@
+using System.Xml;
+
+namespace DigitalPreservation.Utils;
+
+/// <summary>
+/// Encoding of deposit-relative paths for use inside METS <c>xs:ID</c> attributes (issue #188).
+/// An <c>xs:ID</c> must be an XML NCName, which excludes the <c>/</c> and space that appear in
+/// almost every path we mint an ID from, so the path component of every ID the platform mints
+/// passes through <see cref="ToMetsId"/> first.
+/// </summary>
+/// <remarks>
+/// The encoding is <see cref="XmlConvert.EncodeLocalName"/>: invalid characters become
+/// <c>_xNNNN_</c> escapes, a leading digit is escaped the same way, Unicode letters pass
+/// through, and a literal <c>_x</c> sequence is self-escaped so the transform is bijective
+/// (<see cref="DecodeMetsId"/> is its exact inverse). No consumer decodes METS IDs — they are
+/// opaque strings everywhere outside this class — but the inverse exists so the encoding can be
+/// shown to lose nothing.
+/// </remarks>
+public static class MetsIdEncoding
+{
+    /// <summary>
+    /// Encode a deposit-relative path as the variable part of a METS ID. Prefixes
+    /// (<c>PHYS_</c>, <c>FILE_</c>, …) are NOT added — callers concatenate their own, and every
+    /// prefix is itself a valid NCName start, so prefix + encoded path is always a valid ID.
+    /// </summary>
+    public static string ToMetsId(this string localPath) => XmlConvert.EncodeLocalName(localPath);
+
+    /// <summary>
+    /// Recover the original path from a value produced by <see cref="ToMetsId"/>. The prefix, if
+    /// any, must be removed first.
+    /// </summary>
+    public static string DecodeMetsId(this string id) => XmlConvert.DecodeName(id);
+}

--- a/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Utils/StringUtils.cs
@@ -36,6 +36,9 @@ public static class StringUtils
     /// <param name="str"></param>
     /// <param name="start"></param>
     /// <returns></returns>
+    // Null in, null out - and never null otherwise, so callers starting from a non-null string
+    // keep a non-null one through a chain of RemoveStart calls.
+    [return: NotNullIfNotNull(nameof(str))]
     public static string? RemoveStart(this string? str, string start)
     {
         switch (str)

--- a/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/SetLogicalStructMap.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Workspace/Requests/SetLogicalStructMap.cs
@@ -21,7 +21,11 @@ public class SetLogicalStructMapHandler(IMetsManager metsManager) : IRequestHand
         if (metsResult is { Success: true, Value: not null })
         {
             var fullMets = metsResult.Value;
-            metsManager.SetStructMap(fullMets, request.LogicalRange);
+            var setResult = metsManager.SetStructMap(fullMets, request.LogicalRange);
+            if (setResult.Failure)
+            {
+                return setResult;
+            }
             var writeMetsResult = await metsManager.WriteMets(fullMets);
             if (writeMetsResult.Failure)
             {

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -119,7 +119,7 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
         foreach (var binary in binaries)
         {
             var localPath = binary.Id!.LocalPath.RemoveStart(agLocalPath).RemoveStart("/");
-            if (MetsUtils.IsMetsFile(localPath!, true))
+            if (MetsUtils.IsMetsFile(localPath, true))
             {
                 continue;
             }

--- a/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
+++ b/src/DigitalPreservation/Storage.Repository.Common/Mets/MetsFromArchivalGroup.cs
@@ -87,13 +87,14 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
 
             if (childDirectoryDiv == null)
             {
-                var admId = Constants.AdmIdPrefix + localPath;
-                var techId = Constants.TechIdPrefix + localPath;
+                var idPart = localPath.ToMetsId();
+                var admId = Constants.AdmIdPrefix + idPart;
+                var techId = Constants.TechIdPrefix + idPart;
                 childDirectoryDiv = new DivType
                 {
                     Type = Constants.DirectoryType,
                     Label = childContainer.Name,
-                    Id = $"{Constants.PhysIdPrefix}{localPath}",
+                    Id = $"{Constants.PhysIdPrefix}{idPart}",
                     Admid = { admId }
                 };
                 div.Div.Add(childDirectoryDiv);
@@ -122,14 +123,15 @@ public class MetsFromArchivalGroup(IMetsManager metsManager, IMetsParser metsPar
             {
                 continue;
             }
-            var fileId = Constants.FileIdPrefix + localPath;
-            var admId = Constants.AdmIdPrefix + localPath;
-            var techId = Constants.TechIdPrefix + localPath;
+            var idPart = localPath.ToMetsId();
+            var fileId = Constants.FileIdPrefix + idPart;
+            var admId = Constants.AdmIdPrefix + idPart;
+            var techId = Constants.TechIdPrefix + idPart;
             var childItemDiv = new DivType
             {
                 Type = Constants.ItemType,
                 Label = binary.Name,
-                Id = $"{Constants.PhysIdPrefix}{localPath}",
+                Id = $"{Constants.PhysIdPrefix}{idPart}",
                 Fptr = { new DivTypeFptr { Fileid = fileId } }
             };
             div.Div.Add(childItemDiv);

--- a/src/DigitalPreservation/XmlGen.Tests/EncodedMetsIdTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/EncodedMetsIdTests.cs
@@ -2,6 +2,7 @@ using System.Xml;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions;
+using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Mets.StorageImpl;
 using DigitalPreservation.XmlGen.Mets;
@@ -55,6 +56,17 @@ public class EncodedMetsIdTests
         File.Copy(source.FullName, dest.FullName, overwrite: true);
         return new Uri(dest.FullName);
     }
+
+    private static WorkingFile SimpleFile(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            ContentType = "application/pdf",
+            Digest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f",
+            Size = 54321,
+            Modified = DateTime.UtcNow
+        };
 
     private static void AssertIsValidId(string? id)
     {
@@ -233,6 +245,196 @@ public class EncodedMetsIdTests
 
         result.Success.Should().BeTrue(result.ErrorMessage ?? "");
         objectsDiv.Dmdid.Should().ContainSingle().Which.Should().Be($"{Constants.DmdIdPrefix}{FolderNames.Objects}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Regressions found by the cumulative adversarial review (2026-08-13)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Writing_A_Virus_Scan_To_A_Legacy_Document_Mints_A_VALID_Digiprov_Id()
+    {
+        // The digiprovMD ID used to be built from the RESOLVED amdSec's ID, which on a legacy
+        // document is the raw form - so a pipeline run over a legacy deposit minted a brand-new
+        // ID containing a slash and a space, from the very code step 2 was meant to make valid.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "encoded-legacy-digiprov.xml");
+        var fullMets = (await metsStorage.GetFullMets(metsUri, null)).Value!;
+
+        var file = SimpleFile("objects/my file.pdf", "my file.pdf");
+        file.Metadata.Add(new VirusScanMetadata
+        {
+            Source = "ClamAV", HasVirus = false, VirusFound = null, VirusDefinition = "27000"
+        });
+
+        var result = metsManager.AddToMets(fullMets, file);
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var amdSec = fullMets.Mets.AmdSec.Single(a => a.Id == "ADM_objects/my file.pdf");
+        var digiprov = amdSec.DigiprovMd.Should().ContainSingle().Subject;
+        digiprov.Id.Should().StartWith(Constants.VirusProvEventPrefix);
+        AssertIsValidId(digiprov.Id);
+        amdSec.Id.Should().Be("ADM_objects/my file.pdf", "the legacy amdSec's own ID is never rewritten");
+    }
+
+    [Fact]
+    public async Task An_Ambiguous_Path_Is_Refused_Even_When_No_Div_Has_A_Conventional_Id()
+    {
+        // Two siblings resolving to one path make navigation refuse to guess, which arrives
+        // here as an ADD. The guard used to compare IDs only, so divs carrying a third-party
+        // ID scheme slipped past it and the add produced a THIRD div for the same path.
+        var uri = new Uri(new FileInfo("Outputs/encoded-ambiguous-foreign-ids.xml").FullName);
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Foreign ID Ambiguity");
+
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var objectsAmdSec = mets.AmdSec.Single(a => a.Id == MetsIds.Adm(FolderNames.Objects));
+        var twinAdmId = "AMD-0001";
+        mets.AmdSec.Add(new AmdSecType { Id = twinAdmId, TechMd = { objectsAmdSec.TechMd[0] } });
+        objectsAmdSec.TechMd[0].MdWrap.XmlData.Any![0]
+            .GetElementsByTagName("originalName", "http://www.loc.gov/premis/v3")[0]!
+            .InnerText = "objects/twin";
+        objectsDiv.Admid.Clear();
+        // Neither div carries a PHYS_ id, so nothing the guard used to check can see them.
+        objectsDiv.Div.Add(new DivType
+        {
+            Id = "div-1", Type = Constants.DirectoryType, Label = "twin a", Admid = { twinAdmId }
+        });
+        objectsDiv.Div.Add(new DivType
+        {
+            Id = "div-2", Type = Constants.DirectoryType, Label = "twin b", Admid = { twinAdmId }
+        });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        MetsCache.Populate(fullMets);
+        var divCountBefore = objectsDiv.Div.Count;
+
+        var result = metsManager.AddToMets(fullMets, new WorkingDirectory
+        {
+            LocalPath = "objects/twin", Name = "twin", Modified = DateTime.UtcNow
+        });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorCode.Should().Be(ErrorCodes.BadRequest);
+        objectsDiv.Div.Count.Should().Be(divCountBefore, "no third div may be added for one path");
+    }
+
+    [Fact]
+    public async Task Links_Resolve_To_The_OBJECTS_File_Not_A_Derivative_With_The_Same_Href()
+    {
+        // Third-party METS carries derivative groups (THUMBS, ALTO) whose entries can repeat the
+        // master's href. A link must name the master, so the OBJECTS group is searched first.
+        var fullMets = await CreateAndLoadStandardMets("encoded-objects-filegrp.xml");
+        var add = metsManager.AddToMets(fullMets, SimpleFile("objects/page.tif", "page.tif"));
+        add.Success.Should().BeTrue(add.ErrorMessage ?? "");
+
+        // A derivative group, placed FIRST so a naive first-wins scan would find it.
+        fullMets.Mets.FileSec.FileGrp.Insert(0, new MetsTypeFileSecFileGrp
+        {
+            Use = "THUMBS",
+            File = { new FileType
+            {
+                Id = "FILE_THUMB_1",
+                FLocat = { new FileTypeFLocat { Href = "objects/page.tif", Loctype = FileTypeFLocatLoctype.Url } }
+            }}
+        });
+
+        metsManager.LinkFile(fullMets, "objects/page.tif", "objects/page.tif",
+            new Uri("http://example.org/roles/derived-from"));
+
+        var link = fullMets.Mets.StructLink!.SmLink.OfType<StructLinkTypeSmLink>().Single();
+        link.From.Should().Be(MetsIds.File("objects/page.tif"));
+        link.From.Should().NotBe("FILE_THUMB_1");
+    }
+
+    [Fact]
+    public async Task Two_Ranges_With_No_Id_Get_Their_Own_Descriptive_Records()
+    {
+        // A logical div with no ID is a real shape (third-party structMaps, and what the parser
+        // reports for an ID-less div). Deriving its dmdSec ID from the absent div ID gave every
+        // such div the bare prefix "DMD_", so they shared one section and the last save won.
+        var fullMets = await CreateAndLoadStandardMets("encoded-anon-logical-dmds.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "", Type = "Sequence", Name = "Root",
+            Ranges =
+            [
+                new LogicalRange { Id = "", Type = "Item", Name = "Chapter One" },
+                new LogicalRange { Id = "", Type = "Item", Name = "Chapter Two" }
+            ]
+        });
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var root = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Logical).Div!;
+        var titles = new[] { root }.Concat(root.Div)
+            .Select(div => ModsManager.GetModsForDiv(fullMets.Mets, div)?.TitleInfo.FirstOrDefault()?.Title
+                .FirstOrDefault()?.Value)
+            .ToList();
+        titles.Should().Equal("Root", "Chapter One", "Chapter Two");
+        fullMets.Mets.DmdSec.Select(d => d.Id).Should().OnlyHaveUniqueItems();
+    }
+
+    [Theory]
+    [InlineData("LOG_2")]
+    [InlineData("PHYS_objects")]
+    public async Task SetStructMap_Rejects_A_Range_Id_That_Is_Already_Used(string clashingId)
+    {
+        // xs:ID means NCName AND unique. Validating only the first half still lets a caller
+        // write a document no schema-aware consumer can load - and the UI mints
+        // LOG_<epoch-ms>, so two ranges created in the same millisecond collide.
+        var fullMets = await CreateAndLoadStandardMets($"encoded-dup-id-{clashingId.GetHashCode()}.xml");
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "LOG_2", Type = "Sequence" })
+            .Success.Should().BeTrue();
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000",
+            Type = "Sequence",
+            Ranges = [new LogicalRange { Id = clashingId, Type = "Item" }]
+        });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorCode.Should().Be(ErrorCodes.BadRequest);
+        result.ErrorMessage.Should().Contain(clashingId);
+    }
+
+    [Fact]
+    public async Task SetStructMap_Rejects_Two_Sibling_Ranges_Sharing_An_Id()
+    {
+        var fullMets = await CreateAndLoadStandardMets("encoded-dup-sibling-id.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000",
+            Type = "Sequence",
+            Ranges =
+            [
+                new LogicalRange { Id = "LOG_SAME", Type = "Item" },
+                new LogicalRange { Id = "LOG_SAME", Type = "Item" }
+            ]
+        });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorMessage.Should().Contain("LOG_SAME");
+    }
+
+    [Fact]
+    public async Task Replacing_A_StructMap_Under_Its_Own_Id_Is_Not_A_Duplicate()
+    {
+        // The IDs in the structMap being replaced must not count as taken - re-applying an
+        // edited structMap under its own ID is the normal editing path.
+        var fullMets = await CreateAndLoadStandardMets("encoded-replace-not-duplicate.xml");
+        var range = () => new LogicalRange
+        {
+            Id = "LOG_0000", Type = "Sequence", Name = "A sequence",
+            Ranges = [new LogicalRange { Id = "LOG_0001", Type = "Item", Name = "An item" }]
+        };
+        metsManager.SetStructMap(fullMets, range()).Success.Should().BeTrue();
+
+        var result = metsManager.SetStructMap(fullMets, range());
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        fullMets.Mets.StructMap.Count(sm => sm.Type == Constants.Logical).Should().Be(1);
     }
 
     // -----------------------------------------------------------------------

--- a/src/DigitalPreservation/XmlGen.Tests/EncodedMetsIdTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/EncodedMetsIdTests.cs
@@ -1,0 +1,285 @@
+using System.Xml;
+using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using DigitalPreservation.XmlGen.Mets;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// Behaviour introduced by issue #188 step 2, beyond "IDs are now encoded" (which
+/// <see cref="MetsIdIntegrityTests"/> and <see cref="MetsIdEncodingTests"/> cover):
+/// the boundary validation of client-supplied logical IDs, the derivation of a dmdSec ID from
+/// a path rather than from the div's ID, and the duplicate-div guard's awareness that a legacy
+/// document names the same path with a different ID.
+/// </summary>
+public class EncodedMetsIdTests
+{
+    private readonly MetsManager metsManager;
+    private readonly FileSystemMetsStorage metsStorage;
+
+    public EncodedMetsIdTests()
+    {
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        var parser = new MetsParser(metsLoader, parserLogger);
+        metsStorage = new FileSystemMetsStorage(parser);
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManager = new PremisEventManagerVirus();
+        var metadataManager = new MetadataManager(premisManager, premisManagerExif, premisEventManager);
+        metsManager = new MetsManager(parser, metsStorage, metadataManager);
+    }
+
+    private async Task<FullMets> CreateAndLoadStandardMets(string outputFileName)
+    {
+        var uri = new Uri(new FileInfo($"Outputs/{outputFileName}").FullName);
+        var createResult = await metsManager.CreateStandardMets(uri, "Encoded ID Test METS");
+        createResult.Success.Should().BeTrue(createResult.ErrorMessage ?? "");
+        var loadResult = await metsManager.GetFullMets(uri, createResult.Value!.ETag);
+        loadResult.Success.Should().BeTrue(loadResult.ErrorMessage ?? "");
+        return loadResult.Value!;
+    }
+
+    private static Uri CopyFixture(string fixtureName, string outputName)
+    {
+        var source = new FileInfo($"Samples/{fixtureName}");
+        var dest = new FileInfo($"Outputs/{outputName}");
+        File.Copy(source.FullName, dest.FullName, overwrite: true);
+        return new Uri(dest.FullName);
+    }
+
+    private static void AssertIsValidId(string? id)
+    {
+        id.Should().NotBeNull();
+        var verify = () => XmlConvert.VerifyNCName(id!);
+        verify.Should().NotThrow($"'{id}' is written into an xs:ID attribute");
+    }
+
+    // -----------------------------------------------------------------------
+    // Client-supplied logical structMap IDs are validated, not encoded
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("has space")]
+    [InlineData("has/slash")]
+    [InlineData("1leading-digit")]
+    [InlineData("has:colon")]
+    [InlineData("has&ampersand")]
+    public async Task SetStructMap_Rejects_A_Range_Id_That_Cannot_Be_An_Xml_Id(string badId)
+    {
+        var fullMets = await CreateAndLoadStandardMets($"encoded-badid-{badId.GetHashCode()}.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange { Id = badId, Type = "Sequence" });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorCode.Should().Be(ErrorCodes.BadRequest);
+        fullMets.Mets.StructMap.Should().NotContain(sm => sm.Type == Constants.Logical,
+            "a rejected structMap must not be written at all");
+    }
+
+    [Fact]
+    public async Task SetStructMap_Rejects_An_Invalid_Id_On_A_NESTED_Range()
+    {
+        // The whole tree is the client's, so validation cannot stop at the root.
+        var fullMets = await CreateAndLoadStandardMets("encoded-badid-nested.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000",
+            Type = "Sequence",
+            Ranges = [new LogicalRange { Id = "bad id", Type = "Item" }]
+        });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorMessage.Should().Contain("bad id");
+        fullMets.Mets.StructMap.Should().NotContain(sm => sm.Type == Constants.Logical);
+    }
+
+    [Fact]
+    public async Task A_Rejected_SetStructMap_Leaves_An_Existing_StructMap_Intact()
+    {
+        // Validation runs before anything is removed, so a bad replacement cannot destroy the
+        // structMap (and its dmdSecs) that is already there.
+        var fullMets = await CreateAndLoadStandardMets("encoded-badid-nondestructive.xml");
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "LOG_0000", Type = "Sequence", Name = "Keep me" })
+            .Success.Should().BeTrue();
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange { Id = "LOG_0000", Type = "Sequence",
+            Ranges = [new LogicalRange { Id = "still bad", Type = "Item" }] });
+
+        result.Failure.Should().BeTrue();
+        var logical = fullMets.Mets.StructMap.Should().ContainSingle(sm => sm.Type == Constants.Logical).Subject;
+        logical.Div!.Label.Should().Be("Keep me");
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == $"{Constants.DmdIdPrefix}LOG_0000");
+    }
+
+    [Fact]
+    public async Task A_Range_With_No_Id_Writes_No_Id_Attribute_And_Is_Still_Replaceable()
+    {
+        // Third-party logical divs often have no ID; the parser reports that as an empty
+        // string. Writing it back as ID="" would be an invalid xs:ID, so nothing is written -
+        // and the structMap must still be identifiable for replacement.
+        var fullMets = await CreateAndLoadStandardMets("encoded-empty-logical-id.xml");
+
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "", Type = "Sequence", Name = "First" })
+            .Success.Should().BeTrue();
+        fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Logical).Div!.Id.Should().BeNull();
+
+        metsManager.SetStructMap(fullMets, new LogicalRange { Id = "", Type = "Sequence", Name = "Second" })
+            .Success.Should().BeTrue();
+
+        var logical = fullMets.Mets.StructMap.Should().ContainSingle(sm => sm.Type == Constants.Logical).Subject;
+        logical.Div!.Label.Should().Be("Second", "the ID-less structMap must be replaced, not duplicated");
+
+        metsManager.RemoveStructMap(fullMets, "");
+        fullMets.Mets.StructMap.Should().NotContain(sm => sm.Type == Constants.Logical);
+    }
+
+    [Fact]
+    public async Task SetStructMap_Accepts_The_Ids_The_Ui_Generates()
+    {
+        // The UI mints LOG_<epoch-ms>; these must keep working unchanged.
+        var fullMets = await CreateAndLoadStandardMets("encoded-goodid.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_1755091200000",
+            Type = "Sequence",
+            Ranges = [new LogicalRange { Id = "LOG_1755091200001", Type = "Item" }]
+        });
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        fullMets.Mets.StructMap.Should().Contain(sm => sm.Type == Constants.Logical);
+    }
+
+    [Fact]
+    public async Task A_Logical_Div_Still_Takes_Its_Dmd_Id_From_Its_Own_Id()
+    {
+        // Logical divs have no path, so the DMD_ id is derived from the (validated) div ID -
+        // the one case where deriving an ID from an ID is still correct.
+        var fullMets = await CreateAndLoadStandardMets("encoded-logical-dmd.xml");
+
+        var result = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000", Type = "Sequence", Name = "Titled, so it needs MODS"
+        });
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var logicalDiv = fullMets.Mets.StructMap.Single(sm => sm.Type == Constants.Logical).Div!;
+        logicalDiv.Dmdid.Should().ContainSingle().Which.Should().Be($"{Constants.DmdIdPrefix}LOG_0000");
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == $"{Constants.DmdIdPrefix}LOG_0000");
+    }
+
+    // -----------------------------------------------------------------------
+    // dmdSec IDs come from the path, so a legacy div gets a VALID new ID
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Setting_Metadata_On_A_Legacy_Div_By_Path_Mints_An_Encoded_Dmd_Id()
+    {
+        // The frozen fixture's file divs carry raw IDs and no DMDID. Deriving the new dmdSec ID
+        // from the div's ID would mint "DMD_objects/my file.pdf" - a second invalid ID, in a
+        // document we are supposed to be repairing rather than adding to.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "encoded-legacy-dmd-by-path.xml");
+        var fullMets = (await metsStorage.GetFullMets(metsUri, null)).Value!;
+
+        var result = metsManager.SetAccessRestrictionsByPath(fullMets, "objects/my file.pdf", ["Closed"]);
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var div = fullMets.PhysicalDivsByPath["objects/my file.pdf"];
+        div.Id.Should().Be("PHYS_objects/my file.pdf", "the legacy div's own ID is never rewritten");
+        var dmdId = div.Dmdid.Should().ContainSingle().Subject;
+        dmdId.Should().Be(MetsIds.Dmd("objects/my file.pdf"));
+        AssertIsValidId(dmdId);
+        fullMets.Mets.DmdSec.Should().Contain(d => d.Id == dmdId);
+    }
+
+    [Fact]
+    public async Task Setting_Metadata_On_A_Legacy_Div_By_Div_Id_Also_Mints_An_Encoded_Dmd_Id()
+    {
+        // The ByDivId entry point is handed an ID rather than a path, so it recovers the path
+        // from the cache before minting.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "encoded-legacy-dmd-by-divid.xml");
+        var fullMets = (await metsStorage.GetFullMets(metsUri, null)).Value!;
+
+        var result = metsManager.SetAccessRestrictionsByDivId(fullMets, "PHYS_objects/my file.pdf", ["Closed"]);
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        var div = fullMets.PhysicalDivsByPath["objects/my file.pdf"];
+        var dmdId = div.Dmdid.Should().ContainSingle().Subject;
+        dmdId.Should().Be(MetsIds.Dmd("objects/my file.pdf"));
+        AssertIsValidId(dmdId);
+    }
+
+    [Fact]
+    public async Task An_Existing_Legacy_Dmd_Reference_Is_Reused_Not_Replaced()
+    {
+        // The other half of the promise: where a legacy dmdSec is already referenced, editing
+        // its metadata must go on writing to THAT section, not mint an encoded sibling.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "encoded-legacy-dmd-reuse.xml");
+        var fullMets = (await metsStorage.GetFullMets(metsUri, null)).Value!;
+        var objectsDiv = fullMets.PhysicalDivsByPath[FolderNames.Objects];
+        objectsDiv.Dmdid.Should().ContainSingle().Which.Should().Be($"{Constants.DmdIdPrefix}{FolderNames.Objects}");
+
+        var result = metsManager.SetAccessRestrictionsByPath(fullMets, FolderNames.Objects, ["Closed"]);
+
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        objectsDiv.Dmdid.Should().ContainSingle().Which.Should().Be($"{Constants.DmdIdPrefix}{FolderNames.Objects}");
+    }
+
+    // -----------------------------------------------------------------------
+    // The duplicate-div guard knows both ID forms
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Adding_A_Path_Whose_Legacy_Div_Exists_But_Is_Unreachable_Is_Refused()
+    {
+        // Two sibling divs resolve to the same path, so navigation refuses to guess between
+        // them and the edit arrives as an ADD. One of them carries the legacy raw ID for that
+        // path: minting an encoded ID would not collide with it, so without a check for the
+        // legacy form too the add would quietly create a THIRD div for one path.
+        var uri = new Uri(new FileInfo("Outputs/encoded-legacy-duplicate-guard.xml").FullName);
+        var (_, mets) = await metsManager.GetStandardMets(uri, "Legacy Duplicate METS");
+
+        var physRoot = mets.StructMap.Single(sm => sm.Type == Constants.Physical).Div!;
+        var objectsDiv = physRoot.Div.Single(d => d.Label == FolderNames.Objects);
+        var objectsAmdSec = mets.AmdSec.Single(a => a.Id == MetsIds.Adm(FolderNames.Objects));
+        var twinAdmId = $"{Constants.AdmIdPrefix}objects/twin";
+        mets.AmdSec.Add(new AmdSecType { Id = twinAdmId, TechMd = { objectsAmdSec.TechMd[0] } });
+        // Repoint the shared premis originalName so both new divs resolve to objects/twin.
+        var originalName = objectsAmdSec.TechMd[0].MdWrap.XmlData.Any![0]
+            .GetElementsByTagName("originalName", "http://www.loc.gov/premis/v3")[0]!;
+        originalName.InnerText = "objects/twin";
+        objectsDiv.Admid.Clear();
+        objectsDiv.Div.Add(new DivType
+        {
+            Id = "PHYS_objects/twin", Type = Constants.DirectoryType, Label = "twin a", Admid = { twinAdmId }
+        });
+        objectsDiv.Div.Add(new DivType
+        {
+            Id = "PHYS_twin_b", Type = Constants.DirectoryType, Label = "twin b", Admid = { twinAdmId }
+        });
+
+        var fullMets = new FullMets { Mets = mets, Uri = uri };
+        MetsCache.Populate(fullMets).Should().Contain(d => d.Contains("both resolve to path"));
+        var divCountBefore = objectsDiv.Div.Count;
+
+        var result = metsManager.AddToMets(fullMets, new WorkingDirectory
+        {
+            LocalPath = "objects/twin", Name = "twin", Modified = DateTime.UtcNow
+        });
+
+        result.Failure.Should().BeTrue();
+        result.ErrorCode.Should().Be(ErrorCodes.BadRequest);
+        result.ErrorMessage.Should().Contain("PHYS_objects/twin");
+        objectsDiv.Div.Count.Should().Be(divCountBefore, "nothing may be added when the path is already claimed");
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/MetsIdEncodingTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsIdEncodingTests.cs
@@ -1,0 +1,101 @@
+using System.Xml;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Utils;
+using FluentAssertions;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// The path→ID encoding introduced by issue #188 step 2. Two properties matter: the result is
+/// always usable as an xs:ID once a prefix is added, and nothing about the path is lost.
+/// </summary>
+public class MetsIdEncodingTests
+{
+    // Paths chosen to cover every class of NCName-invalid character the platform can meet in a
+    // real deposit, plus the ones that are already legal and must pass through untouched.
+    public static TheoryData<string> Paths => new()
+    {
+        "objects/simple.pdf",
+        "objects/my file.pdf",
+        "objects/my great file.pdf",
+        "objects/AT&T guide.pdf",
+        "objects/résumé.pdf",
+        "objects/2020 minutes.pdf",
+        "objects/report (final), v2.pdf",
+        "objects/a+b=c#d?e!f@g$h%i^j~k.txt",
+        "objects/deep/nested/path/file.tif",
+        "objects/quote'and\"quote.txt",
+        "objects/semi;colon<gt>lt.txt",
+        "metadata/ad-hoc",
+        // A path that already looks like an encoding: proves _x is self-escaped rather than
+        // being mistaken for an escape sequence on the way back.
+        "objects/_x0020_not-a-space.txt",
+        "9-leading-digit.txt"
+    };
+
+    [Theory]
+    [MemberData(nameof(Paths))]
+    public void Encoded_Path_Is_A_Valid_Ncname(string path)
+    {
+        var act = () => XmlConvert.VerifyNCName(path.ToMetsId());
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(Paths))]
+    public void Every_Minted_Id_Is_A_Valid_Ncname(string path)
+    {
+        // What actually goes into the document is prefix + encoded path.
+        foreach (var id in new[] { MetsIds.Phys(path), MetsIds.File(path), MetsIds.Adm(path), MetsIds.Tech(path), MetsIds.Dmd(path) })
+        {
+            var act = () => XmlConvert.VerifyNCName(id);
+            act.Should().NotThrow($"'{id}' is written into an xs:ID attribute");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Paths))]
+    public void Encoding_Is_Reversible(string path)
+    {
+        path.ToMetsId().DecodeMetsId().Should().Be(path);
+    }
+
+    [Theory]
+    [MemberData(nameof(Paths))]
+    public void Encoded_Id_Contains_No_Whitespace(string path)
+    {
+        // The whole point for IDREFS: an ID with a space in it is silently split into several
+        // tokens by any schema-aware processor (issue #188 / the IdRefs work).
+        path.ToMetsId().Should().NotContainAny(" ", "\t", "\n", "\r");
+    }
+
+    [Fact]
+    public void A_Path_Needing_No_Encoding_Is_Left_Alone()
+    {
+        // Keeps the built-in template IDs (PHYS_objects, ADM_metadata …) exactly as they were
+        // before step 2, so no existing METS becomes unnavigable by the ID convention.
+        FolderNames.Objects.ToMetsId().Should().Be(FolderNames.Objects);
+        FolderNames.Metadata.ToMetsId().Should().Be(FolderNames.Metadata);
+        MetsIds.Phys(FolderNames.Objects).Should().Be(Constants.ObjectsDivId);
+        MetsIds.Phys(FolderNames.Metadata).Should().Be(Constants.MetadataDivId);
+    }
+
+    [Fact]
+    public void The_Ad_Hoc_Div_Id_Constant_Is_The_Encoded_Form_Of_Its_Path()
+    {
+        Constants.MetadataAdHocDivId.Should().Be(MetsIds.Phys(FolderNames.MetadataAdHoc));
+        Constants.MetadataAdHocDivId.Should().NotContain("/");
+        var act = () => XmlConvert.VerifyNCName(Constants.MetadataAdHocDivId);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Distinct_Paths_Encode_To_Distinct_Ids()
+    {
+        // Encoding must not collapse two paths onto one ID - that would make two divs collide
+        // on a single xs:ID. These pairs differ only in characters that get escaped.
+        MetsIds.Phys("objects/a b").Should().NotBe(MetsIds.Phys("objects/a/b"));
+        MetsIds.Phys("objects/a b").Should().NotBe(MetsIds.Phys("objects/a_x0020_b"));
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/MetsIdEncodingTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsIdEncodingTests.cs
@@ -34,6 +34,37 @@ public class MetsIdEncodingTests
         "9-leading-digit.txt"
     };
 
+    // ---------------------------------------------------------------------
+    // The anchor. Everything else in this file, and every expectation built through MetsIds,
+    // computes its expected value with the production encoder - which catches a mint site that
+    // FORGETS to encode, but cannot catch the encoding itself changing. These literals are the
+    // only thing pinning the actual on-disk format, which is permanent: a step 3 bulk migration
+    // will be written against exactly these strings. If one of these fails, the format has
+    // changed and every METS file already written is affected.
+    // ---------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("objects/simple.pdf", "objects_x002F_simple.pdf")]
+    [InlineData("objects/my file.pdf", "objects_x002F_my_x0020_file.pdf")]
+    [InlineData("objects/AT&T guide.pdf", "objects_x002F_AT_x0026_T_x0020_guide.pdf")]
+    [InlineData("metadata/ad-hoc", "metadata_x002F_ad-hoc")]
+    [InlineData("objects", "objects")]
+    public void The_Encoded_Form_Is_Exactly_This(string path, string expected)
+    {
+        path.ToMetsId().Should().Be(expected);
+    }
+
+    [Fact]
+    public void A_Minted_Id_Is_Exactly_This()
+    {
+        MetsIds.Phys("objects/my file.pdf").Should().Be("PHYS_objects_x002F_my_x0020_file.pdf");
+        MetsIds.File("objects/my file.pdf").Should().Be("FILE_objects_x002F_my_x0020_file.pdf");
+        MetsIds.Adm("objects/my file.pdf").Should().Be("ADM_objects_x002F_my_x0020_file.pdf");
+        MetsIds.Tech("objects/my file.pdf").Should().Be("TECH_objects_x002F_my_x0020_file.pdf");
+        MetsIds.Dmd("objects/my file.pdf").Should().Be("DMD_objects_x002F_my_x0020_file.pdf");
+        Constants.MetadataAdHocDivId.Should().Be("PHYS_metadata_x002F_ad-hoc");
+    }
+
     [Theory]
     [MemberData(nameof(Paths))]
     public void Encoded_Path_Is_A_Valid_Ncname(string path)
@@ -82,9 +113,10 @@ public class MetsIdEncodingTests
     }
 
     [Fact]
-    public void The_Ad_Hoc_Div_Id_Constant_Is_The_Encoded_Form_Of_Its_Path()
+    public void The_Ad_Hoc_Div_Id_Constant_Is_A_Usable_Id()
     {
-        Constants.MetadataAdHocDivId.Should().Be(MetsIds.Phys(FolderNames.MetadataAdHoc));
+        // Its exact value is pinned by A_Minted_Id_Is_Exactly_This; comparing it against
+        // MetsIds.Phys(...) here would only restate its own definition.
         Constants.MetadataAdHocDivId.Should().NotContain("/");
         var act = () => XmlConvert.VerifyNCName(Constants.MetadataAdHocDivId);
         act.Should().NotThrow();

--- a/src/DigitalPreservation/XmlGen.Tests/MetsIdIntegrityTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsIdIntegrityTests.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Linq;
+using DigitalPreservation.Common.Model;
+using DigitalPreservation.Common.Model.Transit;
+using DigitalPreservation.Common.Model.Transit.Extensions;
+using DigitalPreservation.Mets;
+using DigitalPreservation.Mets.StorageImpl;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// The merge gate for issue #188: whatever the platform writes, every xs:ID in it must be a
+/// valid NCName and unique, and every reference to an ID must resolve. Nothing else in the
+/// suite checks this — XmlSerializer does not enforce xs:ID — which is how #188 survived from
+/// the beginning.
+///
+/// This is deliberately narrower than full METS XSD validation (which would need the schema
+/// set committed and offline, and would fail on unrelated pre-existing issues): it checks the
+/// ID/IDREF contract, which is what step 2 changes and what a broken change would corrupt.
+///
+/// DMDID is excluded from the reference check: the template writes DMDID onto the objects,
+/// metadata and ad-hoc divs while their dmdSecs are only created lazily on first metadata
+/// write, so a DMDID may dangle by design. That is a real (pre-existing, separate) conformance
+/// gap, not something step 2 introduces.
+/// </summary>
+public class MetsIdIntegrityTests
+{
+    private readonly MetsManager metsManager;
+    private readonly MetsParser parser;
+    private readonly MetsFromArchivalGroup metsFromArchivalGroup;
+
+    private static readonly XNamespace MetsNs = "http://www.loc.gov/METS/";
+    private static readonly XNamespace XLinkNs = "http://www.w3.org/1999/xlink";
+    private static readonly char[] XmlWhitespace = [' ', '\t', '\n', '\r'];
+
+    private const string TestDigest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f";
+
+    public MetsIdIntegrityTests()
+    {
+        var serviceProvider = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var factory = serviceProvider.GetService<ILoggerFactory>();
+        var parserLogger = factory!.CreateLogger<MetsParser>();
+        var metsLoader = new FileSystemMetsLoader();
+        parser = new MetsParser(metsLoader, parserLogger);
+        var metsStorage = new FileSystemMetsStorage(parser);
+        var premisManager = new PremisManager();
+        var premisManagerExif = new PremisManagerExif();
+        var premisEventManager = new PremisEventManagerVirus();
+        var metadataManager = new MetadataManager(premisManager, premisManagerExif, premisEventManager);
+        metsManager = new MetsManager(parser, metsStorage, metadataManager);
+        metsFromArchivalGroup = new MetsFromArchivalGroup(metsManager, parser, metadataManager);
+    }
+
+    // -----------------------------------------------------------------------
+    // The gate itself
+    // -----------------------------------------------------------------------
+
+    /// <param name="requireValidIds">
+    /// False only for documents that legitimately contain pre-#188 raw IDs (the frozen legacy
+    /// corpus). Reference integrity is still required there — that is the compatibility promise.
+    /// </param>
+    private static void AssertIdIntegrity(XDocument doc, bool requireValidIds = true)
+    {
+        var ids = doc.Descendants()
+            .Select(e => (string?)e.Attribute("ID"))
+            .Where(id => id != null)
+            .Select(id => id!)
+            .ToList();
+
+        ids.Should().OnlyHaveUniqueItems("xs:ID values must be unique within a document");
+
+        if (requireValidIds)
+        {
+            foreach (var id in ids)
+            {
+                var verify = () => XmlConvert.VerifyNCName(id);
+                verify.Should().NotThrow($"'{id}' is written into an xs:ID attribute");
+            }
+        }
+
+        var declared = ids.ToHashSet();
+
+        foreach (var element in doc.Descendants())
+        {
+            // ADMID is IDREFS; FILEID is a single IDREF.
+            AssertIdRefsResolve(declared, (string?)element.Attribute("ADMID"),
+                $"{element.Name.LocalName}/@ADMID");
+
+            var fileId = (string?)element.Attribute("FILEID");
+            if (fileId != null)
+            {
+                declared.Should().Contain(fileId,
+                    $"{element.Name.LocalName}/@FILEID must name a file element that exists");
+            }
+        }
+
+        // structLink: the platform links FILE elements, so both ends must name real ones.
+        // This is the property issue #188 step 2 could most easily have broken, by minting an
+        // encoded ID for a file whose element still carries a raw one.
+        foreach (var link in doc.Descendants(MetsNs + "smLink"))
+        {
+            foreach (var end in new[] { "from", "to" })
+            {
+                var value = (string?)link.Attribute(XLinkNs + end);
+                if (value == null) continue;
+                declared.Should().Contain(value, $"smLink/@xlink:{end} must name an element that exists");
+            }
+        }
+    }
+
+    private static void AssertIdRefsResolve(HashSet<string> declared, string? attributeValue, string what)
+    {
+        if (attributeValue == null || declared.Contains(attributeValue))
+        {
+            // Either absent, or a single ID — including a legacy one that contains spaces and
+            // therefore looks like several tokens.
+            return;
+        }
+
+        var tokens = attributeValue.Split(XmlWhitespace, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            declared.Should().Contain(token, $"{what} references '{token}'");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Documents the platform writes
+    // -----------------------------------------------------------------------
+
+    private async Task<(Uri metsUri, string eTag)> CreateEmptyMets(string outputFileName)
+    {
+        var uri = new Uri(new FileInfo($"Outputs/{outputFileName}").FullName);
+        var result = await metsManager.CreateStandardMets(uri, "ID Integrity Test");
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        return (uri, result.Value!.ETag!);
+    }
+
+    private static WorkingFile SimpleFile(string localPath, string name) =>
+        new()
+        {
+            LocalPath = localPath,
+            Name = name,
+            ContentType = "application/pdf",
+            Digest = TestDigest,
+            Size = 54321,
+            Modified = DateTime.UtcNow
+        };
+
+    [Fact]
+    public async Task An_Empty_Mets_Has_Valid_Unique_Resolvable_Ids()
+    {
+        var (metsUri, _) = await CreateEmptyMets("id-integrity-empty.xml");
+        AssertIdIntegrity(XDocument.Load(metsUri.LocalPath));
+    }
+
+    [Fact]
+    public async Task A_Mets_Full_Of_Awkward_Paths_Has_Valid_Unique_Resolvable_Ids()
+    {
+        var (metsUri, eTag) = await CreateEmptyMets("id-integrity-awkward.xml");
+
+        // One directory and one file for each class of character that is illegal, or merely
+        // suspicious, in an NCName.
+        string[] directories = ["objects/my folder", "objects/A&B", "objects/2020 files"];
+        foreach (var dir in directories)
+        {
+            var result = await metsManager.HandleCreateFolder(metsUri,
+                new WorkingDirectory { LocalPath = dir, Name = LastSegment(dir), Modified = DateTime.UtcNow }, eTag);
+            result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+            eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        }
+
+        string[] files =
+        [
+            "objects/my folder/my document.pdf",
+            "objects/A&B/AT&T guide.pdf",
+            "objects/2020 files/9 lives.pdf",
+            "objects/résumé.pdf",
+            "objects/report (final), v2.pdf"
+        ];
+        foreach (var file in files)
+        {
+            var result = await metsManager.HandleSingleFileUpload(metsUri,
+                SimpleFile(file, LastSegment(file)), eTag);
+            result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+            eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        }
+
+        AssertIdIntegrity(XDocument.Load(metsUri.LocalPath));
+    }
+
+    [Fact]
+    public async Task A_Mets_With_A_Logical_StructMap_And_Links_Has_Resolvable_References()
+    {
+        var (metsUri, eTag) = await CreateEmptyMets("id-integrity-logical.xml");
+        foreach (var path in new[] { "objects/page one.tif", "objects/page two.tif" })
+        {
+            var result = await metsManager.HandleSingleFileUpload(metsUri, SimpleFile(path, LastSegment(path)), eTag);
+            result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+            eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        }
+
+        var fullMets = (await metsManager.GetFullMets(metsUri, eTag)).Value!;
+        var setResult = metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000",
+            Type = "Sequence",
+            Name = "A sequence",
+            Files = [new FilePointer { LocalPath = "objects/page one.tif" }],
+            Ranges =
+            [
+                new LogicalRange
+                {
+                    Id = "LOG_0001", Type = "Item", Name = "Page two",
+                    Files = [new FilePointer { LocalPath = "objects/page two.tif" }]
+                }
+            ]
+        });
+        setResult.Success.Should().BeTrue(setResult.ErrorMessage ?? "");
+
+        metsManager.LinkFile(fullMets, "objects/page one.tif", "objects/page two.tif",
+            new Uri("http://example.org/roles/transcription-of"));
+        (await metsManager.WriteMets(fullMets)).Success.Should().BeTrue();
+
+        AssertIdIntegrity(XDocument.Load(metsUri.LocalPath));
+    }
+
+    [Fact]
+    public async Task A_Mets_Built_From_An_Archival_Group_Has_Valid_Unique_Resolvable_Ids()
+    {
+        var agFi = new FileInfo("Samples/archivalGroup.json");
+        var agMetsFi = new FileInfo("Outputs/id-integrity-archival-group.xml");
+        var archivalGroup = JsonSerializer.Deserialize<ArchivalGroup>(await File.ReadAllTextAsync(agFi.FullName))!;
+
+        var result = await metsFromArchivalGroup.CreateStandardMets(
+            new Uri(agMetsFi.FullName), archivalGroup, "ID Integrity AG");
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+
+        AssertIdIntegrity(XDocument.Load(agMetsFi.FullName));
+    }
+
+    // -----------------------------------------------------------------------
+    // Mixed-format: a legacy document edited by the post-#188 code
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Editing_A_Legacy_Document_Leaves_Every_Reference_Resolvable()
+    {
+        // The compatibility promise: adding to a document whose IDs are the old raw form must
+        // not leave a single dangling reference, even though the new entries carry encoded IDs.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "id-integrity-legacy-mixed.xml");
+        var eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+
+        var add = await metsManager.HandleSingleFileUpload(metsUri,
+            SimpleFile("objects/my folder/new addition.pdf", "new addition.pdf"), eTag);
+        add.Success.Should().BeTrue(add.ErrorMessage ?? "");
+
+        eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        var fullMets = (await metsManager.GetFullMets(metsUri, eTag)).Value!;
+        // Link a legacy file to the newly added one: one end resolves to a raw ID, the other
+        // to an encoded one.
+        metsManager.LinkFile(fullMets, "objects/my file.pdf", "objects/my folder/new addition.pdf",
+            new Uri("http://example.org/roles/transcription-of"));
+        (await metsManager.WriteMets(fullMets)).Success.Should().BeTrue();
+
+        var doc = XDocument.Load(metsUri.LocalPath);
+        AssertIdIntegrity(doc, requireValidIds: false);
+
+        // The legacy IDs are still there, untouched...
+        var declaredIds = doc.Descendants()
+            .Select(e => (string?)e.Attribute("ID")).Where(id => id != null).ToList();
+        declaredIds.Should().Contain("FILE_objects/my file.pdf");
+        declaredIds.Should().Contain("PHYS_objects/my folder");
+
+        // ...and what we added is in the new, valid form.
+        declaredIds.Should().Contain(MetsIds.File("objects/my folder/new addition.pdf"));
+        var newIds = declaredIds.Where(id => id!.Contains("new_x0020_addition")).ToList();
+        newIds.Should().NotBeEmpty("the added entry must use encoded IDs");
+        foreach (var id in newIds)
+        {
+            var verify = () => XmlConvert.VerifyNCName(id!);
+            verify.Should().NotThrow();
+        }
+
+        // The link's legacy end names the raw FILE id that exists, not a minted encoded one.
+        var link = doc.Descendants(MetsNs + "smLink").Single();
+        link.Attribute(XLinkNs + "from")!.Value.Should().Be("FILE_objects/my file.pdf");
+        link.Attribute(XLinkNs + "to")!.Value
+            .Should().Be(MetsIds.File("objects/my folder/new addition.pdf"));
+    }
+
+    private static string LastSegment(string localPath) => localPath.Split('/')[^1];
+
+    private static Uri CopyFixture(string fixtureName, string outputName)
+    {
+        var source = new FileInfo($"Samples/{fixtureName}");
+        var dest = new FileInfo($"Outputs/{outputName}");
+        File.Copy(source.FullName, dest.FullName, overwrite: true);
+        return new Uri(dest.FullName);
+    }
+}

--- a/src/DigitalPreservation/XmlGen.Tests/MetsIdIntegrityTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsIdIntegrityTests.cs
@@ -227,7 +227,15 @@ public class MetsIdIntegrityTests
             new Uri("http://example.org/roles/transcription-of"));
         (await metsManager.WriteMets(fullMets)).Success.Should().BeTrue();
 
-        AssertIdIntegrity(XDocument.Load(metsUri.LocalPath));
+        var doc = XDocument.Load(metsUri.LocalPath);
+        // The reference checks below iterate collections, so they pass vacuously if nothing was
+        // written. Assert the document actually contains what this test claims to be checking.
+        doc.Descendants(MetsNs + "smLink").Should().ContainSingle("the link must have been written");
+        doc.Descendants(MetsNs + "structMap")
+            .Single(sm => (string?)sm.Attribute("TYPE") == Constants.Logical)
+            .Descendants(MetsNs + "fptr")
+            .Should().HaveCount(2, "both logical ranges paint a file");
+        AssertIdIntegrity(doc);
     }
 
     [Fact]
@@ -292,6 +300,70 @@ public class MetsIdIntegrityTests
         link.Attribute(XLinkNs + "from")!.Value.Should().Be("FILE_objects/my file.pdf");
         link.Attribute(XLinkNs + "to")!.Value
             .Should().Be(MetsIds.File("objects/my folder/new addition.pdf"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Deleting a file takes its references with it
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deleting_A_File_Removes_The_Links_And_Fptrs_That_Named_It()
+    {
+        var (metsUri, eTag) = await CreateEmptyMets("id-integrity-delete-refs.xml");
+        foreach (var path in new[] { "objects/a.tif", "objects/b.tif" })
+        {
+            var add = await metsManager.HandleSingleFileUpload(metsUri, SimpleFile(path, LastSegment(path)), eTag);
+            add.Success.Should().BeTrue(add.ErrorMessage ?? "");
+            eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        }
+
+        var fullMets = (await metsManager.GetFullMets(metsUri, eTag)).Value!;
+        metsManager.SetStructMap(fullMets, new LogicalRange
+        {
+            Id = "LOG_0000", Type = "Sequence", Name = "Both pages",
+            Files = [new FilePointer { LocalPath = "objects/a.tif" }, new FilePointer { LocalPath = "objects/b.tif" }]
+        }).Success.Should().BeTrue();
+        metsManager.LinkFile(fullMets, "objects/a.tif", "objects/b.tif",
+            new Uri("http://example.org/roles/transcription-of"));
+
+        var delete = metsManager.DeleteFromMets(fullMets, "objects/b.tif");
+        delete.Success.Should().BeTrue(delete.ErrorMessage ?? "");
+        (await metsManager.WriteMets(fullMets)).Success.Should().BeTrue();
+
+        // Both fptr/@FILEID and smLink/@xlink:from|to are IDREFs, so a leftover reference to
+        // the removed file makes the document invalid.
+        var doc = XDocument.Load(metsUri.LocalPath);
+        doc.Descendants(MetsNs + "smLink").Should().BeEmpty("the only link named the deleted file");
+        doc.Descendants(MetsNs + "structMap")
+            .Single(sm => (string?)sm.Attribute("TYPE") == Constants.Logical)
+            .Descendants(MetsNs + "fptr")
+            .Should().ContainSingle("only the surviving file may still be painted");
+        AssertIdIntegrity(doc);
+    }
+
+    [Fact]
+    public async Task Deleting_And_Re_Adding_A_Linked_File_Leaves_Nothing_Dangling()
+    {
+        // Before step 2 a re-add re-minted the same raw ID and quietly healed a stale link.
+        // Now it mints an encoded one, so a link left behind by the delete could never be
+        // matched again - by UnLinkFile or anything else. The delete has to clean up.
+        var metsUri = CopyFixture("path-fixture-spaces.xml", "id-integrity-relink-legacy.xml");
+        var eTag = (await parser.GetMetsFileWrapper(metsUri)).Value!.ETag!;
+        var fullMets = (await metsManager.GetFullMets(metsUri, eTag)).Value!;
+
+        var role = new Uri("http://example.org/roles/transcription-of");
+        metsManager.LinkFile(fullMets, "objects/my file.pdf", "objects/my great file.pdf", role);
+        fullMets.Mets.StructLink!.SmLink.Should().ContainSingle();
+
+        metsManager.DeleteFromMets(fullMets, "objects/my great file.pdf")
+            .Success.Should().BeTrue();
+        fullMets.Mets.StructLink.SmLink.Should().BeEmpty("the link named the file that was deleted");
+
+        var readd = metsManager.AddToMets(fullMets, SimpleFile("objects/my great file.pdf", "my great file.pdf"));
+        readd.Success.Should().BeTrue(readd.ErrorMessage ?? "");
+        (await metsManager.WriteMets(fullMets)).Success.Should().BeTrue();
+
+        AssertIdIntegrity(XDocument.Load(metsUri.LocalPath), requireValidIds: false);
     }
 
     private static string LastSegment(string localPath) => localPath.Split('/')[^1];

--- a/src/DigitalPreservation/XmlGen.Tests/MetsIds.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsIds.cs
@@ -1,0 +1,20 @@
+using DigitalPreservation.Mets;
+using DigitalPreservation.Utils;
+
+namespace XmlGen.Tests;
+
+/// <summary>
+/// The METS IDs the platform mints for a deposit-relative path (issue #188). Tests build their
+/// expectations through here rather than writing encoded literals, so that a change to the
+/// encoding surfaces as a deliberate change to <see cref="MetsIdEncoding"/> rather than as a
+/// wall of edited strings — and so that a test asserting a RAW id is visibly doing something
+/// different (the frozen legacy fixtures in Samples/ still do, deliberately).
+/// </summary>
+public static class MetsIds
+{
+    public static string Phys(string localPath) => Constants.PhysIdPrefix + localPath.ToMetsId();
+    public static string File(string localPath) => Constants.FileIdPrefix + localPath.ToMetsId();
+    public static string Adm(string localPath) => Constants.AdmIdPrefix + localPath.ToMetsId();
+    public static string Tech(string localPath) => Constants.TechIdPrefix + localPath.ToMetsId();
+    public static string Dmd(string localPath) => Constants.DmdIdPrefix + localPath.ToMetsId();
+}

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerDeepStructureTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerDeepStructureTests.cs
@@ -548,8 +548,8 @@ public class MetsManagerDeepStructureTests
     // and that a matching amdSec element is present.
     private static void AssertDirectoryDiv(XDocument doc, string localPath, string expectedLabel)
     {
-        var physId = $"PHYS_{localPath}";
-        var admId  = $"ADM_{localPath}";
+        var physId = MetsIds.Phys(localPath);
+        var admId  = MetsIds.Adm(localPath);
 
         var divEl = doc.Descendants(MetsNs + "div")
             .FirstOrDefault(d => (string?)d.Attribute("ID") == physId);
@@ -567,9 +567,9 @@ public class MetsManagerDeepStructureTests
     // amdSec, and the matching structMap Div (with its fptr) are all consistent.
     private static void AssertFileElement(XDocument doc, string localPath)
     {
-        var fileId = $"FILE_{localPath}";
-        var admId  = $"ADM_{localPath}";
-        var physId = $"PHYS_{localPath}";
+        var fileId = MetsIds.File(localPath);
+        var admId  = MetsIds.Adm(localPath);
+        var physId = MetsIds.Phys(localPath);
 
         var fileEl = doc.Descendants(MetsNs + "file")
             .FirstOrDefault(f => (string?)f.Attribute("ID") == fileId);

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerLogicalStructTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerLogicalStructTests.cs
@@ -145,7 +145,7 @@ public class MetsManagerLogicalStructTests
         childDiv.Attribute("ID")!.Value.Should().Be("LOG_0001");
         childDiv.Attribute("TYPE")!.Value.Should().Be("Item");
         var fptr = childDiv.Elements(MetsNs + "fptr").Single();
-        fptr.Attribute("FILEID")!.Value.Should().Be("FILE_objects/page.tif");
+        fptr.Attribute("FILEID")!.Value.Should().Be(MetsIds.File("objects/page.tif"));
     }
 
     [Fact]
@@ -245,7 +245,7 @@ public class MetsManagerLogicalStructTests
         // Must use area, not direct FILEID.
         fptr.Attribute("FILEID").Should().BeNull();
         var area = fptr.Elements(MetsNs + "area").Single();
-        area.Attribute("FILEID")!.Value.Should().Be("FILE_objects/audio.wav");
+        area.Attribute("FILEID")!.Value.Should().Be(MetsIds.File("objects/audio.wav"));
         area.Attribute("BETYPE")!.Value.Should().Be("TIME");
         area.Attribute("BEGIN")!.Value.Should().Be("00:00:15");
         area.Attribute("END")!.Value.Should().Be("00:35:09.5");
@@ -296,7 +296,7 @@ public class MetsManagerLogicalStructTests
 
         fptr.Attribute("FILEID").Should().BeNull();
         var area = fptr.Elements(MetsNs + "area").Single();
-        area.Attribute("FILEID")!.Value.Should().Be("FILE_objects/page.tif");
+        area.Attribute("FILEID")!.Value.Should().Be(MetsIds.File("objects/page.tif"));
         area.Attribute("SHAPE")!.Value.Should().Be("RECT");
         area.Attribute("COORDS")!.Value.Should().Be("0,0,6000,2000");
     }
@@ -459,7 +459,7 @@ public class MetsManagerLogicalStructTests
 
         fptr.Attribute("FILEID").Should().BeNull("area element should be used, not direct FILEID");
         var area = fptr.Elements(MetsNs + "area").Single();
-        area.Attribute("FILEID")!.Value.Should().Be("FILE_objects/audio.wav");
+        area.Attribute("FILEID")!.Value.Should().Be(MetsIds.File("objects/audio.wav"));
         area.Attribute("BETYPE")!.Value.Should().Be("BYTE");
         area.Attribute("BEGIN")!.Value.Should().Be("0");
         area.Attribute("END")!.Value.Should().Be("44100");
@@ -772,8 +772,8 @@ public class MetsManagerLogicalStructTests
         var structLink = doc.Descendants(MetsNs + "structLink").Single();
         var smLink = structLink.Elements(MetsNs + "smLink").Single();
 
-        smLink.Attribute(XLinkNs + "from")!.Value.Should().Be("FILE_objects/audio.m4a");
-        smLink.Attribute(XLinkNs + "to")!.Value.Should().Be("FILE_objects/transcript.docx");
+        smLink.Attribute(XLinkNs + "from")!.Value.Should().Be(MetsIds.File("objects/audio.m4a"));
+        smLink.Attribute(XLinkNs + "to")!.Value.Should().Be(MetsIds.File("objects/transcript.docx"));
         smLink.Attribute(XLinkNs + "arcrole")!.Value.Should().Be(Supplementing.ToString());
     }
 
@@ -798,8 +798,8 @@ public class MetsManagerLogicalStructTests
         var smLinks = doc.Descendants(MetsNs + "smLink").ToList();
 
         smLinks.Should().HaveCount(2);
-        smLinks.Should().Contain(sl => sl.Attribute(XLinkNs + "from")!.Value == "FILE_objects/a.m4a");
-        smLinks.Should().Contain(sl => sl.Attribute(XLinkNs + "from")!.Value == "FILE_objects/b.m4a");
+        smLinks.Should().Contain(sl => sl.Attribute(XLinkNs + "from")!.Value == MetsIds.File("objects/a.m4a"));
+        smLinks.Should().Contain(sl => sl.Attribute(XLinkNs + "from")!.Value == MetsIds.File("objects/b.m4a"));
     }
 
     // -----------------------------------------------------------------------
@@ -831,7 +831,7 @@ public class MetsManagerLogicalStructTests
         var smLinks = doc.Descendants(MetsNs + "smLink").ToList();
 
         smLinks.Should().HaveCount(1);
-        smLinks[0].Attribute(XLinkNs + "from")!.Value.Should().Be("FILE_objects/b.m4a");
+        smLinks[0].Attribute(XLinkNs + "from")!.Value.Should().Be(MetsIds.File("objects/b.m4a"));
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerMetadataTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerMetadataTests.cs
@@ -383,12 +383,12 @@ public class MetsManagerMetadataTests
 
         // No dmdSec for the file, and no empty mods left anywhere.
         doc.Descendants(MetsNs + "dmdSec")
-            .Any(d => (string?)d.Attribute("ID") == "DMD_objects/file.tif")
+            .Any(d => (string?)d.Attribute("ID") == MetsIds.Dmd("objects/file.tif"))
             .Should().BeFalse("the dmdSec should be removed once it carries no MODS information");
 
         // The file div must no longer reference the removed dmdSec.
         var fileDiv = doc.Descendants(MetsNs + "div")
-            .Single(d => (string?)d.Attribute("ID") == "PHYS_objects/file.tif");
+            .Single(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/file.tif"));
         fileDiv.Attribute("DMDID").Should().BeNull("the dangling DMDID reference should be dropped");
     }
 

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerPathTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerPathTests.cs
@@ -15,16 +15,18 @@ namespace XmlGen.Tests;
 /// problematic in XML ID / IDREFS attributes — in particular spaces, ampersands,
 /// and Unicode characters.
 ///
-/// Background: MetsManager generates ID, ADMID, FILEID, and DMDID attribute values
-/// directly from LocalPath strings without escaping. Spaces are especially
-/// problematic because ADMID is typed as IDREFS in the METS schema, which means
-/// the XmlSerializer backing XmlGen types splits the attribute value on whitespace
-/// into a Collection&lt;string&gt; of individual tokens. MetadataManager line 195
-/// works around this with:
+/// Background: MetsManager builds ID, ADMID, FILEID and DMDID values from LocalPath.
+/// A path is not a valid xs:ID — <c>/</c> and space are both illegal — so since issue
+/// #188 the path goes through <see cref="DigitalPreservation.Utils.MetsIdEncoding.ToMetsId"/>
+/// first and the ID becomes e.g. <c>FILE_objects_x002F_my_x0020_file.pdf</c>. Expected
+/// values here are therefore built with <see cref="MetsIds"/> rather than written out.
+/// The paths themselves (FLocat href, premis:originalName) are NOT encoded and keep
+/// their spaces and slashes.
 ///
-///     ctx.FileAdmId = string.Join(' ', ctx.File.Admid);
-///
-/// which rejoins the tokens before looking up the matching AmdSec element.
+/// This removes the IDREFS hazard for everything the platform writes from now on: an
+/// encoded ADMID is a single token, so the XmlSerializer no longer splits it. The
+/// rejoining logic (IdRefs) stays for METS written BEFORE the fix, whose raw IDs still
+/// split — see MetsManagerPathFixtureTests for that frozen corpus.
 ///
 /// Every test validates at two levels:
 ///   1. Parser round-trip — MetsParser reads back what MetsManager wrote and
@@ -117,10 +119,9 @@ public class MetsManagerPathTests
     [Fact]
     public async Task File_With_Space_In_Name_Round_Trips()
     {
-        // A file whose LocalPath contains a space in the filename.
-        // The ADMID attribute "ADM_objects/my file.pdf" is split by the XmlSerializer
-        // into ["ADM_objects/my", "file.pdf"], but all top-level WorkingFile properties
-        // must survive the full write/parse cycle unchanged.
+        // A file whose LocalPath contains a space in the filename. The space is encoded
+        // out of the IDs, but the path itself keeps it, and all top-level WorkingFile
+        // properties must survive the full write/parse cycle unchanged.
 
         var (metsUri, eTag) = await CreateEmptyMets("path-space-filename.xml");
         await AddFile(metsUri, SimpleFile("objects/my file.pdf", "my file.pdf"), eTag);
@@ -142,50 +143,49 @@ public class MetsManagerPathTests
         // generated XML are mutually consistent: each attribute that references
         // another element uses exactly the same string as that element's ID.
         //
-        // Note: ADMID is typed as IDREFS in the METS schema, so schema-aware parsers
-        // will split "ADM_objects/my file.pdf" on the space. That is a known limitation
-        // documented at MetadataManager line 192-195 and is out of scope for this test.
-        // This test focuses on whether the string values written are self-consistent
-        // (i.e., every cross-reference resolves to the right element).
+        // Since #188 the ADMID is also a single IDREFS token — the space that used to
+        // split it is encoded — so a schema-aware parser resolves it to one amdSec.
 
+        const string path = "objects/my file.pdf";
         var (metsUri, eTag) = await CreateEmptyMets("path-space-rawxml.xml");
-        await AddFile(metsUri, SimpleFile("objects/my file.pdf", "my file.pdf"), eTag);
+        await AddFile(metsUri, SimpleFile(path, "my file.pdf"), eTag);
 
         var doc = XDocument.Load(metsUri.LocalPath);
 
         // FileType: ID and ADMID attribute values
         var fileEl = doc.Descendants(MetsNs + "file")
-            .Single(f => (string)f.Attribute("ID")! == "FILE_objects/my file.pdf");
-        fileEl.Attribute("ADMID")!.Value.Should().Be("ADM_objects/my file.pdf");
+            .Single(f => (string)f.Attribute("ID")! == MetsIds.File(path));
+        fileEl.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm(path));
+        fileEl.Attribute("ADMID")!.Value.Should().NotContain(" ",
+            "an encoded ADMID is one IDREFS token, not several");
 
-        // FLocat HREF
+        // FLocat HREF — the path itself is never encoded
         fileEl.Elements(MetsNs + "FLocat").Single()
-            .Attribute(XLinkNs + "href")!.Value.Should().Be("objects/my file.pdf");
+            .Attribute(XLinkNs + "href")!.Value.Should().Be(path);
 
         // AmdSec ID matches the ADMID on the FileType
         var amdSecEl = doc.Descendants(MetsNs + "amdSec")
-            .Single(a => (string)a.Attribute("ID")! == "ADM_objects/my file.pdf");
+            .Single(a => (string)a.Attribute("ID")! == MetsIds.Adm(path));
 
         // TechMD inside that AmdSec
         amdSecEl.Elements(MetsNs + "techMD").Single()
-            .Attribute("ID")!.Value.Should().Be("TECH_objects/my file.pdf");
+            .Attribute("ID")!.Value.Should().Be(MetsIds.Tech(path));
 
         // StructMap Div: ID, and its Fptr FILEID
         var divEl = doc.Descendants(MetsNs + "div")
-            .Single(d => (string?)d.Attribute("ID") == "PHYS_objects/my file.pdf");
+            .Single(d => (string?)d.Attribute("ID") == MetsIds.Phys(path));
         divEl.Elements(MetsNs + "fptr").Single()
-            .Attribute("FILEID")!.Value.Should().Be("FILE_objects/my file.pdf");
+            .Attribute("FILEID")!.Value.Should().Be(MetsIds.File(path));
     }
 
     [Fact]
     public async Task File_With_Space_In_Name_Can_Be_Overwritten()
     {
-        // Verifies that the update path through MetadataManager.GetMetadataXml (line 195)
-        // correctly locates the AmdSec for a file whose path contains a space.
-        //
-        // On update (newUpload=false), MetadataManager sets ctx.FileAdmId by space-joining
-        // ctx.File.Admid to reconstruct "ADM_objects/my file.pdf" from ["ADM_objects/my", "file.pdf"],
-        // then finds the AmdSec by that ID. If the join were wrong the update would throw.
+        // Verifies that the update path through MetadataManager.GetMetadataXml correctly
+        // locates the AmdSec for a file whose path contains a space. On update
+        // (newUpload=false) the amdSec is resolved from the file's ADMID tokens via IdRefs,
+        // which handles both the single encoded token written here and the several tokens a
+        // legacy raw ID splits into.
 
         var (metsUri, eTag) = await CreateEmptyMets("path-space-overwrite.xml");
         eTag = await AddFile(metsUri, SimpleFile("objects/my file.pdf", "my file.pdf"), eTag);
@@ -218,23 +218,22 @@ public class MetsManagerPathTests
     [Fact]
     public async Task File_With_Multiple_Spaces_In_Name_Round_Trips_And_Overwrite_Works()
     {
-        // A path element with more than one space, e.g. "my great file.pdf".
-        // The ADMID attribute "ADM_objects/my great file.pdf" is split by the XmlSerializer
-        // into ["ADM_objects/my", "great", "file.pdf"] — three tokens, not two.
-        // string.Join(' ', ...) must reconstruct the original string correctly in both
-        // the initial upload path and the overwrite path.
+        // A path element with more than one space, e.g. "my great file.pdf" — which before
+        // #188 produced an ADMID that split into THREE tokens. Both spaces are now encoded,
+        // in the initial upload path and in the overwrite path.
 
+        const string path = "objects/my great file.pdf";
         var (metsUri, eTag) = await CreateEmptyMets("path-multi-space.xml");
-        eTag = await AddFile(metsUri, SimpleFile("objects/my great file.pdf", "my great file.pdf"), eTag);
+        eTag = await AddFile(metsUri, SimpleFile(path, "my great file.pdf"), eTag);
 
         // Initial round-trip
         var parseResult = await parser.GetMetsFileWrapper(metsUri);
-        var file = parseResult.Value!.Files.Single(f => f.LocalPath == "objects/my great file.pdf");
+        var file = parseResult.Value!.Files.Single(f => f.LocalPath == path);
         file.Name.Should().Be("my great file.pdf");
         file.Digest.Should().Be(TestDigest);
 
-        // Overwrite — tests that the multi-token Admid Collection is handled in the update path
-        var updatedFile = SimpleFile("objects/my great file.pdf", "my great file.pdf");
+        // Overwrite — tests that the Admid Collection is resolved in the update path
+        var updatedFile = SimpleFile(path, "my great file.pdf");
         updatedFile.Metadata.Add(new FileFormatMetadata
         {
             Source = "Siegfried",
@@ -248,14 +247,15 @@ public class MetsManagerPathTests
         overwriteResult.Success.Should().BeTrue();
 
         var parseResult2 = await parser.GetMetsFileWrapper(metsUri);
-        var updatedFile2 = parseResult2.Value!.Files.Single(f => f.LocalPath == "objects/my great file.pdf");
+        var updatedFile2 = parseResult2.Value!.Files.Single(f => f.LocalPath == path);
         updatedFile2.Metadata.OfType<FileFormatMetadata>().Single().PronomKey.Should().Be("fmt/19");
 
-        // Raw XML: ADMID contains all three space-separated tokens in a single attribute string
+        // Raw XML: both spaces are encoded, so the ADMID is a single IDREFS token
         var doc = XDocument.Load(metsUri.LocalPath);
         var fileEl = doc.Descendants(MetsNs + "file")
-            .Single(f => (string)f.Attribute("ID")! == "FILE_objects/my great file.pdf");
-        fileEl.Attribute("ADMID")!.Value.Should().Be("ADM_objects/my great file.pdf");
+            .Single(f => (string)f.Attribute("ID")! == MetsIds.File(path));
+        fileEl.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm(path));
+        fileEl.Attribute("ADMID")!.Value.Should().NotContain(" ");
     }
 
     // -----------------------------------------------------------------------
@@ -265,9 +265,9 @@ public class MetsManagerPathTests
     [Fact]
     public async Task Directory_With_Space_In_Name_Round_Trips()
     {
-        // A child directory under objects/ whose LocalPath contains a space.
-        // Navigation through GetMetsElements uses Div IDs derived from the path,
-        // so "PHYS_objects/my folder" must be findable in memory after writing.
+        // A child directory under objects/ whose LocalPath contains a space. Navigation is
+        // by premis:originalName (the path cache), so the div is findable whatever form its
+        // ID takes; the ID itself is now the encoded form.
 
         var (metsUri, eTag) = await CreateEmptyMets("path-space-dirname.xml");
         eTag = await AddDirectory(metsUri, SimpleDirectory("objects/my folder", "my folder"), eTag);
@@ -287,41 +287,42 @@ public class MetsManagerPathTests
         // Raw XML: directory Div ID and its ADMID
         var doc = XDocument.Load(metsUri.LocalPath);
         var dirDiv = doc.Descendants(MetsNs + "div")
-            .Single(d => (string?)d.Attribute("ID") == "PHYS_objects/my folder");
-        dirDiv.Attribute("ADMID")!.Value.Should().Be("ADM_objects/my folder");
+            .Single(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/my folder"));
+        dirDiv.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm("objects/my folder"));
     }
 
     [Fact]
     public async Task File_With_Space_In_Both_Directory_And_Name_Round_Trips()
     {
-        // Combines a spaced directory name with a spaced filename.
-        // GetMetsElements navigates two levels of IDs, both containing spaces.
+        // Combines a spaced directory name with a spaced filename: navigation crosses two
+        // levels whose paths both contain spaces.
 
+        const string dirPath = "objects/some archive";
+        const string filePath = "objects/some archive/scanned page.pdf";
         var (metsUri, eTag) = await CreateEmptyMets("path-space-both.xml");
-        eTag = await AddDirectory(metsUri, SimpleDirectory("objects/some archive", "some archive"), eTag);
-        await AddFile(metsUri, SimpleFile("objects/some archive/scanned page.pdf", "scanned page.pdf"), eTag);
+        eTag = await AddDirectory(metsUri, SimpleDirectory(dirPath, "some archive"), eTag);
+        await AddFile(metsUri, SimpleFile(filePath, "scanned page.pdf"), eTag);
 
         var parseResult = await parser.GetMetsFileWrapper(metsUri);
         parseResult.Success.Should().BeTrue();
 
-        var file = parseResult.Value!.Files
-            .Single(f => f.LocalPath == "objects/some archive/scanned page.pdf");
+        var file = parseResult.Value!.Files.Single(f => f.LocalPath == filePath);
         file.Name.Should().Be("scanned page.pdf");
         file.Digest.Should().Be(TestDigest);
 
-        // Raw XML: both the directory Div ID and the file Div ID contain spaces
+        // Raw XML: the spaces and slashes are encoded out of both Div IDs
         var doc = XDocument.Load(metsUri.LocalPath);
         doc.Descendants(MetsNs + "div")
-            .Should().Contain(d => (string?)d.Attribute("ID") == "PHYS_objects/some archive");
+            .Should().Contain(d => (string?)d.Attribute("ID") == MetsIds.Phys(dirPath));
         doc.Descendants(MetsNs + "div")
-            .Should().Contain(d => (string?)d.Attribute("ID") == "PHYS_objects/some archive/scanned page.pdf");
+            .Should().Contain(d => (string?)d.Attribute("ID") == MetsIds.Phys(filePath));
 
         // The file FileType ADMID and AmdSec ID are consistent
         var fileEl = doc.Descendants(MetsNs + "file")
-            .Single(f => (string)f.Attribute("ID")! == "FILE_objects/some archive/scanned page.pdf");
-        fileEl.Attribute("ADMID")!.Value.Should().Be("ADM_objects/some archive/scanned page.pdf");
+            .Single(f => (string)f.Attribute("ID")! == MetsIds.File(filePath));
+        fileEl.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm(filePath));
         doc.Descendants(MetsNs + "amdSec")
-            .Should().Contain(a => (string?)a.Attribute("ID") == "ADM_objects/some archive/scanned page.pdf");
+            .Should().Contain(a => (string?)a.Attribute("ID") == MetsIds.Adm(filePath));
     }
 
     // -----------------------------------------------------------------------
@@ -374,11 +375,13 @@ public class MetsManagerPathTests
         file.Name.Should().Be("résumé.pdf");
         file.Digest.Should().Be(TestDigest);
 
-        // Raw XML: ID attributes contain the unescaped Unicode characters
+        // Raw XML: accented characters are valid NCName characters and pass through the ID
+        // encoding untouched — only the path separator is escaped.
         var doc = XDocument.Load(metsUri.LocalPath);
+        MetsIds.File("objects/résumé.pdf").Should().EndWith("résumé.pdf");
         doc.Descendants(MetsNs + "file")
-            .Should().Contain(f => (string)f.Attribute("ID")! == "FILE_objects/résumé.pdf");
+            .Should().Contain(f => (string)f.Attribute("ID")! == MetsIds.File("objects/résumé.pdf"));
         doc.Descendants(MetsNs + "amdSec")
-            .Should().Contain(a => (string?)a.Attribute("ID") == "ADM_objects/résumé.pdf");
+            .Should().Contain(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/résumé.pdf"));
     }
 }

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerSyncTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerSyncTests.cs
@@ -217,27 +217,27 @@ public class MetsManagerSyncTests
 
         // FileType in fileSec
         var fileEl = doc.Descendants(MetsNs + "file")
-            .Single(f => (string)f.Attribute("ID")! == "FILE_objects/doc.tif");
-        fileEl.Attribute("ADMID")!.Value.Should().Be("ADM_objects/doc.tif");
+            .Single(f => (string)f.Attribute("ID")! == MetsIds.File("objects/doc.tif"));
+        fileEl.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm("objects/doc.tif"));
         fileEl.Elements(MetsNs + "FLocat").Single()
             .Attribute(XLinkNs + "href")!.Value.Should().Be("objects/doc.tif");
 
         // AmdSec with matching ID
         doc.Descendants(MetsNs + "amdSec")
-            .Should().Contain(a => (string?)a.Attribute("ID") == "ADM_objects/doc.tif");
+            .Should().Contain(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/doc.tif"));
 
         // TechMD inside that AmdSec
         var amdSec = doc.Descendants(MetsNs + "amdSec")
-            .Single(a => (string)a.Attribute("ID")! == "ADM_objects/doc.tif");
+            .Single(a => (string)a.Attribute("ID")! == MetsIds.Adm("objects/doc.tif"));
         amdSec.Elements(MetsNs + "techMD").Single()
-            .Attribute("ID")!.Value.Should().Be("TECH_objects/doc.tif");
+            .Attribute("ID")!.Value.Should().Be(MetsIds.Tech("objects/doc.tif"));
 
         // StructMap Div
         var divEl = doc.Descendants(MetsNs + "div")
-            .Single(d => (string?)d.Attribute("ID") == "PHYS_objects/doc.tif");
+            .Single(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/doc.tif"));
         divEl.Attribute("TYPE")!.Value.Should().Be("Item");
         divEl.Elements(MetsNs + "fptr").Single()
-            .Attribute("FILEID")!.Value.Should().Be("FILE_objects/doc.tif");
+            .Attribute("FILEID")!.Value.Should().Be(MetsIds.File("objects/doc.tif"));
     }
 
     [Fact]
@@ -284,14 +284,14 @@ public class MetsManagerSyncTests
 
         // StructMap Div for the directory
         var dirDiv = doc.Descendants(MetsNs + "div")
-            .Single(d => (string?)d.Attribute("ID") == "PHYS_objects/archive");
+            .Single(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/archive"));
         dirDiv.Attribute("TYPE")!.Value.Should().Be("Directory");
         dirDiv.Attribute("LABEL")!.Value.Should().Be("Archive");
-        dirDiv.Attribute("ADMID")!.Value.Should().Be("ADM_objects/archive");
+        dirDiv.Attribute("ADMID")!.Value.Should().Be(MetsIds.Adm("objects/archive"));
 
         // AmdSec for the directory
         doc.Descendants(MetsNs + "amdSec")
-            .Should().Contain(a => (string?)a.Attribute("ID") == "ADM_objects/archive");
+            .Should().Contain(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/archive"));
     }
 
     [Fact]
@@ -363,12 +363,12 @@ public class MetsManagerSyncTests
         // Raw XML: fileSec entry and amdSec entry for the removed file must be gone.
         var doc = XDocument.Load(metsUri.LocalPath);
         doc.Descendants(MetsNs + "file")
-            .Should().NotContain(f => (string?)f.Attribute("ID") == "FILE_objects/remove.tif");
+            .Should().NotContain(f => (string?)f.Attribute("ID") == MetsIds.File("objects/remove.tif"));
         doc.Descendants(MetsNs + "amdSec")
-            .Should().NotContain(a => (string?)a.Attribute("ID") == "ADM_objects/remove.tif");
+            .Should().NotContain(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/remove.tif"));
         // The structMap Div for the deleted file must also be gone.
         doc.Descendants(MetsNs + "div")
-            .Should().NotContain(d => (string?)d.Attribute("ID") == "PHYS_objects/remove.tif");
+            .Should().NotContain(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/remove.tif"));
     }
 
     [Fact]
@@ -405,9 +405,9 @@ public class MetsManagerSyncTests
         // Raw XML: structMap Div and amdSec for the removed directory must be gone.
         var doc = XDocument.Load(metsUri.LocalPath);
         doc.Descendants(MetsNs + "div")
-            .Should().NotContain(d => (string?)d.Attribute("ID") == "PHYS_objects/remove-dir");
+            .Should().NotContain(d => (string?)d.Attribute("ID") == MetsIds.Phys("objects/remove-dir"));
         doc.Descendants(MetsNs + "amdSec")
-            .Should().NotContain(a => (string?)a.Attribute("ID") == "ADM_objects/remove-dir");
+            .Should().NotContain(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/remove-dir"));
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerTests.cs
@@ -95,7 +95,7 @@ public class MetsManagerTests
         physical.Descendants(mets + "div")
             .Count(d => (string?)d.Attribute("ID") == Constants.MetadataDivId).Should().Be(1);
         xml.Descendants(mets + "file")
-            .Count(f => (string?)f.Attribute("ID") == "FILE_metadata/report.txt").Should().Be(1);
+            .Count(f => (string?)f.Attribute("ID") == MetsIds.File("metadata/report.txt")).Should().Be(1);
     }
 
     [Fact]
@@ -654,8 +654,8 @@ public class MetsManagerTests
         result.Success.Should().BeTrue();
 
         var xDoc = result.Value!.XDocument!;
-        var expectedAdmId = $"{Constants.AdmIdPrefix}{FolderNames.Metadata}/{FolderNames.AdHoc}";
-        var expectedTechId = $"{Constants.TechIdPrefix}{FolderNames.Metadata}/{FolderNames.AdHoc}";
+        var expectedAdmId = MetsIds.Adm(FolderNames.MetadataAdHoc);
+        var expectedTechId = MetsIds.Tech(FolderNames.MetadataAdHoc);
 
         var amdSec = xDoc.Descendants(XNames.MetsAmdSec)
             .SingleOrDefault(a => a.Attribute("ID")?.Value == expectedAdmId);
@@ -694,7 +694,7 @@ public class MetsManagerTests
 
         adHocDiv.Should().NotBeNull("the ad-hoc div must be a direct child of the metadata div");
 
-        var expectedAdmId = $"{Constants.AdmIdPrefix}{FolderNames.Metadata}/{FolderNames.AdHoc}";
+        var expectedAdmId = MetsIds.Adm(FolderNames.MetadataAdHoc);
         adHocDiv!.Attribute("ADMID")?.Value.Should().Be(expectedAdmId);
     }
 
@@ -769,8 +769,8 @@ public class MetsManagerTests
     /// </summary>
     private static void AssertBuiltInDirectoryDiv(XDocument doc, string localPath, string expectedLabel)
     {
-        var physId = $"PHYS_{localPath}";
-        var admId  = $"ADM_{localPath}";
+        var physId = MetsIds.Phys(localPath);
+        var admId  = MetsIds.Adm(localPath);
 
         var divEl = doc.Descendants(XNames.MetsDiv)
             .FirstOrDefault(d => d.Attribute("ID")?.Value == physId);

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
@@ -130,12 +130,12 @@ public class MetsManagerWithPremis
 
         // fileSec: file element has correct MIMETYPE
         var fileEl = xml.Descendants(MetsNs + "file")
-            .Single(f => (string?)f.Attribute("ID") == "FILE_objects/document.pdf");
+            .Single(f => (string?)f.Attribute("ID") == MetsIds.File("objects/document.pdf"));
         fileEl.Attribute("MIMETYPE")?.Value.Should().Be("application/pdf");
 
         // amdSec: has techMD with PREMIS, but no digiprovMD (no virus event)
         var amdSec = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/document.pdf");
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"));
         amdSec.Elements(MetsNs + "techMD").Should().HaveCount(1);
         amdSec.Elements(MetsNs + "digiprovMD").Should().BeEmpty();
 
@@ -195,7 +195,7 @@ public class MetsManagerWithPremis
         // --- Raw XML ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var amdSec = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/document.pdf");
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"));
         var premisObject = amdSec.Descendants(PremisNs + "object").Single();
 
         // Fixity
@@ -264,13 +264,15 @@ public class MetsManagerWithPremis
         // --- Raw XML: exactly one format element in PREMIS ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var premisObject = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/document.pdf")
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"))
             .Descendants(PremisNs + "object").Single();
         premisObject.Descendants(PremisNs + "format").Should().HaveCount(1);
 
         // --- Also: only one amdSec for this file ---
+        // Matched on the whole ID: METS IDs are opaque, and since #188 they no longer contain
+        // the path as a substring.
         xml.Descendants(MetsNs + "amdSec")
-            .Where(a => ((string?)a.Attribute("ID"))!.Contains("objects/document.pdf"))
+            .Where(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"))
             .Should().HaveCount(1);
     }
 
@@ -319,7 +321,7 @@ public class MetsManagerWithPremis
         // --- Raw XML ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var amdSec = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/document.pdf");
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"));
 
         var digiprovMd = amdSec.Elements(MetsNs + "digiprovMD").Single();
         var premisEvent = digiprovMd.Descendants(PremisNs + "event").Single();
@@ -369,7 +371,7 @@ public class MetsManagerWithPremis
         // --- Raw XML ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var premisEvent = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/suspect.exe")
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/suspect.exe"))
             .Descendants(MetsNs + "digiprovMD").Single()
             .Descendants(PremisNs + "event").Single();
 
@@ -439,7 +441,7 @@ public class MetsManagerWithPremis
         // --- Raw XML: ObjectCharacteristicsExtension contains ExifMetadata element ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var premisObject = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/photo.tif")
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/photo.tif"))
             .Descendants(PremisNs + "object").Single();
 
         var exifEl = premisObject.Descendants("ExifMetadata").SingleOrDefault();
@@ -489,7 +491,7 @@ public class MetsManagerWithPremis
         // --- Raw XML: PREMIS significantProperties written for Duration and Bitrate ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var premisObject = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/recording.mp3")
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/recording.mp3"))
             .Descendants(PremisNs + "object").Single();
 
         var sigProps = premisObject.Descendants(PremisNs + "significantProperties").ToList();
@@ -569,7 +571,7 @@ public class MetsManagerWithPremis
         // --- Raw XML: one techMD, one digiprovMD ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var amdSec = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/photo.tif");
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/photo.tif"));
         amdSec.Elements(MetsNs + "techMD").Should().HaveCount(1);
         amdSec.Elements(MetsNs + "digiprovMD").Should().HaveCount(1);
     }
@@ -630,7 +632,7 @@ public class MetsManagerWithPremis
         // --- Raw XML: exactly one amdSec for this file (no duplicate created by overwrite) ---
         var xml = XDocument.Load(metsUri.LocalPath);
         xml.Descendants(MetsNs + "amdSec")
-            .Where(a => ((string?)a.Attribute("ID"))?.Contains("objects/document.pdf") == true)
+            .Where(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"))
             .Should().HaveCount(1, "overwriting a file must not create a second amdSec");
     }
 
@@ -699,7 +701,7 @@ public class MetsManagerWithPremis
         // --- Raw XML: still exactly one digiprovMD (not two) ---
         var xml = XDocument.Load(metsUri.LocalPath);
         var amdSec = xml.Descendants(MetsNs + "amdSec")
-            .Single(a => (string?)a.Attribute("ID") == "ADM_objects/document.pdf");
+            .Single(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"));
         amdSec.Elements(MetsNs + "digiprovMD").Should().HaveCount(1);
     }
 

--- a/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/MetsManagerWithPremis.cs
@@ -269,11 +269,7 @@ public class MetsManagerWithPremis
         premisObject.Descendants(PremisNs + "format").Should().HaveCount(1);
 
         // --- Also: only one amdSec for this file ---
-        // Matched on the whole ID: METS IDs are opaque, and since #188 they no longer contain
-        // the path as a substring.
-        xml.Descendants(MetsNs + "amdSec")
-            .Where(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"))
-            .Should().HaveCount(1);
+        AssertSingleAmdSecFor(xml, "objects/document.pdf");
     }
 
     // -----------------------------------------------------------------------
@@ -630,10 +626,21 @@ public class MetsManagerWithPremis
         ffm.PronomKey.Should().Be("fmt/276");
 
         // --- Raw XML: exactly one amdSec for this file (no duplicate created by overwrite) ---
-        var xml = XDocument.Load(metsUri.LocalPath);
+        AssertSingleAmdSecFor(XDocument.Load(metsUri.LocalPath), "objects/document.pdf");
+    }
+
+    /// <summary>
+    /// Exactly one amdSec describes the file at this path. Matched on the PREMIS originalName
+    /// inside the techMD, NOT on the amdSec's ID: the regression being guarded against is a
+    /// SECOND amdSec for the same file, and a duplicate minted under a different ID scheme
+    /// (a raw-path ID alongside an encoded one, in a mixed-format document) is invisible to an
+    /// ID-equality check — which is how this assertion was silently defanged once already.
+    /// </summary>
+    private static void AssertSingleAmdSecFor(XDocument xml, string localPath)
+    {
         xml.Descendants(MetsNs + "amdSec")
-            .Where(a => (string?)a.Attribute("ID") == MetsIds.Adm("objects/document.pdf"))
-            .Should().HaveCount(1, "overwriting a file must not create a second amdSec");
+            .Where(amdSec => amdSec.Descendants(PremisNs + "originalName").Any(n => n.Value == localPath))
+            .Should().HaveCount(1, $"exactly one amdSec may describe '{localPath}'");
     }
 
     [Fact]

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -108,7 +108,7 @@ public class PhysicalDivsCacheTests
     private static System.Xml.XmlElement GetPremisOriginalNameElement(
         DigitalPreservation.XmlGen.Mets.Mets mets, string directoryPath)
     {
-        var amdSec = mets.AmdSec.Single(a => a.Id == $"{Constants.AdmIdPrefix}{directoryPath}");
+        var amdSec = mets.AmdSec.Single(a => a.Id == MetsIds.Adm(directoryPath));
         var premisXml = amdSec.TechMd[0].MdWrap.XmlData.Any[0];
         var elements = premisXml.GetElementsByTagName("originalName", "http://www.loc.gov/premis/v3");
         return (System.Xml.XmlElement)elements[0]!;


### PR DESCRIPTION
Step 2 of #188. Every METS `xs:ID` the platform mints is now schema-valid.

`PHYS_objects/my file.pdf` — which is neither a valid NCName nor a single IDREFS token — becomes `PHYS_objects_x002F_my_x0020_file.pdf`, via a single `MetsIdEncoding.ToMetsId()` (`XmlConvert.EncodeLocalName`) that every minting site goes through. Paths themselves are untouched: FLocat `href` and `premis:originalName` keep their spaces and slashes, and remain what navigation actually uses (the step 1 path cache).

**Backwards compatibility is preserved and tested.** Existing raw IDs are never rewritten, legacy documents stay navigable and editable, and anything we write *into* one references the IDs that document actually holds.

## Beyond the plan's inventory

Four things needed more than the planned find-and-replace:

- **`BuildFptr`/`LinkFile`/`UnLinkFile`/`SetFileLinks` now RESOLVE the FILE element's real ID** from the fileSec (`ResolveFileId`) instead of minting one. Minting would have written dangling FILEID/smLink references into legacy documents, and made their existing raw-ID smLinks unremovable (removal matches on the same derivation). This is finding **F3** from the whole-feature review; the pin test added for it back then passes unchanged.
- **The ID-convention navigation tier had to learn both forms.** It reconstructed only `PHYS_` + raw path, so a div minted with an encoded ID that later lost its path metadata became unreachable — the exact failure that tier exists to prevent. Found by an existing test, not a new one.
- **The duplicate-div guard needed widening.** An encoded mint no longer collides with a legacy raw-ID div for the same path, so without checking both forms an add could quietly create a *second* div for one path.
- **dmdSec IDs now come from the div's path, not its ID.** Setting metadata on a legacy div therefore mints a valid ID rather than a second invalid one. The `ByDivId` entry points recover the path from the cache.

## New validation at the client boundary

`SetStructMap` is the only route by which a caller-supplied string becomes an `xs:ID`. It now validates the whole range tree and returns `BadRequest` **before writing anything** (so a bad replacement can't destroy the structMap already there). IDs are rejected, not encoded — the client round-trips them, so silently changing one would break its own references. The UI only ever mints `LOG_<epoch-ms>`, which passes.

`IMetsManager.SetStructMap` returns `Result` as a result; `SetLogicalStructMapHandler` propagates it. A range with no ID is now written *without* an ID attribute rather than as `ID=""` (also invalid) — this shape is real, it is what the parser reports for third-party logical divs, and replace/remove still match it.

## Tests

`MetsIdIntegrityTests` is the merge gate: every ID valid and unique, every ADMID/FILEID/smLink reference resolving, across empty, awkward-path, logical-structMap, Archival-Group and **mixed legacy** documents. Nothing in the suite checked this before — `XmlSerializer` does not enforce `xs:ID`, which is how #188 survived from the beginning.

It stands in for the planned XSD validation, which would need the METS + xlink schema set committed for offline CI and would currently fail on an unrelated pre-existing issue: the template writes DMDID onto the objects/metadata/ad-hoc divs while their dmdSecs are only created lazily, so those references dangle by design. **Dangling-DMDID and full XSD validation are both recorded as conformance-checker backlog**, not fixed here.

Expectations are built through `MetsIds`/`ToMetsId`, never as encoded literals, so a change to the encoding shows up as one deliberate edit rather than a wall of strings. The frozen legacy corpus in `Samples/` is untouched.

XmlGen 444 passed (Debug **and** Release), Storage.API 55, Preservation.API 106, Core 68, Common.Model 8.

## ⚠️ Release engineering

`DigitalPreservation.Mets` and `Storage.Repository.Common` are compiled into **Preservation.API, Pipeline.API, DigitalPreservation.UI, Storage.API, Storage.API.Importer and Deposit.Archiver**. A mixed-version window means one service minting raw IDs while another mints encoded ones into the same METS. **This must ship as a single release tagging all of them.**

Step 3 (bulk migration of existing documents) stays deferred. Until it happens the legacy tiers — the ID-convention fallback, the IdRefs rejoining, and the raw-form checks added here — all stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
