### PR TITLE
fix: label the file-link role and target selects for assistive tech

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Deposits/Deposit.cshtml
@@ -854,8 +854,8 @@
                         @if (Model.CanBeWorkedOn() && Model.WorkspaceManager.Editable)
                         {
                             <div class="input-group mt-2" id="fileLinkAddRow">
-                                <select id="fileLinkRoleSelect" class="form-select" style="max-width:12rem"></select>
-                                <select id="fileLinkTargetSelect" class="form-select"></select>
+                                <select id="fileLinkRoleSelect" class="form-select" style="max-width:12rem" aria-label="File link role"></select>
+                                <select id="fileLinkTargetSelect" class="form-select" aria-label="File link target"></select>
                                 <button type="button" id="fileLinkAddBtn" class="btn btn-outline-primary">Add</button>
                             </div>
                         }


### PR DESCRIPTION
## What

Adds an `aria-label` to each of the two `<select>`s in the Deposit page's file-link add row (`fileLinkRoleSelect`, `fileLinkTargetSelect`). They had no accessible name: their options are filled by `deposit.js`, and the section only carries the visual "File Links" heading, so a screen reader announced two anonymous comboboxes.

## Why now

These are the two Reliability issues (Sonar S6853, WCAG 2 Level A) that hold the main branch's quality-gate Reliability rating on new code at C. With them fixed the rating returns to A. Part of the gate-repair sweep alongside the SonarCloud-side changes (accepted canonical-IIIF-URI and CORS findings, 90-day new-code window, duplicated-files condition removed in favour of the existing duplicated-lines-density check).

`aria-label` (rather than a visible `<label>`/`aria-labelledby`) follows the page's existing convention for script-populated controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg
