### PR TITLE
tool: survey real METS for path-navigability, and why it fails (#223)

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Mets/MetsCache.cs
@@ -18,13 +18,24 @@ namespace DigitalPreservation.Mets;
 public static class MetsCache
 {
     /// <summary>
+    /// The invariant part of the diagnostic reported when two divs resolve to one path. The rest of
+    /// that message names the two divs, so this is the only part of it anything can match on.
+    /// </summary>
+    /// <remarks>
+    /// Public because recognising this diagnostic is not just an internal concern: a caller looking
+    /// at <see cref="FullMets.PathDiagnostics"/> can tell a collision from the other six shapes only
+    /// by this text. Sharing the constant is the point - a matcher written against a copy of the
+    /// wording silently stops matching the first time the wording changes, which is precisely how
+    /// the corpus survey's collision bucket came to be dead code.
+    /// </remarks>
+    public const string DuplicatePathFragment = "both resolve to path";
+
+    /// <summary>
     /// Rebuild the path cache from the current state of the METS. Returns diagnostics for any
     /// div whose path could not be resolved, or that collided with another div's path; an empty
     /// list means the whole physical structMap is navigable by path. The diagnostics are also
     /// stored on <see cref="FullMets.PathDiagnostics"/> so later failures can explain themselves.
     /// </summary>
-    internal const string DuplicatePathFragment = "both resolve to path";
-
     public static List<string> Populate(FullMets fullMets)
     {
         fullMets.PhysicalDivsByPath.Clear();

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
@@ -2,6 +2,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using DigitalPreservation.Mets;
+using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace XmlGen.Tests.Experimental.Parsing;
@@ -43,6 +44,11 @@ public class SurveyMetsCorpus(ITestOutputHelper output)
             }
         }
 
+        // The one thing a survey can assert: if a corpus was pointed at, it was read. An empty
+        // result otherwise looks exactly like a corpus in which nothing was worth reporting,
+        // when in fact it usually means the path is wrong or holds no METS.
+        verdicts.Should().NotBeEmpty($"{PathVariable} ('{root}') should hold METS files to survey");
+
         output.WriteLine("");
         output.WriteLine($"=== {verdicts.Count} document(s) ===");
         foreach (var group in verdicts.GroupBy(v => v).OrderByDescending(g => g.Count()))
@@ -56,7 +62,7 @@ public class SurveyMetsCorpus(ITestOutputHelper output)
     /// <c>mets-objects</c> element, and a document we cannot deserialise is reported rather than
     /// thrown - a survey that stops at the first unreadable file surveys nothing.
     /// </summary>
-    private IEnumerable<(DigitalPreservation.XmlGen.Mets.Mets? Mets, string Label)> ReadMetsDocuments(string file)
+    private static IEnumerable<(DigitalPreservation.XmlGen.Mets.Mets? Mets, string Label)> ReadMetsDocuments(string file)
     {
         var name = Path.GetFileName(file);
         XDocument? document = null;

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
@@ -187,7 +187,9 @@ public class SurveyMetsCorpus(ITestOutputHelper output)
         if (diagnostic.Contains("has no ADMID")) return "directory div has no ADMID";
         if (diagnostic.Contains("has no fptr")) return "item div has no fptr";
         if (diagnostic.Contains("no FLocat href")) return "item div's FILEID resolves to no FLocat href";
-        if (diagnostic.Contains("already", StringComparison.OrdinalIgnoreCase)) return "two divs claim one path";
+        // Matched via the constant, not a copy of the wording: this bucket was dead for exactly that
+        // reason, looking for an "already" that the diagnostic has never said.
+        if (diagnostic.Contains(MetsCache.DuplicatePathFragment)) return "two divs claim one path";
         return diagnostic;
     }
 

--- a/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
+++ b/src/DigitalPreservation/XmlGen.Tests/Experimental/Parsing/SurveyMetsCorpus.cs
@@ -1,0 +1,193 @@
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using DigitalPreservation.Mets;
+using Xunit.Abstractions;
+
+namespace XmlGen.Tests.Experimental.Parsing;
+
+/// <summary>
+/// A read-only survey of real METS files: what does the platform's path cache make of each one,
+/// and where it makes nothing, why?
+/// </summary>
+/// <remarks>
+/// Two questions this exists to answer, both of which need real documents rather than fixtures.
+/// How much of an existing corpus would pass the navigability half of a conformance check
+/// (issue #223) - and of the documents that fail, how many fail only because they do not follow
+/// conventions that METS itself makes optional?
+/// <para>
+/// It reads and reports; it writes nothing and mutates nothing on disk. Point it at a directory
+/// with <c>METS_SURVEY_PATH</c>. Manual because it needs a corpus that is not in the repository.
+/// </para>
+/// </remarks>
+public class SurveyMetsCorpus(ITestOutputHelper output)
+{
+    private const string PathVariable = "METS_SURVEY_PATH";
+
+    [Fact, Trait("Category", "Manual")]
+    public void Survey()
+    {
+        var root = Environment.GetEnvironmentVariable(PathVariable);
+        if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+        {
+            output.WriteLine($"Set {PathVariable} to a directory of METS files. Nothing surveyed.");
+            return;
+        }
+
+        var verdicts = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*.xml", SearchOption.AllDirectories).Order())
+        {
+            foreach (var (mets, label) in ReadMetsDocuments(file))
+            {
+                verdicts.Add(Report(mets, label));
+            }
+        }
+
+        output.WriteLine("");
+        output.WriteLine($"=== {verdicts.Count} document(s) ===");
+        foreach (var group in verdicts.GroupBy(v => v).OrderByDescending(g => g.Count()))
+        {
+            output.WriteLine($"  {group.Count(),6}  {group.Key}");
+        }
+    }
+
+    /// <summary>
+    /// The METS documents in a file. Usually one, but an EPrints export wraps several in a
+    /// <c>mets-objects</c> element, and a document we cannot deserialise is reported rather than
+    /// thrown - a survey that stops at the first unreadable file surveys nothing.
+    /// </summary>
+    private IEnumerable<(DigitalPreservation.XmlGen.Mets.Mets? Mets, string Label)> ReadMetsDocuments(string file)
+    {
+        var name = Path.GetFileName(file);
+        XDocument? document = null;
+        string? loadError = null;
+        try
+        {
+            document = XDocument.Load(file);
+        }
+        catch (Exception e)
+        {
+            loadError = e.Message;
+        }
+
+        if (document == null)
+        {
+            yield return (null, $"{name}: not well-formed XML ({loadError})");
+            yield break;
+        }
+
+        var metsElements = document.Descendants(XName.Get("mets", "http://www.loc.gov/METS/")).ToList();
+        if (metsElements.Count == 0)
+        {
+            yield return (null, $"{name}: contains no mets:mets element");
+            yield break;
+        }
+
+        var serializer = new XmlSerializer(typeof(DigitalPreservation.XmlGen.Mets.Mets));
+        for (var i = 0; i < metsElements.Count; i++)
+        {
+            var label = metsElements.Count == 1 ? name : $"{name}[{i}]";
+            DigitalPreservation.XmlGen.Mets.Mets? mets = null;
+            string? deserialiseError = null;
+            try
+            {
+                using var reader = metsElements[i].CreateReader();
+                mets = (DigitalPreservation.XmlGen.Mets.Mets?)serializer.Deserialize(reader);
+            }
+            catch (Exception e)
+            {
+                deserialiseError = e.Message;
+            }
+
+            yield return mets == null
+                ? (null, $"{label}: does not deserialise ({deserialiseError})")
+                : (mets, label);
+        }
+    }
+
+    private string Report(DigitalPreservation.XmlGen.Mets.Mets? mets, string label)
+    {
+        if (mets == null)
+        {
+            output.WriteLine(label);
+            return "unreadable";
+        }
+
+        var asIs = Populate(mets);
+
+        output.WriteLine($"{label}");
+        output.WriteLine($"    agent      : {mets.MetsHdr?.Agent?.FirstOrDefault()?.Name ?? "(none)"}");
+        output.WriteLine($"    structMaps : {Describe(mets.StructMap.Select(sm => sm.Type))}");
+        output.WriteLine($"    fileGrps   : {Describe(mets.FileSec?.FileGrp.Select(g => g.Use) ?? [])}");
+        output.WriteLine($"    cached     : {asIs.Entries}, diagnostics: {asIs.Diagnostics.Count}");
+        foreach (var bucket in Bucket(asIs.Diagnostics)) output.WriteLine($"        {bucket}");
+
+        if (asIs.Diagnostics.Count == 0)
+        {
+            return "conforms: navigable as it stands";
+        }
+
+        // The what-if: a structMap the cache does not accept as physical stops it before it looks
+        // at a single div, so a document can fail for that alone and hide whatever else is wrong.
+        // Two shapes reach here - no TYPE at all (EPrints), and a TYPE that differs only in case
+        // (Archivematica writes "physical"). Typing it in memory shows what is really underneath;
+        // nothing is written back.
+        var soleStructMap = mets.StructMap.Count == 1 ? mets.StructMap[0] : null;
+        var acceptableIfTyped = soleStructMap != null
+                                && (string.IsNullOrEmpty(soleStructMap.Type)
+                                    || soleStructMap.Type.Equals(Constants.Physical, StringComparison.OrdinalIgnoreCase));
+        if (acceptableIfTyped)
+        {
+            mets.StructMap[0].Type = Constants.Physical;
+            var typed = Populate(mets);
+            output.WriteLine($"    if typed   : {typed.Entries}, diagnostics: {typed.Diagnostics.Count}");
+            foreach (var bucket in Bucket(typed.Diagnostics)) output.WriteLine($"        {bucket}");
+
+            if (typed.Diagnostics.Count == 0) return "blocked only by the structMap TYPE";
+            if (typed.Diagnostics.All(IsUntypedDiv)) return "blocked only by structMap and div typing";
+            return "blocked by more than typing";
+        }
+
+        return asIs.Diagnostics.All(IsUntypedDiv)
+            ? "blocked only by div typing"
+            : "blocked by more than typing";
+    }
+
+    private static (int Entries, List<string> Diagnostics) Populate(DigitalPreservation.XmlGen.Mets.Mets mets)
+    {
+        var fullMets = new FullMets { Mets = mets, Uri = new Uri("file:///survey/mets.xml") };
+        var diagnostics = MetsCache.Populate(fullMets);
+        return (fullMets.PhysicalDivsByPath.Count, diagnostics);
+    }
+
+    /// <summary>A div carrying no TYPE - legal METS, but not a shape the cache recognises.</summary>
+    private static bool IsUntypedDiv(string diagnostic) => diagnostic.Contains("unrecognised TYPE");
+
+    /// <summary>
+    /// Diagnostics are one per div, so a large document produces hundreds that say the same
+    /// thing. Report the shapes and their counts instead of the list.
+    /// </summary>
+    private static IEnumerable<string> Bucket(IEnumerable<string> diagnostics) =>
+        diagnostics
+            .GroupBy(Shape)
+            .OrderByDescending(g => g.Count())
+            .Select(g => $"{g.Count(),6}  {g.Key}");
+
+    private static string Shape(string diagnostic)
+    {
+        if (diagnostic.Contains("no PHYSICAL structMap")) return "no PHYSICAL structMap";
+        if (IsUntypedDiv(diagnostic)) return "div has no recognised TYPE";
+        if (diagnostic.Contains("no premis:originalName")) return "directory div has no premis:originalName";
+        if (diagnostic.Contains("has no ADMID")) return "directory div has no ADMID";
+        if (diagnostic.Contains("has no fptr")) return "item div has no fptr";
+        if (diagnostic.Contains("no FLocat href")) return "item div's FILEID resolves to no FLocat href";
+        if (diagnostic.Contains("already", StringComparison.OrdinalIgnoreCase)) return "two divs claim one path";
+        return diagnostic;
+    }
+
+    private static string Describe(IEnumerable<string?> values) =>
+        string.Join(", ", values
+            .Select(value => string.IsNullOrEmpty(value) ? "(untyped)" : value)
+            .GroupBy(value => value)
+            .Select(group => group.Count() == 1 ? group.Key : $"{group.Key}×{group.Count()}"));
+}


### PR DESCRIPTION
A `Manual`-category harness that runs the platform's own path cache over a directory of real METS files and reports what it made of each one — and where it made nothing, which shape of diagnostic stopped it. Point it at a corpus with `METS_SURVEY_PATH`; it reads and reports, writes nothing.

Groundwork for #223, and the tool that can answer "how many of the Archival Groups at Leeds would conform?" without anyone guessing.

## Why a what-if

A structMap the cache will not accept as physical stops it before it examines a single div, so one rejection hides everything behind it. Where a document has a single structMap that is untyped, or typed in a different case, the harness types it *in memory* and runs again. Nothing is written back.

## What it says about the METS we already have

| Document | As it stands | With the structMap typed |
|---|---|---|
| our own fixture | **6 cached, 0 diagnostics** | — |
| EPrints (sample, 4 files) | 0 cached, `no PHYSICAL structMap` | 0 cached, 4 × `div has no recognised TYPE` |
| **EPrints (real, 410 files)** | 0 cached, `no PHYSICAL structMap` | 0 cached, **410 × `div has no recognised TYPE`** |
| Archivematica | 0 cached, `no PHYSICAL structMap` | **38 cached**, 11 × `directory div has no ADMID` |
| Goobi 2026 | 0 cached, 29 × `div has no recognised TYPE` | — |

Three things worth pulling out:

**EPrints is two conventions away from fully navigable.** Both documents are flat — a root div and one div per file, no directory divs — and every `FLocat/@xlink:href` is already deposit-relative (`objects/650510_001.tif`). They carry no `premis:originalName`, but with no directory divs nothing needs it. What blocks them is that METS makes `TYPE` optional on both the structMap and the div, and EPrints omits both. Tolerating an untyped div that has an `fptr` takes the real 410-file document from 0 entries to **410 entries and 0 diagnostics** — I measured that with a temporary patch, which is not in this PR.

**Archivematica is blocked by letter case.** It writes `TYPE="physical"`; we compare against `"PHYSICAL"` ordinally. Behind that one comparison, 38 of its paths already resolve.

**Goobi 2026 would be a false positive.** Its divs are `TYPE="page"`, so div-tolerance would admit it — but its `FLocat` hrefs are absolute IIIF URLs, so the "paths" cached would be `https://…`. Navigability needs *deposit-relative* paths, and the cache does not currently check that. Worth knowing before tolerance is loosened.

## What this does not claim

Navigability is not editability. `SetFileAndFileGroup` requires a single `OBJECTS` fileGrp and these documents have `reference`, `original`, `DEFAULT`; there is no div for `objects` itself, so operations needing a parent div have nothing to attach to; and writing into a document that uses none of our conventions needs a policy, not just a parser change. The `mets:agent` gate sits on top of all of it, and that is the part #223 replaces.

Also: five documents is not a survey. That is what the tool is for.

Full suite green, CI-equivalent filter (`Category!=Manual`) unaffected: XmlGen 478, Preservation.API 106, Storage.API 55, Core 68, Common.Model 8.