### PR TITLE
fix(mets-id-migration): a failed read before the deposit exists is not a verdict

### DIFF
--- a/src/mets-id-migration/app/migrate.py
+++ b/src/mets-id-migration/app/migrate.py
@@ -29,12 +29,22 @@ class MigrationRefused(RuntimeError):
     """The migration stopped on purpose, before changing anything preserved."""
 
 
+class ReadFailed(MigrationRefused):
+    """
+    The Archival Group's METS could not be read before anything was created. The same rule as
+    the survey's and verify's: a failed read is not a verdict. Recording it as FAILED would drop a
+    perfectly migratable group from the campaign because the VPN was off.
+    """
+
+
 def migrate_all(ledger: Ledger, candidates, dry_run: bool) -> None:
     for index, row in enumerate(candidates, start=1):
         path = row["path"]
         logger.info("[%s/%s] %s", index, len(candidates), path)
         try:
             migrate_one(ledger, path, dry_run)
+        except ReadFailed as error:
+            logger.warning("%s: leaving it %s for a rerun - %s", path, row["state"], error)
         except (MigrationRefused, api.ApiError, TimeoutError) as error:
             logger.error("%s: %s", path, error)
             ledger.record(path, FAILED, note=str(error))
@@ -182,9 +192,14 @@ def _is_mets_file(slug: str) -> bool:
 def _fingerprint(path: str) -> dict[str, str]:
     """Path to digest for every file the Archival Group's METS lists."""
     try:
-        return ids.file_digests(ids.parse(api.get_archival_group_mets(path)))
-    except (api.ApiError, etree.XMLSyntaxError) as error:
-        raise MigrationRefused(f"Could not read the Archival Group's METS: {error}") from error
+        mets_xml = api.get_archival_group_mets(path)
+    except api.ApiError as error:
+        raise ReadFailed(f"Could not read the Archival Group's METS: {error}") from error
+    try:
+        return ids.file_digests(ids.parse(mets_xml))
+    except etree.XMLSyntaxError as error:
+        # Unlike a failed read, a preserved METS that does not parse IS a verdict.
+        raise MigrationRefused(f"The Archival Group's METS is not well-formed XML: {error}") from error
 
 
 def _verify(before: dict[str, str], after: dict[str, str]) -> None:

--- a/src/mets-id-migration/app/migrate.py
+++ b/src/mets-id-migration/app/migrate.py
@@ -29,11 +29,15 @@ class MigrationRefused(RuntimeError):
     """The migration stopped on purpose, before changing anything preserved."""
 
 
-class ReadFailed(MigrationRefused):
+class ReadFailed(RuntimeError):
     """
     The Archival Group's METS could not be read before anything was created. The same rule as
     the survey's and verify's: a failed read is not a verdict. Recording it as FAILED would drop a
     perfectly migratable group from the campaign because the VPN was off.
+
+    Only the read at the very front of migrate_one qualifies: once the import job has run, the
+    Archival Group has changed and a failed re-read must be recorded, not exempted - so this is
+    deliberately NOT a MigrationRefused, and only that first call site raises it.
     """
 
 
@@ -53,7 +57,11 @@ def migrate_all(ledger: Ledger, candidates, dry_run: bool) -> None:
 
 
 def migrate_one(ledger: Ledger, path: str, dry_run: bool) -> None:
-    before = _fingerprint(path)
+    try:
+        before = _fingerprint(path)
+    except api.ApiError as error:
+        # Nothing has been created yet, so a failed read here is not a verdict on the group.
+        raise ReadFailed(f"Could not read the Archival Group's METS: {error}") from error
 
     deposit = api.create_deposit(path)
     deposit_id = api.slug(deposit["id"])
@@ -190,11 +198,12 @@ def _is_mets_file(slug: str) -> bool:
 
 
 def _fingerprint(path: str) -> dict[str, str]:
-    """Path to digest for every file the Archival Group's METS lists."""
-    try:
-        mets_xml = api.get_archival_group_mets(path)
-    except api.ApiError as error:
-        raise ReadFailed(f"Could not read the Archival Group's METS: {error}") from error
+    """
+    Path to digest for every file the Archival Group's METS lists. A failed read raises
+    api.ApiError untouched: only the caller knows whether anything has been changed yet, so only
+    the caller can say whether that failure is exempt (ReadFailed) or evidence (FAILED).
+    """
+    mets_xml = api.get_archival_group_mets(path)
     try:
         return ids.file_digests(ids.parse(mets_xml))
     except etree.XMLSyntaxError as error:

--- a/src/mets-id-migration/tests.py
+++ b/src/mets-id-migration/tests.py
@@ -521,6 +521,19 @@ class MigrateSafetyTests(SurveyLedgerTestCase):
         self.assertEqual(DONE, row["state"])
         self.assertEqual("v2", row["to_version"], "the migration evidence survives the blip")
 
+    def test_migrate_leaves_a_candidate_alone_when_the_first_read_fails(self):
+        # Same rule again, at the front of migrate: a connect timeout before any deposit exists
+        # says nothing about the group. Recording FAILED would drop it from the campaign.
+        from app import migrate
+        from app.ledger import CANDIDATE
+        self.ledger.record("cc/unreachable", CANDIDATE)
+        with mock.patch.object(api, "get_archival_group_mets",
+                               side_effect=api.ApiError("Could not read METS", "ConnectTimeout")), \
+             mock.patch.object(api, "create_deposit") as created:
+            migrate.migrate_all(self.ledger, self.ledger.in_state(CANDIDATE), dry_run=True)
+        created.assert_not_called()
+        self.assertEqual(CANDIDATE, self.ledger.get("cc/unreachable")["state"])
+
 
 @mock.patch.object(settings, "DISABLE_AUTH", True)
 class IfMatchTests(unittest.TestCase):

--- a/src/mets-id-migration/tests.py
+++ b/src/mets-id-migration/tests.py
@@ -534,6 +534,29 @@ class MigrateSafetyTests(SurveyLedgerTestCase):
         created.assert_not_called()
         self.assertEqual(CANDIDATE, self.ledger.get("cc/unreachable")["state"])
 
+    def test_a_failed_read_after_the_import_is_recorded_not_exempted(self):
+        # The exemption above must not extend past the import. Once the job has completed the
+        # Archival Group HAS changed; a row silently left as candidate would erase this run's
+        # evidence and send a rerun at an already-migrated group.
+        from app import migrate
+        from app.ledger import CANDIDATE, FAILED
+        reads = [b"<mets xmlns='http://www.loc.gov/METS/'/>",  # the before read
+                 api.ApiError("Could not read METS", "ReadTimeout")]  # the verification re-read
+        with mock.patch.object(api, "create_deposit", return_value=self.deposit), \
+             mock.patch.object(api, "get_archival_group_mets", side_effect=reads), \
+             mock.patch.object(api, "normalise_mets_ids",
+                               return_value={"changed": True, "idsRewritten": 1,
+                                             "referencesRewritten": 0}), \
+             mock.patch.object(api, "get_diff_import_job", return_value={
+                 "binariesToPatch": [{"id": "https://x/mets.xml"}]}), \
+             mock.patch.object(api, "execute_import_job", return_value={"id": "https://x/r/1"}), \
+             mock.patch.object(api, "await_import_job", return_value={"status": "completed"}), \
+             mock.patch.object(api, "delete_deposit") as deleted:
+            migrate.migrate_all(self.ledger, self.ledger.in_state(CANDIDATE), dry_run=False)
+        row = self.ledger.get("cc/thing")
+        self.assertEqual(FAILED, row["state"], "the group was changed; the blip must be recorded")
+        deleted.assert_not_called()
+
 
 @mock.patch.object(settings, "DISABLE_AUTH", True)
 class IfMatchTests(unittest.TestCase):


### PR DESCRIPTION
Found on the first dev dry run of the #188 step 3 migrator (started, as it turned out, without the VPN).

Every `GET /repository/{path}?view=mets` hit a 60 s connect timeout, and `migrate_all` recorded each Archival Group as `failed` — which removes it from the campaign, silently, for a reason that says nothing about the document. `survey` and `verify` already follow the rule that a failed read is not a verdict; `migrate` now applies it to the fingerprint read that precedes deposit creation: `ReadFailed` is logged as a warning and the row is left in whatever state it had. A METS that does not parse is still a verdict, as in `verify`.

The three rows this bit on `ledger-dev.sqlite` were reset by hand to `candidate`.

Python only: no image build. 52/52 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg
