### PR TITLE
refactor: name the parts of canvas building and the image service router

### DIFF
--- a/src/DigitalPreservation/Preservation.API/Features/MediaServer/MediaController.cs
+++ b/src/DigitalPreservation/Preservation.API/Features/MediaServer/MediaController.cs
@@ -77,47 +77,7 @@ public class MediaController(
         var origin = FolderNames.GetFilesLocation(deposit.Files!, isBagIt);
 
         if (type == "imagesvc")
-        {
-            var elements = localPath.Split('/');
-
-            if (elements[^1] == "info.json")
-            {
-                var realLocalPath = localPath[..^"/info.json".Length];
-                var mediaItem = workingDirectory.FindFile(FolderNames.GetPathPrefix(isBagIt) + realLocalPath);
-                var imageBaseUrl = Request.GetDisplayUrl();
-                imageBaseUrl = imageBaseUrl[..imageBaseUrl.LastIndexOf("/info.json", StringComparison.Ordinal)];
-                Response.Headers.CacheControl = "private, max-age=600";
-                return InfoJson(imageBaseUrl, mediaItem);
-            }
-
-            // /full/{w,h}/0/default.jpg — requires at least 4 segments after the file path
-            if (elements.Length >= 4 && elements[^1] == "default.jpg" && elements[^2] == "0" && elements[^4] == "full")
-            {
-                var size = elements[^3];
-                var imageApi = $"/full/{size}/0/default.jpg";
-                var realLocalPath = localPath[..^imageApi.Length];
-                Response.Headers.CacheControl = "private, max-age=3600";
-                Response.Headers.ETag = ImageETag(realLocalPath, size);
-                return await ImageFromImageService(workspaceManager, origin, realLocalPath, size);
-            }
-
-            // Bare imagesvc URL — redirect to info.json if the file exists
-            if (elements.Length >= 4)
-            {
-                var testRealLocalPath = string.Join('/', elements[..^4]);
-                var testMediaItem = workingDirectory.FindFile(FolderNames.GetPathPrefix(isBagIt) + testRealLocalPath);
-                if (testMediaItem != null)
-                {
-                    // Relative redirect: avoids echoing the client-supplied Host header
-                    // and any query string back into the Location header (Sonar S5146).
-                    var infoJsonUrl = Request.PathBase.Add(Request.Path).Add("/info.json").Value!;
-                    if (Url.IsLocalUrl(infoJsonUrl))
-                        return Redirect(infoJsonUrl);
-                }
-            }
-
-            return NotFound();
-        }
+            return await ImageServiceRequest(workspaceManager, workingDirectory, origin, isBagIt, localPath);
 
         var item = workingDirectory.FindFile(FolderNames.GetPathPrefix(isBagIt) + localPath);
         if (item == null)
@@ -126,6 +86,57 @@ public class MediaController(
         Response.Headers.CacheControl = "private, max-age=3600";
         Response.Headers.ETag = FileETag(localPath, item.Size);
         return await ProxyFileWithByteRangeSupport(workspaceManager, origin, localPath, item, HttpContext);
+    }
+
+    // The three request shapes of the level-0 image service, most specific first:
+    // .../imagesvc/{path}/info.json, .../imagesvc/{path}/full/{w,h}/0/default.jpg, and the bare
+    // .../imagesvc/{path}, which redirects to its info.json when the file exists.
+    private async Task<IActionResult> ImageServiceRequest(
+        WorkspaceManager workspaceManager,
+        WorkingDirectory workingDirectory,
+        Uri origin,
+        bool isBagIt,
+        string localPath)
+    {
+        var elements = localPath.Split('/');
+
+        if (elements[^1] == "info.json")
+        {
+            var realLocalPath = localPath[..^"/info.json".Length];
+            var mediaItem = workingDirectory.FindFile(FolderNames.GetPathPrefix(isBagIt) + realLocalPath);
+            var imageBaseUrl = Request.GetDisplayUrl();
+            imageBaseUrl = imageBaseUrl[..imageBaseUrl.LastIndexOf("/info.json", StringComparison.Ordinal)];
+            Response.Headers.CacheControl = "private, max-age=600";
+            return InfoJson(imageBaseUrl, mediaItem);
+        }
+
+        // /full/{w,h}/0/default.jpg — requires at least 4 segments after the file path
+        if (elements.Length >= 4 && elements[^1] == "default.jpg" && elements[^2] == "0" && elements[^4] == "full")
+        {
+            var size = elements[^3];
+            var imageApi = $"/full/{size}/0/default.jpg";
+            var realLocalPath = localPath[..^imageApi.Length];
+            Response.Headers.CacheControl = "private, max-age=3600";
+            Response.Headers.ETag = ImageETag(realLocalPath, size);
+            return await ImageFromImageService(workspaceManager, origin, realLocalPath, size);
+        }
+
+        // Bare imagesvc URL — redirect to info.json if the file exists
+        if (elements.Length >= 4)
+        {
+            var testRealLocalPath = string.Join('/', elements[..^4]);
+            var testMediaItem = workingDirectory.FindFile(FolderNames.GetPathPrefix(isBagIt) + testRealLocalPath);
+            if (testMediaItem != null)
+            {
+                // Relative redirect: avoids echoing the client-supplied Host header
+                // and any query string back into the Location header (Sonar S5146).
+                var infoJsonUrl = Request.PathBase.Add(Request.Path).Add("/info.json").Value!;
+                if (Url.IsLocalUrl(infoJsonUrl))
+                    return Redirect(infoJsonUrl);
+            }
+        }
+
+        return NotFound();
     }
 
     // ValidateLocalPath guards against path traversal in the S3 key.

--- a/src/DigitalPreservation/Preservation.API/IIIF/ManifestBuilder.cs
+++ b/src/DigitalPreservation/Preservation.API/IIIF/ManifestBuilder.cs
@@ -23,23 +23,8 @@ public class ManifestBuilder
         string? mediaServerBaseUrl,
         Func<WorkingFile, string>? originUriResolver = null)
     {
-        const string none = "none";
         var canvasMap = new Dictionary<string, Canvas>();
-
-        // Establish which files are targets of links before building canvases
-        var linkTargets = new Dictionary<string, List<WorkingFile>>();
-        foreach (var file in wrapper.Files)
-        {
-            foreach (var to in file.Links.Select(fileLink => fileLink.To))
-            {
-                if (!linkTargets.TryGetValue(to, out var from))
-                {
-                    from = [];
-                    linkTargets[to] = from;
-                }
-                from.Add(file);
-            }
-        }
+        var linkTargets = GetLinkTargetPaths(wrapper);
 
         manifest.Items = [];
         foreach (var file in wrapper.Files)
@@ -49,173 +34,13 @@ public class ManifestBuilder
             if (file.ContentType.IsNullOrWhiteSpace())
                 continue;
 
-            if (linkTargets.TryGetValue(file.LocalPath, out _))
+            if (linkTargets.Contains(file.LocalPath))
             {
                 // Adjunct file (e.g. transcript target) — skipped as a canvas; served via file/ URL.
                 continue;
             }
 
-            var escapedLocal = file.LocalPath.EscapePathElements();
-            var canvas = new Canvas
-            {
-                Id = $"{plainBaseUrl}canvases/{escapedLocal}",
-                Label = new LanguageMap(none, file.LocalPath)
-            };
-            var extents = file.Metadata.OfType<ExtentMetadata>().SingleOrDefault();
-            if (extents != null)
-            {
-                canvas.Width = extents.PixelWidth;
-                canvas.Height = extents.PixelHeight;
-                canvas.Duration = extents.Duration;
-            }
-            var paintingAnno = new PaintingAnnotation
-            {
-                Id = $"{canvas.Id}/painting/annotation",
-                Target = new Canvas { Id = canvas.Id }
-            };
-            canvas.Items =
-            [
-                new AnnotationPage
-                {
-                    Id = $"{canvas.Id}/painting",
-                    Items = [paintingAnno]
-                }
-            ];
-
-            // Image in Deposit: IIIF image service for mediaServer, scaled JPEG + thumbnail
-            if (file.ContentType.StartsWith("image/") && canvas is { Width: > 0, Height: > 0 } && originUriResolver == null)
-            {
-                var size = new Size(canvas.Width.Value, canvas.Height.Value);
-                var mainSize = Size.Confine(1200, size);
-                var thumbSize = Size.Confine(100, size);
-                paintingAnno.Body = new Image
-                {
-                    Id = $"{mediaServerBaseUrl}imagesvc/{escapedLocal}/full/{mainSize.Width},{mainSize.Height}/0/default.jpg",
-                    Width = mainSize.Width,
-                    Height = mainSize.Height,
-                    Format = "image/jpeg"
-                };
-                canvas.Thumbnail =
-                [
-                    new Image
-                    {
-                        Id = $"{mediaServerBaseUrl}imagesvc/{escapedLocal}/full/{thumbSize.Width},{thumbSize.Height}/0/default.jpg",
-                        Width = thumbSize.Width,
-                        Height = thumbSize.Height,
-                        Format = "image/jpeg"
-                    }
-                ];
-            }
-            else if (file.ContentType.StartsWith("image/") && originUriResolver != null)
-            {
-                paintingAnno.Body = new Image
-                {
-                    Id = originUriResolver(file),
-                    Width = canvas.Width,
-                    Height = canvas.Height,
-                    Format = file.ContentType
-                };
-            }
-            // Video/audio: body type, structure, and rendering are the same in both modes — only the ID differs.
-            else if (file.ContentType.StartsWith("video/") && canvas is { Width: > 0, Height: > 0, Duration: > 0 })
-            {
-                var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}video/{escapedLocal}";
-                paintingAnno.Body = new Video
-                {
-                    Id = id,
-                    Width = canvas.Width,
-                    Height = canvas.Height,
-                    Duration = canvas.Duration,
-                    Format = file.ContentType
-                };
-            }
-            else if (file.ContentType.StartsWith("audio/") && canvas is { Duration: > 0 })
-            {
-                var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}audio/{escapedLocal}";
-                paintingAnno.Body = new Sound
-                {
-                    Id = id,
-                    Duration = canvas.Duration,
-                    Format = file.ContentType
-                };
-            }
-            // Placeholder: ExternalResource has no extents, there is no painting body. —
-            // the canvas carries only a rendering link pointing to the binary.
-            else
-            {
-                canvas.Behavior = ["placeholder"];
-                var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}file/{escapedLocal}";
-                paintingAnno.Body = new Image
-                {
-                    Id = $"{mediaServerBaseUrl}placeholder/canvas.png",
-                    Width = 1000,
-                    Height = 800,
-                    Format = "image/png"
-                };
-                canvas.Thumbnail =
-                [
-                    new Image
-                    {
-                        Id = $"{mediaServerBaseUrl}placeholder/thumb.png",
-                        Width = 100,
-                        Height = 80,
-                        Format = "image/png"
-                    }
-                ];
-                canvas.Rendering =
-                [
-                    new ExternalResource("Text")
-                    {
-                        Id = id,
-                        Format = file.ContentType,
-                        Behavior = ["original"],
-                        Label = canvas.Label
-                    }
-                ];
-            }
-
-
-            // Collect all links into a single AnnotationPage
-            var linkItems = new List<IAnnotation>();
-            foreach (var fileLink in file.Links)
-            {
-                var target = wrapper.Files.SingleOrDefault(f => f.LocalPath == fileLink.To);
-                if (target == null) continue;
-                var bodyId = originUriResolver != null
-                    ? originUriResolver(target)
-                    : $"{mediaServerBaseUrl}file/{target.LocalPath.EscapePathElements()}";
-                var provides = FileLinkRoles.ToIiifProvides(fileLink.Role);
-                var annotation = new GeneralAnnotation("supplementing") // may need
-                {
-                    Body =
-                    [
-                        new ExternalResource(GetDcType(target.ContentType))
-                        {
-                            Id = bodyId,
-                            Label = new LanguageMap("none", $"{bodyId.GetSlug()} ({provides ?? fileLink.Role?.ToString()} for {file.Name})"),
-                            Format = target.ContentType
-                        }
-                    ],
-                    Target = new Canvas { Id = canvas.Id }
-                };
-                if (provides.HasText())
-                {
-                    annotation.AdditionalProperties["provides"] = new JArray(provides);
-                }
-                linkItems.Add(annotation);
-            }
-            if (linkItems.Count > 0)
-            {
-                canvas.Annotations =
-                [
-                    new AnnotationPage
-                    {
-                        Id = $"{canvas.Id}/annotations",
-                        Items = linkItems
-                    }
-                ];
-            }
-
+            var canvas = MakeCanvas(file, wrapper, plainBaseUrl, mediaServerBaseUrl, originUriResolver);
             manifest.Items.Add(canvas);
             canvasMap[file.LocalPath] = canvas;
         }
@@ -230,6 +55,202 @@ public class ManifestBuilder
         }
 
         manifest.EnsurePresentation3Context();
+    }
+
+    private static HashSet<string> GetLinkTargetPaths(MetsFileWrapper wrapper) =>
+        wrapper.Files.SelectMany(f => f.Links.Select(link => link.To)).ToHashSet();
+
+    private static Canvas MakeCanvas(
+        WorkingFile file,
+        MetsFileWrapper wrapper,
+        string plainBaseUrl,
+        string? mediaServerBaseUrl,
+        Func<WorkingFile, string>? originUriResolver)
+    {
+        var escapedLocal = file.LocalPath.EscapePathElements();
+        var canvas = new Canvas
+        {
+            Id = $"{plainBaseUrl}canvases/{escapedLocal}",
+            Label = new LanguageMap("none", file.LocalPath)
+        };
+        var extents = file.Metadata.OfType<ExtentMetadata>().SingleOrDefault();
+        if (extents != null)
+        {
+            canvas.Width = extents.PixelWidth;
+            canvas.Height = extents.PixelHeight;
+            canvas.Duration = extents.Duration;
+        }
+        var paintingAnno = new PaintingAnnotation
+        {
+            Id = $"{canvas.Id}/painting/annotation",
+            Target = new Canvas { Id = canvas.Id }
+        };
+        canvas.Items =
+        [
+            new AnnotationPage
+            {
+                Id = $"{canvas.Id}/painting",
+                Items = [paintingAnno]
+            }
+        ];
+
+        SetPaintingBody(canvas, paintingAnno, file, escapedLocal, mediaServerBaseUrl, originUriResolver);
+        AddLinkAnnotations(canvas, file, wrapper, mediaServerBaseUrl, originUriResolver);
+        return canvas;
+    }
+
+    // One branch per media type; a file whose extents don't support its type falls through to the
+    // placeholder, whose rendering link still reaches the binary.
+    private static void SetPaintingBody(
+        Canvas canvas,
+        PaintingAnnotation paintingAnno,
+        WorkingFile file,
+        string escapedLocal,
+        string? mediaServerBaseUrl,
+        Func<WorkingFile, string>? originUriResolver)
+    {
+        var contentType = file.ContentType!; // the caller has already skipped files with no content type
+
+        // Image in Deposit: IIIF image service for mediaServer, scaled JPEG + thumbnail
+        if (contentType.StartsWith("image/") && canvas is { Width: > 0, Height: > 0 } && originUriResolver == null)
+        {
+            var size = new Size(canvas.Width.Value, canvas.Height.Value);
+            var mainSize = Size.Confine(1200, size);
+            var thumbSize = Size.Confine(100, size);
+            paintingAnno.Body = new Image
+            {
+                Id = $"{mediaServerBaseUrl}imagesvc/{escapedLocal}/full/{mainSize.Width},{mainSize.Height}/0/default.jpg",
+                Width = mainSize.Width,
+                Height = mainSize.Height,
+                Format = "image/jpeg"
+            };
+            canvas.Thumbnail =
+            [
+                new Image
+                {
+                    Id = $"{mediaServerBaseUrl}imagesvc/{escapedLocal}/full/{thumbSize.Width},{thumbSize.Height}/0/default.jpg",
+                    Width = thumbSize.Width,
+                    Height = thumbSize.Height,
+                    Format = "image/jpeg"
+                }
+            ];
+        }
+        else if (contentType.StartsWith("image/") && originUriResolver != null)
+        {
+            paintingAnno.Body = new Image
+            {
+                Id = originUriResolver(file),
+                Width = canvas.Width,
+                Height = canvas.Height,
+                Format = file.ContentType
+            };
+        }
+        // Video/audio: body type, structure, and rendering are the same in both modes — only the ID differs.
+        else if (contentType.StartsWith("video/") && canvas is { Width: > 0, Height: > 0, Duration: > 0 })
+        {
+            var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}video/{escapedLocal}";
+            paintingAnno.Body = new Video
+            {
+                Id = id,
+                Width = canvas.Width,
+                Height = canvas.Height,
+                Duration = canvas.Duration,
+                Format = file.ContentType
+            };
+        }
+        else if (contentType.StartsWith("audio/") && canvas is { Duration: > 0 })
+        {
+            var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}audio/{escapedLocal}";
+            paintingAnno.Body = new Sound
+            {
+                Id = id,
+                Duration = canvas.Duration,
+                Format = file.ContentType
+            };
+        }
+        // Placeholder: ExternalResource has no extents, there is no painting body. —
+        // the canvas carries only a rendering link pointing to the binary.
+        else
+        {
+            canvas.Behavior = ["placeholder"];
+            var id = originUriResolver?.Invoke(file) ?? $"{mediaServerBaseUrl}file/{escapedLocal}";
+            paintingAnno.Body = new Image
+            {
+                Id = $"{mediaServerBaseUrl}placeholder/canvas.png",
+                Width = 1000,
+                Height = 800,
+                Format = "image/png"
+            };
+            canvas.Thumbnail =
+            [
+                new Image
+                {
+                    Id = $"{mediaServerBaseUrl}placeholder/thumb.png",
+                    Width = 100,
+                    Height = 80,
+                    Format = "image/png"
+                }
+            ];
+            canvas.Rendering =
+            [
+                new ExternalResource("Text")
+                {
+                    Id = id,
+                    Format = file.ContentType,
+                    Behavior = ["original"],
+                    Label = canvas.Label
+                }
+            ];
+        }
+    }
+
+    // Collect all links into a single AnnotationPage
+    private static void AddLinkAnnotations(
+        Canvas canvas,
+        WorkingFile file,
+        MetsFileWrapper wrapper,
+        string? mediaServerBaseUrl,
+        Func<WorkingFile, string>? originUriResolver)
+    {
+        var linkItems = new List<IAnnotation>();
+        foreach (var fileLink in file.Links)
+        {
+            var target = wrapper.Files.SingleOrDefault(f => f.LocalPath == fileLink.To);
+            if (target == null) continue;
+            var bodyId = originUriResolver != null
+                ? originUriResolver(target)
+                : $"{mediaServerBaseUrl}file/{target.LocalPath.EscapePathElements()}";
+            var provides = FileLinkRoles.ToIiifProvides(fileLink.Role);
+            var annotation = new GeneralAnnotation("supplementing") // may need
+            {
+                Body =
+                [
+                    new ExternalResource(GetDcType(target.ContentType))
+                    {
+                        Id = bodyId,
+                        Label = new LanguageMap("none", $"{bodyId.GetSlug()} ({provides ?? fileLink.Role?.ToString()} for {file.Name})"),
+                        Format = target.ContentType
+                    }
+                ],
+                Target = new Canvas { Id = canvas.Id }
+            };
+            if (provides.HasText())
+            {
+                annotation.AdditionalProperties["provides"] = new JArray(provides);
+            }
+            linkItems.Add(annotation);
+        }
+        if (linkItems.Count > 0)
+        {
+            canvas.Annotations =
+            [
+                new AnnotationPage
+                {
+                    Id = $"{canvas.Id}/annotations",
+                    Items = linkItems
+                }
+            ];
+        }
     }
 
     private static string GetDcType(string? targetContentType)


### PR DESCRIPTION
## What

The two cognitive-complexity findings from the main-branch quality-gate triage where refactoring genuinely improves clarity, rather than just moving the metric:

**`ManifestBuilder.MakeCanvasesAndRanges`** (S3776 complexity 41 → orchestration only). The single loop interleaved four concerns; each is now nameable:
- `GetLinkTargetPaths` — which files are adjuncts (transcript targets) rather than canvases. Also a genuine simplification: the old `Dictionary<string, List<WorkingFile>>` accumulated per-target "from" lists that nothing ever read; a `HashSet<string>` says what the structure is actually for.
- `MakeCanvas` — canvas + extents + painting annotation scaffold.
- `SetPaintingBody` — the per-media-type dispatch (image via image service / image via origin resolver / video / audio / placeholder), so each media type reads alone.
- `AddLinkAnnotations` — the supplementing-annotation page for file links.

**`MediaController.GetMedia`** (S3776 complexity 23). The three request shapes of the level-0 image service (`info.json`, `/full/{w,h}/0/default.jpg`, bare-URL redirect) move to `ImageServiceRequest`, leaving `GetMedia` as the guard chain plus a visible route table: placeholder → imagesvc → file proxy.

## Behaviour

No change intended. All 141 Preservation.API tests pass, including the 27 `ManifestBuilderTests` covering every body-dispatch branch in both deposit and origin-resolver modes.

## Context

Part of the 2026-09-07 quality-gate repair: of the fifteen new-code S3776 criticals, twelve were accepted with per-method rationale ("the nesting is the rules"), `MetsParser.ProcessChildStructDivs` (179) was accepted with its remedy scheduled on #248, and these two were judged worth actually fixing. Once this merges and analysis runs, the "Critical Issues > 0 on new code" gate condition clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg
