### PR TITLE
fix: the two legacy Sonar blockers that are real defects in waiting

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.Common.Model.Tests/ObjectVersionTests.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model.Tests/ObjectVersionTests.cs
@@ -1,0 +1,47 @@
+using DigitalPreservation.Common.Model.Storage;
+using FluentAssertions;
+
+namespace DigitalPreservation.Common.Model.Tests;
+
+public class ObjectVersionTests
+{
+    private static ObjectVersion Version(string memento, string? ocflVersion = null) => new()
+    {
+        MementoTimestamp = memento,
+        MementoDateTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        OcflVersion = ocflVersion
+    };
+
+    [Fact]
+    public void GetHashCode_DoesNotThrow_WhenOcflVersionIsNull()
+    {
+        // The old implementation threw here, so a memento-only version - which Equals
+        // explicitly supports - crashed any HashSet, Dictionary or Distinct() it met.
+        var act = () => Version("20250101000000").GetHashCode();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EqualVersions_HaveEqualHashCodes_InTheMixedCaseEqualsAllows()
+    {
+        // Equals falls back to MementoTimestamp when either OcflVersion is null, so a
+        // memento-only version equals the same memento carrying its OCFL version.
+        var mementoOnly = Version("20250101000000");
+        var withOcflVersion = Version("20250101000000", "v2");
+
+        mementoOnly.Should().Be(withOcflVersion);
+        mementoOnly.GetHashCode().Should().Be(withOcflVersion.GetHashCode());
+    }
+
+    [Fact]
+    public void MementoOnlyVersions_WorkInHashContainers()
+    {
+        var versions = new HashSet<ObjectVersion>
+        {
+            Version("20250101000000"),
+            Version("20250101000000"),
+            Version("20250202000000", "v2")
+        };
+        versions.Should().HaveCount(2);
+    }
+}

--- a/src/DigitalPreservation/DigitalPreservation.Common.Model/Storage/ObjectVersion.cs
+++ b/src/DigitalPreservation/DigitalPreservation.Common.Model/Storage/ObjectVersion.cs
@@ -45,10 +45,10 @@ public class ObjectVersion
 
     public override int GetHashCode()
     {
-        if(OcflVersion == null)
-        {
-            throw new InvalidOperationException("Can't call GetHashCode until OcflVersion is set");
-        }
-        return OcflVersion.GetHashCode();
+        // MementoTimestamp is the one member that is always set, and it keeps the contract with
+        // Equals: a version identified only by memento equals one that also carries the OCFL
+        // version for the same memento, so the hash cannot come from OcflVersion. (Two objects
+        // sharing an OcflVersion always share a memento timestamp - a version has exactly one.)
+        return MementoTimestamp.GetHashCode();
     }
 }

--- a/src/DigitalPreservation/DigitalPreservation.UI/Pages/Search.cshtml
+++ b/src/DigitalPreservation/DigitalPreservation.UI/Pages/Search.cshtml
@@ -60,7 +60,7 @@
     var faqActive = faqHasRec ? "active" : "";
 
 
-    var hideIdentCount = !(@results?.DepositSearch?.Total is null && @results?.FedoraSearch?.Total is null & @results?.Identifier is null);
+    var hideIdentCount = !(@results?.DepositSearch?.Total is null && @results?.FedoraSearch?.Total is null && @results?.Identifier is null);
     var identCount = @results?.Identifier != null ? "1" : "0";
     var desCount = results?.DepositSearch?.Total?.ToString() ?? "0";
     var fedCount = results?.FedoraSearch?.Total?.ToString() ?? "0";


### PR DESCRIPTION
## What

Fixes two of the three legacy Sonar blockers on main; the third is accepted with its remedy scheduled (see below).

**`ObjectVersion.GetHashCode` no longer throws** (S3877). It threw whenever `OcflVersion` was null — which is exactly the memento-only case its own `Equals` supports via the `MementoTimestamp` fallback. Nothing hashes an `ObjectVersion` today, so this was dormant, but the first future `HashSet`/`Dictionary`/`Distinct()` over versions would have crashed at runtime. It now hashes `MementoTimestamp`: the one `required` member, and the only choice that keeps the `Equals` contract in the mixed case (`{null, T}` equals `{v2, T}`, so their hashes must agree — hashing `OcflVersion` when present would break that). The theoretical wrinkle — equal-by-OcflVersion objects with different timestamps — can't occur, since a version has exactly one memento timestamp; the comment in the method says so. Three regression tests: no-throw, mixed-case hash agreement, and a `HashSet` round trip.

**`Search.cshtml:63` `&` → `&&`** (S2178). Same computed value for these side-effect-free bools, so no behaviour change — but a typo in a chain that uses `&&` everywhere else, primed to mislead the next edit.

## The third blocker

`FedoraTransactionMonitor`'s undisposed `CancellationTokenSource` (S2930) is deliberately **not** fixed here: `MaintainTransactionState` is an async-void timer callback that calls `CancelAsync`, and `Timer.DisposeAsync` only guarantees the synchronous part of in-flight callbacks — a naive dispose can therefore throw `ObjectDisposedException` inside async void and crash the process, which is worse than leaking one small GC-reclaimed CTS per import job. Accepted in SonarCloud with the analysis, and the dispose-plus-guard fix specified on **#250** for the next deliberate change to the import/transaction path.

## Context

Completes the blocker leg of the 2026-09-07 quality-gate repair (with #247, #249, and issues #248/#250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg
