### PR TITLE
test: AG-derived METS navigability, in every build configuration (#222)

### DIFF
--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -1,12 +1,15 @@
+using System.Text.Json;
 using DigitalPreservation.Common.Model;
 using DigitalPreservation.Common.Model.Transit;
 using DigitalPreservation.Common.Model.Transit.Extensions.Metadata;
 using DigitalPreservation.Mets;
 using DigitalPreservation.Mets.StorageImpl;
+using DigitalPreservation.Utils;
 using DigitalPreservation.XmlGen.Mets;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Storage.Repository.Common.Mets;
 
 namespace XmlGen.Tests;
 
@@ -21,6 +24,7 @@ public class PhysicalDivsCacheTests
 {
     private readonly MetsManager metsManager;
     private readonly FileSystemMetsStorage metsStorage;
+    private readonly MetsFromArchivalGroup metsFromArchivalGroup;
 
     private const string TestDigest = "eb634d64ce8e6be5195174ceaef9ac9e19c37119f3b31618630aa633ccdbf68f";
 
@@ -40,6 +44,7 @@ public class PhysicalDivsCacheTests
         var premisEventManager = new PremisEventManagerVirus();
         var metadataManager = new MetadataManager(premisManager, premisManagerExif, premisEventManager);
         metsManager = new MetsManager(parser, metsStorage, metadataManager);
+        metsFromArchivalGroup = new MetsFromArchivalGroup(metsManager, parser, metadataManager);
     }
 
     // -----------------------------------------------------------------------
@@ -731,5 +736,83 @@ public class PhysicalDivsCacheTests
         fullMets.PhysicalDivsByPath.Keys.Should().NotContain(
             ["objects/my folder", "objects/my folder/my document.pdf"]);
         AssertCacheMatchesRebuild(fullMets);
+    }
+
+    // -----------------------------------------------------------------------
+    // METS built from an Archival Group, rather than by MetsManager mutation
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A METS that MetsFromArchivalGroup builds must be navigable by path, exactly as one built
+    /// by MetsManager must be — the whole of #188 step 1 rests on it.
+    /// </summary>
+    /// <remarks>
+    /// This was previously checked only by <c>MetsFromArchivalGroup.AssertNavigable</c>, which is
+    /// <c>[Conditional("DEBUG")]</c>, while the CI job that gates merges builds Release (issue
+    /// #222). Breaking navigability here — by dropping the <c>premis:originalName</c> that
+    /// directory divs resolve through — failed 8 tests in Debug and 1 in Release, and that 1 was
+    /// an incidental catch in a delete test. Notably
+    /// <c>MetsIdIntegrityTests.A_Mets_Built_From_An_Archival_Group_Has_Valid_Unique_Resolvable_Ids</c>
+    /// passed: IDs stay valid and unique when paths stop resolving, so the ID gate says nothing
+    /// about navigability. This test is the coverage, and it does not depend on build configuration.
+    /// </remarks>
+    [Fact]
+    public async Task A_Mets_Built_From_An_Archival_Group_Is_Fully_Navigable_By_Path()
+    {
+        var archivalGroup = JsonSerializer.Deserialize<ArchivalGroup>(
+            await File.ReadAllTextAsync(new FileInfo("Samples/archivalGroup.json").FullName))!;
+
+        var metsUri = OutputUri("cache-archival-group-export.xml");
+        var created = await metsFromArchivalGroup.CreateStandardMets(metsUri, archivalGroup, "Cache AG Export");
+        created.Success.Should().BeTrue(created.ErrorMessage ?? "");
+
+        // Load it back the way anything reading this METS would, which is what populates the cache.
+        var loaded = await metsManager.GetFullMets(metsUri, created.Value!.ETag);
+        loaded.Success.Should().BeTrue(loaded.ErrorMessage ?? "");
+        var fullMets = loaded.Value!;
+
+        fullMets.PathDiagnostics.Should().BeEmpty(
+            "every div in an exported Archival Group must resolve to a path");
+
+        // Every container and binary the Archival Group holds, by its deposit-relative path.
+        // Derived from the Archival Group itself rather than listed here, so the test cannot
+        // drift from the fixture, and so it states the contract independently of the code that
+        // builds the structMap.
+        var expected = DepositPathsIn(archivalGroup);
+        expected.Should().HaveCountGreaterThan(5, "the fixture is meant to be a nested structure");
+        fullMets.PhysicalDivsByPath.Keys.Should().Contain(expected);
+
+        // The nested case spelled out, because that is where a path-building bug shows first.
+        fullMets.PhysicalDivsByPath.Keys.Should().Contain(
+            "objects/folder-b/folder-bb/minutes-laqm-22-april-2020.pdf");
+    }
+
+    /// <summary>
+    /// Paths of everything in an Archival Group, relative to the group's own root — except the
+    /// METS file itself, which does not appear in its own structMap.
+    /// </summary>
+    private static List<string> DepositPathsIn(ArchivalGroup archivalGroup)
+    {
+        var root = archivalGroup.Id!.LocalPath;
+        var paths = new List<string>();
+
+        void Collect(Container container)
+        {
+            foreach (var binary in container.Binaries)
+            {
+                if (MetsUtils.IsMetsFile(binary.Name ?? "")) continue;
+                paths.Add(Relative(binary.Id!));
+            }
+            foreach (var child in container.Containers)
+            {
+                paths.Add(Relative(child.Id!));
+                Collect(child);
+            }
+        }
+
+        string Relative(Uri id) => id.LocalPath.RemoveStart(root).RemoveStart("/");
+
+        Collect(archivalGroup);
+        return paths.Where(path => path.HasText()).ToList();
     }
 }

--- a/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/PhysicalDivsCacheTests.cs
@@ -791,6 +791,16 @@ public class PhysicalDivsCacheTests
     /// Paths of everything in an Archival Group, relative to the group's own root — except the
     /// METS file itself, which does not appear in its own structMap.
     /// </summary>
+    /// <remarks>
+    /// The exclusion is deliberately the same expression <c>MetsFromArchivalGroup.AddBinariesToMets</c>
+    /// uses to decide what to leave out — the deposit-relative path, matched exactly. The looser
+    /// name-only form agrees with it on today's fixture, where the METS sits at the root and is
+    /// called <c>mets.xml</c>, but the two come apart the moment that stops being true: a binary
+    /// named <c>old-mets-backup.xml</c> would be dropped from the expected set while production
+    /// still put it in the structMap, and a METS in a subdirectory would be the reverse. Both
+    /// divergences make this test cover less while still passing, which is the failure mode a
+    /// derived expectation exists to avoid.
+    /// </remarks>
     private static List<string> DepositPathsIn(ArchivalGroup archivalGroup)
     {
         var root = archivalGroup.Id!.LocalPath;
@@ -800,7 +810,7 @@ public class PhysicalDivsCacheTests
         {
             foreach (var binary in container.Binaries)
             {
-                if (MetsUtils.IsMetsFile(binary.Name ?? "")) continue;
+                if (MetsUtils.IsMetsFile(Relative(binary.Id!), true)) continue;
                 paths.Add(Relative(binary.Id!));
             }
             foreach (var child in container.Containers)


### PR DESCRIPTION
Closes #222.

`MetsFromArchivalGroup.AssertNavigable` is `[Conditional("DEBUG")]`, so the check that an exported Archival Group produces a navigable structMap only ever ran in a Debug build. This replaces that accidental coverage with an ordinary test, which is the resolution proposed on the issue.

An earlier draft of this description said the assertion "never ran where it mattered" because "the CI job that gates merges builds Release". Prompted by review, I checked the actual configuration rather than assuming it, and both halves of that were wrong:

- **`sonar-cloud-analysis` builds Debug.** It runs bare `dotnet build` / `dotnet test` with no `--configuration`, so the assertion *has* been executing on every PR. Only `test-dotnet` is Release.
- **No CI check gates merges at all.** The `main` ruleset (`gh api repos/.../rules/branches/main`) carries exactly three rules — `deletion`, `non_fast_forward`, and `pull_request` with `required_approving_review_count: 0`. There is no `required_status_checks` rule, so neither job blocks a merge.

So the assertion was running, in a job that blocks nothing, where a red test sits behind a green quality-gate badge. That is a weaker gap than "never ran" and a better argument for this change than the one I originally made: an ordinary test in `test-dotnet` is coverage you can actually see fail.

## What the measurement actually showed

I broke navigability *only* — dropping the `premis:originalName` that directory divs resolve through, which leaves every ID valid and unique — and counted:

| | Debug | Release |
|---|---|---|
| XmlGen.Tests failures | **8** | **1** |

The single Release failure was `MetsManagerTests.Can_Delete_Directories_From_Mets`, an incidental catch from a delete test that happens to lean on the AG-built structure.

The interesting part is what *passed*. `MetsIdIntegrityTests.A_Mets_Built_From_An_Archival_Group_Has_Valid_Unique_Resolvable_Ids` — the one test named for this construction path — passed in Release with the structMap unnavigable, because **IDs stay valid, unique and resolvable when paths stop resolving.** The #188 merge gate says nothing at all about navigability. The gap was real, not theoretical arithmetic.

## The test

`PhysicalDivsCacheTests.A_Mets_Built_From_An_Archival_Group_Is_Fully_Navigable_By_Path` builds a METS from the existing `Samples/archivalGroup.json` fixture, loads it back the way any reader would, and asserts:

- `PathDiagnostics` is empty — the same invariant `AssertNavigable` checks;
- every container and binary in the Archival Group is reachable by its deposit-relative path;
- the nested case (`objects/folder-b/folder-bb/…`) explicitly, because that is where a path-building bug shows first.

Expected paths are **derived from the Archival Group** rather than listed, so the test cannot drift from the fixture and states the contract independently of the code that builds the structMap.

One exclusion, which the first run of the test established rather than something I assumed: the METS file itself does not appear in its own structMap, so it is filtered out via `MetsUtils.IsMetsFile`.

**Verified by re-applying the break: the new test fails in Release.** Full suite green in Debug and Release (XmlGen 479, Preservation.API 106, Storage.API 55, Core 68, Common.Model 8).

## What this does not change

The assertion stays. With the coverage in a real test it goes back to being what it was meant to be — a development-time self-check — rather than the only thing standing behind this path. `MetsManager.AssertCacheConsistent` is untouched and should stay conditional: it rebuilds the whole cache on every navigation, so making it unconditional would recreate the quadratic regression R1 removed, and its invariant is covered plainly by the other tests in this file.

I am **not** proposing a Debug CI job. Tom's point on the issue is that `MetsFromArchivalGroup` only runs when an Archival Group with no METS file is exported, which is not expected in production — it was useful during development. That is the same fact that defused the duplicate-ID finding during the #188 audit: no production item was ever made this way. So the only place where a debug assertion carried real coverage is a path we do not expect to run in production, and with this test the residual risk is that the assertions themselves rot unnoticed. That does not seem worth a second CI job.

Sized to go into the release with the rest of the #188 work.

