### PR TITLE
chore: use the Number namespace for parseInt, parseFloat and isNaN

### DIFF
--- a/src/DigitalPreservation/DigitalPreservation.UI/wwwroot/js/logical-structmap.js
+++ b/src/DigitalPreservation/DigitalPreservation.UI/wwwroot/js/logical-structmap.js
@@ -786,15 +786,15 @@ function parseTimeInput(str) {
     if (!str?.trim()) return null;
     const parts = str.trim().split(':');
     if (parts.length === 3) {
-        const h = parseInt(parts[0], 10);
-        const m = parseInt(parts[1], 10);
-        const s = parseFloat(parts[2]);
-        if (!isNaN(h) && !isNaN(m) && !isNaN(s) && h >= 0 && m >= 0 && s >= 0)
+        const h = Number.parseInt(parts[0], 10);
+        const m = Number.parseInt(parts[1], 10);
+        const s = Number.parseFloat(parts[2]);
+        if (!Number.isNaN(h) && !Number.isNaN(m) && !Number.isNaN(s) && h >= 0 && m >= 0 && s >= 0)
             return h * 3600 + m * 60 + s;
     } else if (parts.length === 2) {
-        const m = parseInt(parts[0], 10);
-        const s = parseFloat(parts[1]);
-        if (!isNaN(m) && !isNaN(s) && m >= 0 && s >= 0)
+        const m = Number.parseInt(parts[0], 10);
+        const s = Number.parseFloat(parts[1]);
+        if (!Number.isNaN(m) && !Number.isNaN(s) && m >= 0 && s >= 0)
             return m * 60 + s;
     }
     return null;
@@ -876,11 +876,11 @@ function createEditFilePointerModal() {
             result.endTime   = parseTimeInput(document.getElementById('editFpTimeEnd').value);
         }
         if (areaEnabled) {
-            const x1 = parseInt(document.getElementById('editFpX1').value, 10);
-            const y1 = parseInt(document.getElementById('editFpY1').value, 10);
-            const x2 = parseInt(document.getElementById('editFpX2').value, 10);
-            const y2 = parseInt(document.getElementById('editFpY2').value, 10);
-            if (!isNaN(x1) && !isNaN(y1) && !isNaN(x2) && !isNaN(y2))
+            const x1 = Number.parseInt(document.getElementById('editFpX1').value, 10);
+            const y1 = Number.parseInt(document.getElementById('editFpY1').value, 10);
+            const x2 = Number.parseInt(document.getElementById('editFpX2').value, 10);
+            const y2 = Number.parseInt(document.getElementById('editFpY2').value, 10);
+            if (!Number.isNaN(x1) && !Number.isNaN(y1) && !Number.isNaN(x2) && !Number.isNaN(y2))
                 result.region = { x1, y1, x2, y2 };
         }
         bootstrap.Modal.getInstance(document.getElementById('editFilePointerModal')).hide();


### PR DESCRIPTION
## What

Moves the twelve global `parseInt` / `parseFloat` / `isNaN` calls in `logical-structmap.js` to the `Number.` namespace, clearing the "Prefer `Number.parseInt` over `parseInt`" family of Sonar findings. A repo-wide search confirms this was the only JS file using the globals.

## Why it's safe

- `Number.parseInt` and `Number.parseFloat` are the **same functions** as the globals (ES2015 aliases) — pure renames.
- `Number.isNaN` is **not** the same as global `isNaN` (it doesn't coerce: `isNaN("abc")` is true, `Number.isNaN("abc")` is false) — but every `isNaN` call site here tests the result of a `parseInt`/`parseFloat`, which is always a number, so the two agree at every site. Verified each of the nine uses individually (`parseTimeInput` and the file-pointer region editor).

`node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TanpyLxjH5U7Tkw3szLMg
