### PR TITLE
docs: correct the EPrints fileGrp assumption in the 223 plan

### DIFF
--- a/docs/issues/223/issue-223-editability-plan.md
+++ b/docs/issues/223/issue-223-editability-plan.md
@@ -83,10 +83,14 @@ editable. Each is a reading rule; none changes a byte on disk until a save:
    file, no directory divs — and every `FLocat/@xlink:href` is already deposit-relative under
    `objects/`. The root container div for `objects` is synthesised on read from the common path
    prefix. Reading never writes it back.
-5. **The file group is mapped.** These documents carry `reference`/`original`/`DEFAULT` fileGrps
-   rather than our single `OBJECTS`. The fileGrp whose files the physical structMap references is
-   treated as the OBJECTS-equivalent; ambiguity (structMap referencing files across multiple
-   fileGrps) fails the editable tier and is reported by the judge.
+5. **The file groups are mapped.** These documents carry fileGrps with USE values like
+   `reference`/`original`/`DEFAULT` rather than our single `OBJECTS` — and EPrints writes **one
+   fileGrp per file**, all `USE="reference"` (verified against the real `eprint_10315` sample), so
+   referencing several groups is the *normal* shape, not an ambiguity. All the groups the physical
+   structMap references are treated together as the OBJECTS-equivalent, consolidated into one
+   `USE="OBJECTS"` group on save. What fails the tier is genuine ambiguity: referenced files in
+   groups with *different* USE values, or two referenced entries resolving to the same
+   deposit-relative path.
 6. **Every resolved path is deposit-relative** (the standing guard).
 
 Because these documents have no directory divs, nothing in them needs `premis:originalName` on


### PR DESCRIPTION
One-paragraph correction found while writing the phase 2 worked example against the real `eprint_10315` sample: EPrints writes **one fileGrp per file** (all `USE="reference"`), so the plan's assumption 5 — which failed the editable tier when the structMap references several fileGrps — described the *normal* EPrints shape as an ambiguity. The tier now consolidates all referenced groups into the single OBJECTS group on save, and fails only on genuine ambiguity (mixed USE values, or two entries resolving to the same path). The docs repo's 02e page carries the same correction (commit 2777c5a on `mets-profiles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg